### PR TITLE
exclude arrays of non-primitive types for now

### DIFF
--- a/rosidl_generator_c/resource/msg__struct.h.template
+++ b/rosidl_generator_c/resource/msg__struct.h.template
@@ -42,8 +42,10 @@ for field in spec.fields:
 @{
 for field in spec.fields:
     if field.type.is_array and field.type.array_size is not None:
-        print('ROSIDL_GENERATE_STATIC_ARRAY(%s, %s, %s, %s);' %
-              (c_full_name, field.name, MSG_TYPE_TO_C[field.type.type], field.type.array_size))
+        # TODO the generated code fails for non primitive types and needs to be fixed and reenabled
+        if field.type.is_primitive_type():
+            print('ROSIDL_GENERATE_STATIC_ARRAY(%s, %s, %s, %s);' %
+                  (c_full_name, field.name, MSG_TYPE_TO_C[field.type.type], field.type.array_size))
 }@
 
 // message struct


### PR DESCRIPTION
Temporary workaround for #26.

The patch does not generate any code for static arrays of non-primitive types anymore because the template does not work in that case.