### PR TITLE
use more strict rules for identifiers

### DIFF
--- a/rosidl_parser/rosidl_parser/__init__.py
+++ b/rosidl_parser/rosidl_parser/__init__.py
@@ -47,14 +47,14 @@ PRIMITIVE_TYPES = [
     'time',  # for compatibility only
 ]
 
-VALID_PACKAGE_NAME_PATTERN = re.compile('^[a-z][a-z0-9_]*$')
-# TODO replace relaxed patterns used for compatibility
-# VALID_FIELD_NAME_PATTERN = re.compile('^[a-z][a-z0-9_]*$')
-VALID_FIELD_NAME_PATTERN = re.compile('^[A-Za-z][A-Za-z0-9_]*$')
-# TODO replace relaxed patterns used for compatibility
-# VALID_MESSAGE_NAME_PATTERN = re.compile('^[A-Z][A-Za-z0-9]*$')
-VALID_MESSAGE_NAME_PATTERN = re.compile('^[A-Za-z][A-Za-z0-9]*$')
-VALID_CONSTANT_NAME_PATTERN = re.compile('^[A-Z][A-Z0-9_]*$')
+VALID_PACKAGE_NAME_PATTERN = re.compile('^[a-z]([a-z0-9_]?[a-z0-9]+)*$')
+VALID_FIELD_NAME_PATTERN = re.compile('^[a-z]([a-z0-9_]?[a-z0-9]+)*$')
+# relaxed patterns used for compatibility with ROS 1 messages
+# VALID_FIELD_NAME_PATTERN = re.compile('^[A-Za-z][A-Za-z0-9_]*$')
+VALID_MESSAGE_NAME_PATTERN = re.compile('^[A-Z][A-Za-z0-9]*$')
+# relaxed patterns used for compatibility with ROS 1 messages
+# VALID_MESSAGE_NAME_PATTERN = re.compile('^[A-Za-z][A-Za-z0-9]*$')
+VALID_CONSTANT_NAME_PATTERN = re.compile('^[A-Z]([A-Z0-9_]?[A-Z0-9]+)*$')
 
 
 class InvalidSpecification(Exception):

--- a/rosidl_parser/test/test_valid_names.py
+++ b/rosidl_parser/test/test_valid_names.py
@@ -23,10 +23,10 @@ from rosidl_parser import is_valid_package_name
 
 def test_is_valid_package_name():
     for valid_package_name in [
-            'foo']:
+            'foo', 'foo_bar']:
         assert is_valid_package_name(valid_package_name)
     for invalid_package_name in [
-            'foo-bar']:
+            '_foo', 'foo_', 'foo__bar', 'foo-bar']:
         assert not is_valid_package_name(invalid_package_name)
     with assert_raises(InvalidResourceName):
         is_valid_package_name(None)
@@ -34,10 +34,10 @@ def test_is_valid_package_name():
 
 def test_is_valid_field_name():
     for valid_field_name in [
-            'foo']:
+            'foo', 'foo_bar']:
         is_valid_field_name(valid_field_name)
     for invalid_field_name in [
-            'foo-bar']:
+            '_foo', 'foo_', 'foo__bar', 'foo-bar']:
         assert not is_valid_field_name(invalid_field_name)
     with assert_raises(InvalidResourceName):
         is_valid_field_name(None)
@@ -45,10 +45,10 @@ def test_is_valid_field_name():
 
 def test_is_valid_message_name():
     for valid_message_name in [
-            'Foo']:
+            'Foo', 'FooBar']:
         assert is_valid_message_name(valid_message_name)
     for invalid_message_name in [
-            '0foo']:
+            '0foo', '_Foo', 'Foo_', 'Foo_Bar']:
         assert not is_valid_message_name(invalid_message_name)
     with assert_raises(InvalidResourceName):
         is_valid_message_name(None)
@@ -56,10 +56,10 @@ def test_is_valid_message_name():
 
 def test_is_valid_constant_name():
     for valid_constant_name in [
-            'FOO']:
+            'FOO', 'FOO_BAR']:
         assert is_valid_constant_name(valid_constant_name)
     for invalid_constant_name in [
-            'Foo']:
+            '_FOO', 'FOO_', 'FOO__BAR', 'Foo']:
         assert not is_valid_constant_name(invalid_constant_name)
     with assert_raises(InvalidResourceName):
         is_valid_constant_name(None)


### PR DESCRIPTION
The patch enables the stricter rules (instead of using the relaxed one to be able to read all ROS 1 messages). It also makes the regular expressions even more strict to match the spec from the article.

Please review.