### PR TITLE
use ament_lint_auto

### DIFF
--- a/rosidl_cmake/CMakeLists.txt
+++ b/rosidl_cmake/CMakeLists.txt
@@ -4,6 +4,11 @@ project(rosidl_cmake NONE)
 
 find_package(ament_cmake REQUIRED)
 
+if(AMENT_ENABLE_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_package(
   CONFIG_EXTRAS "rosidl_cmake-extras.cmake"
 )

--- a/rosidl_cmake/package.xml
+++ b/rosidl_cmake/package.xml
@@ -9,4 +9,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
 </package>

--- a/rosidl_default_generators/CMakeLists.txt
+++ b/rosidl_default_generators/CMakeLists.txt
@@ -14,4 +14,9 @@ ament_export_dependencies(rosidl_typesupport_introspection_cpp)
 #ament_export_dependencies(rosidl_typesupport_connext_cpp)
 ament_export_dependencies(rosidl_typesupport_opensplice_cpp)
 
+if(AMENT_ENABLE_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_package()

--- a/rosidl_default_generators/package.xml
+++ b/rosidl_default_generators/package.xml
@@ -19,4 +19,7 @@
   <buildtool_export_depend>rosidl_typesupport_connext_cpp</buildtool_export_depend>
 -->
   <buildtool_export_depend>rosidl_typesupport_opensplice_cpp</buildtool_export_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
 </package>

--- a/rosidl_generator_c/CMakeLists.txt
+++ b/rosidl_generator_c/CMakeLists.txt
@@ -10,6 +10,11 @@ ament_export_include_directories(include)
 
 ament_python_install_package(${PROJECT_NAME})
 
+if(AMENT_ENABLE_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_package(
   CONFIG_EXTRAS "rosidl_generator_c-extras.cmake.in"
 )

--- a/rosidl_generator_c/package.xml
+++ b/rosidl_generator_c/package.xml
@@ -13,4 +13,7 @@
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
 
   <exec_depend>rosidl_parser</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
 </package>

--- a/rosidl_generator_cpp/CMakeLists.txt
+++ b/rosidl_generator_cpp/CMakeLists.txt
@@ -10,6 +10,11 @@ ament_export_include_directories(include)
 
 ament_python_install_package(${PROJECT_NAME})
 
+if(AMENT_ENABLE_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_package(
   CONFIG_EXTRAS "rosidl_generator_cpp-extras.cmake.in"
 )

--- a/rosidl_generator_cpp/package.xml
+++ b/rosidl_generator_cpp/package.xml
@@ -13,4 +13,7 @@
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
 
   <exec_depend>rosidl_parser</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
 </package>

--- a/rosidl_parser/CMakeLists.txt
+++ b/rosidl_parser/CMakeLists.txt
@@ -7,4 +7,13 @@ find_package(ament_cmake_python REQUIRED)
 
 ament_python_install_package(${PROJECT_NAME})
 
+if(AMENT_ENABLE_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_package()
+
+if(AMENT_ENABLE_TESTING)
+  ament_add_nose_test(nosetests test)
+endif()

--- a/rosidl_parser/package.xml
+++ b/rosidl_parser/package.xml
@@ -7,4 +7,7 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
 </package>


### PR DESCRIPTION
Update `rosidl_generator_c` and `rosidl_parser` to use `ament_lint_auto` (depends on ament/ament_lint#2).

Note: adding all current linters will result in a lot of failing tests.

@esteve @tfoote @wjwwood Please review.

Connects to ros2/ros2#3