### PR TITLE
Fix get type support handle

### DIFF
--- a/rosidl_generator_c/include/rosidl_generator_c/message_type_support.h
+++ b/rosidl_generator_c/include/rosidl_generator_c/message_type_support.h
@@ -16,12 +16,14 @@
 #ifndef ROSIDL_GENERATOR_C_ROSIDL_GENERATOR_C_MESSAGE_TYPE_SUPPORT_H_
 #define ROSIDL_GENERATOR_C_ROSIDL_GENERATOR_C_MESSAGE_TYPE_SUPPORT_H_
 
+#include "visibility_control.h"
+
 #ifdef __cplusplus
 extern "C"
 {
 #endif
 
-typedef struct rosidl_message_type_support_t
+typedef struct ROSIDL_PUBLIC rosidl_message_type_support_t
 {
   const char * typesupport_identifier;
   const void * data;

--- a/rosidl_generator_c/include/rosidl_generator_c/message_type_support.h
+++ b/rosidl_generator_c/include/rosidl_generator_c/message_type_support.h
@@ -16,7 +16,7 @@
 #ifndef ROSIDL_GENERATOR_C_ROSIDL_GENERATOR_C_MESSAGE_TYPE_SUPPORT_H_
 #define ROSIDL_GENERATOR_C_ROSIDL_GENERATOR_C_MESSAGE_TYPE_SUPPORT_H_
 
-#include "visibility_control.h"
+#include "rosidl_generator_c/visibility_control.h"
 
 #ifdef __cplusplus
 extern "C"
@@ -29,12 +29,13 @@ typedef struct ROSIDL_PUBLIC rosidl_message_type_support_t
   const void * data;
 } rosidl_message_type_support_t;
 
-/* This macro is used to create the symbol of the get_type_support function
- * for a specific message type. The library of the message package which
- * defines a given message will provide the symbol to which this macro expands.
+/* This macro is used to create the symbol of the get_message_type_support
+ * function for a specific message type. The library of the message package
+ * which defines a given message will provide the symbol to which this macro
+ * expands.
  */
 #define ROSIDL_GET_TYPE_SUPPORT(MsgPkgName, MsgName) \
-rosidl_get_type_support__##MsgPkgName##__##MsgName()
+rosidl_get_message_type_support__##MsgPkgName##__##MsgName()
 
 #ifdef __cplusplus
 }

--- a/rosidl_generator_c/include/rosidl_generator_c/service_type_support.h
+++ b/rosidl_generator_c/include/rosidl_generator_c/service_type_support.h
@@ -27,9 +27,10 @@ typedef struct rosidl_service_type_support_t
   const void * data;
 } rosidl_service_type_support_t;
 
-/* This macro is used to create the symbol of the get_type_support function
- * for a specific service type. The library of the message package which
- * defines a given service will provide the symbol to which this macro expands.
+/* This macro is used to create the symbol of the get_service_type_support
+ * function for a specific service type. The library of the message package
+ * which defines a given service will provide the symbol to which this macro
+ * expands.
  */
 #define ROSIDL_GET_SERVICE_TYPE_SUPPORT(SrvPkgName, SrvName) \
 rosidl_get_service_type_support__##SrvPkgName##__##SrvName()

--- a/rosidl_generator_c/include/rosidl_generator_c/visibility_control.h
+++ b/rosidl_generator_c/include/rosidl_generator_c/visibility_control.h
@@ -1,0 +1,57 @@
+/* Copyright 2015 Open Source Robotics Foundation, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ROSIDL_GENERATOR_C_ROSIDL_GENERATOR_C_VISIBILITY_CONTROL_H_
+#define ROSIDL_GENERATOR_C_ROSIDL_GENERATOR_C_VISIBILITY_CONTROL_H_
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define ROSIDL_EXPORT __attribute__ ((dllexport))
+    #define ROSIDL_IMPORT __attribute__ ((dllimport))
+  #else
+    #define ROSIDL_EXPORT __declspec(dllexport)
+    #define ROSIDL_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef ROSIDL_BUILDING_DLL
+    #define ROSIDL_PUBLIC ROSIDL_EXPORT
+  #else
+    #define ROSIDL_PUBLIC ROSIDL_IMPORT
+  #endif
+  #define ROSIDL_LOCAL
+#else
+  #define ROSIDL_EXPORT __attribute__ ((visibility ("default")))
+  #define ROSIDL_IMPORT
+  #if __GNUC__ >= 4
+    #define ROSIDL_PUBLIC __attribute__ ((visibility ("default")))
+    #define ROSIDL_LOCAL  __attribute__ ((visibility ("hidden")))
+  #else
+    #define ROSIDL_PUBLIC
+    #define ROSIDL_LOCAL
+  #endif
+#endif
+
+#if __cplusplus
+}
+#endif
+
+#endif  // ROSIDL_GENERATOR_C_ROSIDL_GENERATOR_C_VISIBILITY_CONTROL_H_

--- a/rosidl_generator_cpp/include/rosidl_generator_cpp/MessageTypeSupport.h
+++ b/rosidl_generator_cpp/include/rosidl_generator_cpp/MessageTypeSupport.h
@@ -17,13 +17,22 @@
 #define __rosidl_generator_cpp__MessageTypeSupport__h__
 
 #include <rosidl_generator_c/message_type_support.h>
+#include <rosidl_generator_c/visibility_control.h>
 
 namespace rosidl_generator_cpp
 {
 
 template<typename T>
+ROSIDL_PUBLIC
 const rosidl_message_type_support_t * get_type_support_handle();
 
 }  // namespace rosidl_generator_cpp
+
+// Tail include the implementation for this function.
+// This include is provided by the implementation and therefore only
+// one version of this header will get included from the path.
+// This header maps the get_type_support_handle function to an implementation
+// specific version of that function.
+#include <rosidl_generator_cpp/get_type_support_handle_impl.hpp>
 
 #endif  // __rosidl_generator_cpp__MessageTypeSupport__h__

--- a/rosidl_generator_cpp/include/rosidl_generator_cpp/message_type_support.hpp
+++ b/rosidl_generator_cpp/include/rosidl_generator_cpp/message_type_support.hpp
@@ -1,0 +1,3 @@
+#error The wrong version of rosidl_generator_cpp/message_type_support.hpp has been included. \
+Please make sure that exactly one ROS middleware (rmw) implementation has put a version of this \
+header on the include path.

--- a/rosidl_generator_cpp/include/rosidl_generator_cpp/message_type_support_decl.hpp
+++ b/rosidl_generator_cpp/include/rosidl_generator_cpp/message_type_support_decl.hpp
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-#ifndef __rosidl_generator_cpp__MessageTypeSupport__h__
-#define __rosidl_generator_cpp__MessageTypeSupport__h__
+#ifndef __rosidl_generator_cpp__message_type_support_decl__hpp__
+#define __rosidl_generator_cpp__message_type_support_decl__hpp__
 
 #include <rosidl_generator_c/message_type_support.h>
 #include <rosidl_generator_c/visibility_control.h>
@@ -24,15 +24,8 @@ namespace rosidl_generator_cpp
 
 template<typename T>
 ROSIDL_PUBLIC
-const rosidl_message_type_support_t * get_type_support_handle();
+const rosidl_message_type_support_t * get_message_type_support_handle();
 
 }  // namespace rosidl_generator_cpp
 
-// Tail include the implementation for this function.
-// This include is provided by the implementation and therefore only
-// one version of this header will get included from the path.
-// This header maps the get_type_support_handle function to an implementation
-// specific version of that function.
-#include <rosidl_generator_cpp/get_type_support_handle_impl.hpp>
-
-#endif  // __rosidl_generator_cpp__MessageTypeSupport__h__
+#endif  // __rosidl_generator_cpp__message_type_support_decl__hpp__

--- a/rosidl_generator_cpp/include/rosidl_generator_cpp/service_type_support.hpp
+++ b/rosidl_generator_cpp/include/rosidl_generator_cpp/service_type_support.hpp
@@ -1,0 +1,3 @@
+#error The wrong version of rosidl_generator_cpp/service_type_support.hpp has been included. \
+Please make sure that exactly one ROS middleware (rmw) implementation has put a version of this \
+header on the include path.

--- a/rosidl_generator_cpp/include/rosidl_generator_cpp/service_type_support_decl.hpp
+++ b/rosidl_generator_cpp/include/rosidl_generator_cpp/service_type_support_decl.hpp
@@ -13,17 +13,19 @@
  * limitations under the License.
  */
 
-#ifndef __rosidl_generator_cpp__ServiceTypeSupport__h__
-#define __rosidl_generator_cpp__ServiceTypeSupport__h__
+#ifndef __rosidl_generator_cpp__service_type_support_decl__hpp__
+#define __rosidl_generator_cpp__service_type_support_decl__hpp__
 
 #include <rosidl_generator_c/service_type_support.h>
+#include <rosidl_generator_c/visibility_control.h>
 
 namespace rosidl_generator_cpp
 {
 
 template<typename T>
+ROSIDL_PUBLIC
 const rosidl_service_type_support_t * get_service_type_support_handle();
 
 }  // namespace rosidl_generator_cpp
 
-#endif  // __rosidl_generator_cpp__ServiceTypeSupport__h__
+#endif  // __rosidl_generator_cpp__service_type_support_decl__hpp__

--- a/rosidl_generator_cpp/package.xml
+++ b/rosidl_generator_cpp/package.xml
@@ -9,8 +9,13 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_cmake</buildtool_depend>
 
+  <!-- This is needed for the rosidl_message_type_support_t struct and visibility macros -->
+  <build_depend>rosidl_generator_c</build_depend>
+
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
+
+  <build_export_depend>rosidl_generator_c</build_export_depend>
 
   <exec_depend>rosidl_parser</exec_depend>
 

--- a/rosidl_generator_cpp/resource/msg.h.template
+++ b/rosidl_generator_cpp/resource/msg.h.template
@@ -5,15 +5,4 @@
 
 #include "@(spec.base_type.pkg_name)/@(spec.base_type.type)_Struct.h"
 
-namespace rosidl_generator_cpp
-{
-
-template<>
-const rosidl_message_type_support_t *
-get_type_support_handle<
-  @(spec.base_type.pkg_name)::@(spec.base_type.type)
->();
-
-}  // namespace rosidl_generator_cpp
-
 #endif  // __@(spec.base_type.pkg_name)__@(spec.base_type.type)__h__

--- a/rosidl_generator_cpp/resource/msg.h.template
+++ b/rosidl_generator_cpp/resource/msg.h.template
@@ -1,8 +1,6 @@
 #ifndef __@(spec.base_type.pkg_name)__@(spec.base_type.type)__h__
 #define __@(spec.base_type.pkg_name)__@(spec.base_type.type)__h__
 
-#include <rosidl_generator_cpp/MessageTypeSupport.h>
-
 #include "@(spec.base_type.pkg_name)/@(spec.base_type.type)_Struct.h"
 
 #endif  // __@(spec.base_type.pkg_name)__@(spec.base_type.type)__h__

--- a/rosidl_generator_cpp/resource/srv.h.template
+++ b/rosidl_generator_cpp/resource/srv.h.template
@@ -1,19 +1,6 @@
 #ifndef __@(spec.pkg_name)__@(spec.srv_name)__h__
 #define __@(spec.pkg_name)__@(spec.srv_name)__h__
 
-#include <rosidl_generator_cpp/MessageTypeSupport.h>
-
 #include "@(spec.pkg_name)/@(spec.srv_name)_Service.h"
-
-namespace rosidl_generator_cpp
-{
-
-template<>
-const rosidl_service_type_support_t *
-get_service_type_support_handle<
-  @(spec.pkg_name)::@(spec.srv_name)
->();
-
-}  // namespace rosidl_generator_cpp
 
 #endif  // __@(spec.pkg_name)__@(spec.srv_name)__h__


### PR DESCRIPTION
This pull request changes how the implementation specific version of the `get_type_support_handle` function is included. Each vendor specific implementation provides a custom version of this function in a header called `rosidl_generator_cpp/get_type_support_handle_impl.hpp` and the `rosidl_generator_cpp` package provides a header called `rosidl_generator_cpp/get_type_support_handle.h` which the client library imports. A different `rosidl_generator_cpp/get_type_support_handle_impl.hpp` is included based on the include paths set when building a library or executable, allowing you to select an implementation that way.

I've also renamed the implementation specific version of the function to `get_type_support_handle_impl`, to reduce confusion and improve searching, but that function is defined in the various implementations not here.

Connects to ros2/ros2#26