### PR TITLE
refactor generators, fix timestamp of generated files

### DIFF
--- a/rosidl_cmake/cmake/rosidl_write_generator_arguments.cmake
+++ b/rosidl_cmake/cmake/rosidl_write_generator_arguments.cmake
@@ -1,0 +1,117 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# include CMake functions
+include(CMakeParseArguments)
+
+#
+# Generate a JSON / YAML file containing the rosidl generator arguments.
+#
+#
+# @public
+#
+function(rosidl_write_generator_arguments output_file)
+  set(REQUIRED_ONE_VALUE_KEYWORDS
+    "PACKAGE_NAME"
+    "OUTPUT_DIR"
+    "TEMPLATE_DIR")
+
+  set(REQUIRED_MULTI_VALUE_KEYWORDS
+    "ROS_INTERFACE_FILES")
+  set(OPTIONAL_MULTI_VALUE_KEYWORDS
+    "ROS_INTERFACE_DEPENDENCIES"  # since the dependencies can be empty
+    "TARGET_DEPENDENCIES"
+    "ADDITIONAL_FILES")
+
+  cmake_parse_arguments(
+    ARG
+    ""
+    "${REQUIRED_ONE_VALUE_KEYWORDS}"
+    "${REQUIRED_MULTI_VALUE_KEYWORDS};${OPTIONAL_MULTI_VALUE_KEYWORDS}"
+    ${ARGN})
+  if(ARG_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "rosidl_write_generator_arguments() called with unused "
+      "arguments: ${ARG_UNPARSED_ARGUMENTS}")
+  endif()
+  foreach(required_argument ${REQUIRED_ONE_VALUE_KEYWORDS};${REQUIRED_MULTI_VALUE_KEYWORDS})
+    if(NOT ARG_${required_argument})
+      message(FATAL_ERROR
+        "rosidl_write_generator_arguments() must be invoked with the "
+        "${required_argument} argument")
+    endif()
+  endforeach()
+
+  # create folder
+  get_filename_component(output_path "${output_file}" PATH)
+  file(MAKE_DIRECTORY "${output_path}")
+
+  # open object
+  file(WRITE "${output_file}"
+    "{")
+
+  set(first_element TRUE)
+
+  # write string values
+  foreach(one_value_argument ${REQUIRED_ONE_VALUE_KEYWORDS})
+    if(ARG_${one_value_argument})
+      # write conditional comma and mandatory newline
+      if(NOT first_element)
+        file(APPEND "${output_file}" ",")
+      else()
+        set(first_element FALSE)
+      endif()
+      file(APPEND "${output_file}" "\n")
+
+      string(TOLOWER "${one_value_argument}" key)
+      file(APPEND "${output_file}"
+        "  \"${key}\": \"${ARG_${one_value_argument}}\"")
+    endif()
+  endforeach()
+
+  # write array values
+  foreach(multi_value_argument ${REQUIRED_MULTI_VALUE_KEYWORDS} ${OPTIONAL_MULTI_VALUE_KEYWORDS})
+    if(ARG_${multi_value_argument})
+      # write conditional comma and mandatory newline and indentation
+      if(NOT first_element)
+        file(APPEND "${output_file}" ",")
+      else()
+        set(first_element FALSE)
+      endif()
+      file(APPEND "${output_file}" "\n")
+
+      # write key, open array
+      string(TOLOWER "${multi_value_argument}" key)
+      file(APPEND "${output_file}"
+        "  \"${key}\": [\n")
+
+      # write array values, last without trailing colon
+      list(GET ARG_${multi_value_argument} -1 last_value)
+      list(REMOVE_AT ARG_${multi_value_argument} -1)
+      foreach(value ${ARG_${multi_value_argument}})
+        file(APPEND "${output_file}"
+          "    \"${value}\",\n")
+      endforeach()
+      file(APPEND "${output_file}"
+        "    \"${last_value}\"\n")
+
+      # close array
+      file(APPEND "${output_file}"
+        "  ]")
+    endif()
+  endforeach()
+
+  # close object
+  file(APPEND "${output_file}"
+    "\n}\n")
+endfunction()

--- a/rosidl_cmake/rosidl_cmake-extras.cmake
+++ b/rosidl_cmake/rosidl_cmake-extras.cmake
@@ -29,4 +29,5 @@ endmacro()
 
 include("${rosidl_cmake_DIR}/rosidl_generate_interfaces.cmake")
 include("${rosidl_cmake_DIR}/rosidl_target_interfaces.cmake")
+include("${rosidl_cmake_DIR}/rosidl_write_generator_arguments.cmake")
 include("${rosidl_cmake_DIR}/string_camel_case_to_lower_case_underscore.cmake")

--- a/rosidl_generator_c/bin/rosidl_generator_c
+++ b/rosidl_generator_c/bin/rosidl_generator_c
@@ -11,33 +11,13 @@ def main(argv=sys.argv[1:]):
         description='Generate the C ROS interfaces.',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
-        '--pkg-name',
+        '--generator-arguments-file',
         required=True,
-        help='The package name to generate interfaces for')
-    parser.add_argument(
-        '--ros-interface-files',
-        nargs='*',
-        help='The ROS interface files')
-    parser.add_argument(
-        '--deps',
-        nargs='*',
-        help="The dependencies (each as '<pkgname>:<abs_interface_file>')")
-    parser.add_argument(
-        '--output-dir',
-        required=True,
-        help='The location of the generated C interfaces')
-    parser.add_argument(
-        '--template-dir',
-        required=True,
-        help='The location of the template files')
+        help='The location of the file containing the generator arguments')
     args = parser.parse_args(argv)
 
     return generate_c(
-        args.pkg_name,
-        args.ros_interface_files,
-        args.deps,
-        args.output_dir,
-        args.template_dir,
+        args.generator_arguments_file,
     )
 
 

--- a/rosidl_generator_c/cmake/rosidl_generator_c_generate_interfaces.cmake
+++ b/rosidl_generator_c/cmake/rosidl_generator_c_generate_interfaces.cmake
@@ -51,21 +51,35 @@ foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
 endforeach()
 
 if(NOT "${_generated_msg_files} " STREQUAL " ")
+  set(target_dependencies
+    "${rosidl_generator_c_BIN}"
+    ${rosidl_generator_c_GENERATOR_FILES}
+    "${rosidl_generator_c_TEMPLATE_DIR}/msg.h.template"
+    "${rosidl_generator_c_TEMPLATE_DIR}/msg__struct.h.template"
+    ${rosidl_generate_interfaces_c_IDL_FILES}
+    ${_dependency_files})
+  foreach(dep ${target_dependencies})
+    if(NOT EXISTS "${dep}")
+      message(FATAL_ERROR "Target dependency '${dep}' does not exist")
+    endif()
+  endforeach()
+
+  set(generator_arguments_file "${CMAKE_BINARY_DIR}/rosidl_generator_c__arguments.json")
+  rosidl_write_generator_arguments(
+    "${generator_arguments_file}"
+    PACKAGE_NAME "${PROJECT_NAME}"
+    ROS_INTERFACE_FILES "${rosidl_generate_interfaces_c_IDL_FILES}"
+    ROS_INTERFACE_DEPENDENCIES "${_dependencies}"
+    OUTPUT_DIR "${_output_path}"
+    TEMPLATE_DIR "${rosidl_generator_c_TEMPLATE_DIR}"
+    TARGET_DEPENDENCIES ${target_dependencies}
+  )
+
   add_custom_command(
     OUTPUT ${_generated_msg_files}
     COMMAND ${PYTHON_EXECUTABLE} ${rosidl_generator_c_BIN}
-    --pkg-name ${PROJECT_NAME}
-    --ros-interface-files ${rosidl_generate_interfaces_c_IDL_FILES}
-    --deps ${_dependencies}
-    --output-dir ${_output_path}
-    --template-dir ${rosidl_generator_c_TEMPLATE_DIR}
-    DEPENDS
-    ${rosidl_generator_c_BIN}
-    ${rosidl_generator_c_GENERATOR_FILES}
-    ${rosidl_generator_c_TEMPLATE_DIR}/msg.h.template
-    ${rosidl_generator_c_TEMPLATE_DIR}/msg__struct.h.template
-    ${rosidl_generate_interfaces_c_IDL_FILES}
-    ${_dependency_files}
+    --generator-arguments-file "${generator_arguments_file}"
+    DEPENDS ${target_dependencies}
     COMMENT "Generating C code for ROS interfaces"
     VERBATIM
   )
@@ -84,6 +98,6 @@ if(NOT "${_generated_msg_files} " STREQUAL " ")
     FILES ${_generated_msg_files}
     DESTINATION "include/${PROJECT_NAME}/msg"
   )
-endif()
 
-ament_export_include_directories(include)
+  ament_export_include_directories(include)
+endif()

--- a/rosidl_generator_c/package.xml
+++ b/rosidl_generator_c/package.xml
@@ -7,7 +7,6 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>rosidl_cmake</buildtool_depend>
 
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>

--- a/rosidl_generator_c/rosidl_generator_c/__init__.py
+++ b/rosidl_generator_c/rosidl_generator_c/__init__.py
@@ -12,15 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import em
-from io import StringIO
 import os
 
 from rosidl_cmake import convert_camel_case_to_lower_case_underscore
+from rosidl_cmake import expand_template
+from rosidl_cmake import get_newest_modification_time
+from rosidl_cmake import read_generator_arguments
 from rosidl_parser import parse_message_file
 
 
-def generate_c(pkg_name, ros_interface_files, deps, output_dir, template_dir):
+def generate_c(generator_arguments_file):
+    args = read_generator_arguments(generator_arguments_file)
+
+    template_dir = args['template_dir']
     mapping = {
         os.path.join(template_dir, 'msg.h.template'): '%s.h',
         os.path.join(template_dir, 'msg__struct.h.template'): '%s__struct.h',
@@ -31,49 +35,22 @@ def generate_c(pkg_name, ros_interface_files, deps, output_dir, template_dir):
     functions = {
         'get_header_filename_from_msg_name': convert_camel_case_to_lower_case_underscore,
     }
+    latest_target_timestamp = get_newest_modification_time(args['target_dependencies'])
 
-    for ros_interface_file in ros_interface_files:
+    for ros_interface_file in args['ros_interface_files']:
         extension = os.path.splitext(ros_interface_file)[1]
         subfolder = os.path.basename(os.path.dirname(ros_interface_file))
         if extension == '.msg':
-            spec = parse_message_file(pkg_name, ros_interface_file)
+            spec = parse_message_file(args['package_name'], ros_interface_file)
             for template_file, generated_filename in mapping.items():
                 generated_file = os.path.join(
-                    output_dir, subfolder, generated_filename %
+                    args['output_dir'], subfolder, generated_filename %
                     convert_camel_case_to_lower_case_underscore(spec.base_type.type))
-
-                try:
-                    output = StringIO()
-                    data = {'spec': spec, 'subfolder': subfolder}
-                    data.update(functions)
-                    # TODO reuse interpreter
-                    interpreter = em.Interpreter(
-                        output=output,
-                        options={
-                            em.RAW_OPT: True,
-                            em.BUFFERED_OPT: True,
-                        },
-                        globals=data,
-                    )
-                    interpreter.file(open(template_file))
-                    content = output.getvalue()
-                    interpreter.shutdown()
-                except Exception:
-                    if os.path.exists(generated_file):
-                        os.remove(generated_file)
-                    raise
-
-                # only overwrite file if necessary
-                if os.path.exists(generated_file):
-                    with open(generated_file, 'r') as h:
-                        if h.read() == content:
-                            continue
-                try:
-                    os.makedirs(os.path.dirname(generated_file))
-                except FileExistsError:
-                    pass
-                with open(generated_file, 'w') as h:
-                    h.write(content)
+                data = {'spec': spec, 'subfolder': subfolder}
+                data.update(functions)
+                expand_template(
+                    template_file, data, generated_file,
+                    minimum_timestamp=latest_target_timestamp)
     return 0
 
 

--- a/rosidl_generator_cpp/bin/rosidl_generator_cpp
+++ b/rosidl_generator_cpp/bin/rosidl_generator_cpp
@@ -11,33 +11,13 @@ def main(argv=sys.argv[1:]):
         description='Generate the C++ ROS interfaces.',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
-        '--pkg-name',
+        '--generator-arguments-file',
         required=True,
-        help='The package name to generate interfaces for')
-    parser.add_argument(
-        '--ros-interface-files',
-        nargs='*',
-        help='The ROS interface files')
-    parser.add_argument(
-        '--deps',
-        nargs='*',
-        help="The dependencies (each as '<pkgname>:<abs_interface_file>')")
-    parser.add_argument(
-        '--output-dir',
-        required=True,
-        help='The location of the generated C++ interfaces')
-    parser.add_argument(
-        '--template-dir',
-        required=True,
-        help='The location of the template files')
+        help='The location of the file containing the generator arguments')
     args = parser.parse_args(argv)
 
     return generate_cpp(
-        args.pkg_name,
-        args.ros_interface_files,
-        args.deps,
-        args.output_dir,
-        args.template_dir,
+        args.generator_arguments_file,
     )
 
 

--- a/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_interfaces.cmake
+++ b/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_interfaces.cmake
@@ -48,23 +48,37 @@ foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
   endforeach()
 endforeach()
 
+set(target_dependencies
+  "${rosidl_generator_cpp_BIN}"
+  ${rosidl_generator_cpp_GENERATOR_FILES}
+  "${rosidl_generator_cpp_TEMPLATE_DIR}/msg.hpp.template"
+  "${rosidl_generator_cpp_TEMPLATE_DIR}/msg__struct.hpp.template"
+  "${rosidl_generator_cpp_TEMPLATE_DIR}/srv.hpp.template"
+  "${rosidl_generator_cpp_TEMPLATE_DIR}/srv__struct.hpp.template"
+  ${rosidl_generate_interfaces_IDL_FILES}
+  ${_dependency_files})
+foreach(dep ${target_dependencies})
+  if(NOT EXISTS "${dep}")
+    message(FATAL_ERROR "Target dependency '${dep}' does not exist")
+  endif()
+endforeach()
+
+set(generator_arguments_file "${CMAKE_BINARY_DIR}/rosidl_generator_cpp__arguments.json")
+rosidl_write_generator_arguments(
+  "${generator_arguments_file}"
+  PACKAGE_NAME "${PROJECT_NAME}"
+  ROS_INTERFACE_FILES "${rosidl_generate_interfaces_IDL_FILES}"
+  ROS_INTERFACE_DEPENDENCIES "${_dependencies}"
+  OUTPUT_DIR "${_output_path}"
+  TEMPLATE_DIR "${rosidl_generator_cpp_TEMPLATE_DIR}"
+  TARGET_DEPENDENCIES ${target_dependencies}
+)
+
 add_custom_command(
   OUTPUT ${_generated_msg_files} ${_generated_srv_files}
   COMMAND ${PYTHON_EXECUTABLE} ${rosidl_generator_cpp_BIN}
-  --pkg-name ${PROJECT_NAME}
-  --ros-interface-files ${rosidl_generate_interfaces_IDL_FILES}
-  --deps ${_dependencies}
-  --output-dir ${_output_path}
-  --template-dir ${rosidl_generator_cpp_TEMPLATE_DIR}
-  DEPENDS
-  ${rosidl_generator_cpp_BIN}
-  ${rosidl_generator_cpp_GENERATOR_FILES}
-  ${rosidl_generator_cpp_TEMPLATE_DIR}/msg.hpp.template
-  ${rosidl_generator_cpp_TEMPLATE_DIR}/msg__struct.hpp.template
-  ${rosidl_generator_cpp_TEMPLATE_DIR}/srv.hpp.template
-  ${rosidl_generator_cpp_TEMPLATE_DIR}/srv__struct.hpp.template
-  ${rosidl_generate_interfaces_IDL_FILES}
-  ${_dependency_files}
+  --generator-arguments-file "${generator_arguments_file}"
+  DEPENDS ${target_dependencies}
   COMMENT "Generating C++ code for ROS interfaces"
   VERBATIM
 )

--- a/rosidl_generator_cpp/package.xml
+++ b/rosidl_generator_cpp/package.xml
@@ -7,14 +7,11 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>rosidl_cmake</buildtool_depend>
-
-  <!-- This is needed for the rosidl_message_type_support_t struct and visibility macros -->
-  <build_depend>rosidl_generator_c</build_depend>
 
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
 
+  <!-- This is needed for the rosidl_message_type_support_t struct and visibility macros -->
   <build_export_depend>rosidl_generator_c</build_export_depend>
 
   <exec_depend>rosidl_parser</exec_depend>


### PR DESCRIPTION
Refactoring to pass all generator arguments through a JSON / YAML file. This will avoid problems with the length of commands on Windows.

Unification of expanding templates by moving the implementation to `rosidl_cmake`. This will address ros2/ros2#44 once the same patch has been applied to all generators.

Fix problem of reinvoking generator targets because the generated files where skipped (since the content did not change) but their timestamp was older then other target dependencies which led to rebuilds even in the install step.