### PR TITLE
Add "has_bounded_size()" to generated message code

### DIFF
--- a/rosidl_generator_cpp/resource/msg__struct.hpp.template
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.template
@@ -15,6 +15,7 @@
 @{
 from rosidl_generator_cpp import escape_string
 from rosidl_generator_cpp import msg_type_to_cpp
+from rosidl_generator_cpp import cpp_type_of_array 
 from rosidl_generator_cpp import MSG_TYPE_TO_CPP
 from rosidl_generator_cpp import value_to_cpp
 
@@ -148,25 +149,23 @@ for field in spec.fields:
     return !this->operator==(other);
   }
 
-  // Message introspection
-  bool is_dynamic() const
+  // Message type introspection
+  static bool has_bounded_size()
   {
-@[if spec.is_dynamic()]@
-    return true;
-@#@[else]@
-@#    return false;
-@[elif spec.base_type.is_primitive_type() or all([field.type.is_primitive_type() for field in spec.fields])]@
+@[if not spec.has_bounded_size()]@
     return false;
+@[elif spec.base_type.is_primitive_type() or all([field.type.is_primitive_type() for field in spec.fields])]@
+    return true;
 @[else]@
-    bool dynamic = false;
+    bool has_bounded_size = true;
 @[for msg_field in [field for field in spec.fields if not field.type.is_primitive_type()]]@
 @[if msg_field.type.is_array]@
-    dynamic |= @(msg_field.name)[0].is_dynamic();
-@[else]
-    dynamic |= @(msg_field.name).is_dynamic();
+    has_bounded_size &= @(cpp_type_of_array(msg_field.type))::has_bounded_size();
+@[else]@
+    has_bounded_size &= @(msg_type_to_cpp(msg_field.type))::has_bounded_size();
 @[end if]@
 @[end for]@
-    return dynamic;
+    return has_bounded_size;
 @[end if]@
   }
 

--- a/rosidl_generator_cpp/resource/msg__struct.hpp.template
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.template
@@ -149,25 +149,11 @@ for field in spec.fields:
     return !this->operator==(other);
   }
 
-  // Message type introspection
-  static bool has_bounded_size()
-  {
-@[if not spec.has_bounded_size()]@
-    return false;
-@[elif spec.base_type.is_primitive_type() or all([field.type.is_primitive_type() for field in spec.fields])]@
-    return true;
+@[if spec.has_bounded_size()]@
+  static const bool has_bounded_size = true;
 @[else]@
-    bool has_bounded_size = true;
-@[for msg_field in [field for field in spec.fields if not field.type.is_primitive_type()]]@
-@[if msg_field.type.is_array]@
-    has_bounded_size &= @(cpp_type_of_array(msg_field.type))::has_bounded_size();
-@[else]@
-    has_bounded_size &= @(msg_type_to_cpp(msg_field.type))::has_bounded_size();
+  static const bool has_bounded_size = false;
 @[end if]@
-@[end for]@
-    return has_bounded_size;
-@[end if]@
-  }
 
 }; // struct @(cpp_class)
 

--- a/rosidl_generator_cpp/resource/msg__struct.hpp.template
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.template
@@ -148,6 +148,29 @@ for field in spec.fields:
     return !this->operator==(other);
   }
 
+  // Message introspection
+  bool is_dynamic()
+  {
+    @[dynamic = True]@
+    @[for field in spec.fields]@
+        @[if field.type.is_array and field.type.array_size is None:]@
+            @[dynamic = False]@
+            @[break]@
+        @[end if]@
+    @[end for]@
+    @[if not dynamic]@
+    return false;
+    @[else]@
+    bool dynamic = true;
+        @[for field in spec.fields]@
+            @[if not field.type.is_array and not field.type.is_primitive_type()]@
+        dynamic &= this->@(field.type.name).is_dynamic();
+            @[end if]@
+        @[end for]@
+    return dynamic;
+    @[end if]@
+  }
+
 }; // struct @(cpp_class)
 
 // typedef to use template instance with default allocator

--- a/rosidl_generator_cpp/resource/msg__struct.hpp.template
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.template
@@ -149,26 +149,25 @@ for field in spec.fields:
   }
 
   // Message introspection
-  bool is_dynamic()
+  bool is_dynamic() const
   {
-    @[dynamic = True]@
-    @[for field in spec.fields]@
-        @[if field.type.is_array and field.type.array_size is None:]@
-            @[dynamic = False]@
-            @[break]@
-        @[end if]@
-    @[end for]@
-    @[if not dynamic]@
+@[if spec.is_dynamic()]@
+    return true;
+@#@[else]@
+@#    return false;
+@[elif spec.base_type.is_primitive_type() or all([field.type.is_primitive_type() for field in spec.fields])]@
     return false;
-    @[else]@
-    bool dynamic = true;
-        @[for field in spec.fields]@
-            @[if not field.type.is_array and not field.type.is_primitive_type()]@
-        dynamic &= this->@(field.type.name).is_dynamic();
-            @[end if]@
-        @[end for]@
+@[else]@
+    bool dynamic = false;
+@[for msg_field in [field for field in spec.fields if not field.type.is_primitive_type()]]@
+@[if msg_field.type.is_array]@
+    dynamic |= @(msg_field.name)[0].is_dynamic();
+@[else]
+    dynamic |= @(msg_field.name).is_dynamic();
+@[end if]@
+@[end for]@
     return dynamic;
-    @[end if]@
+@[end if]@
   }
 
 }; // struct @(cpp_class)

--- a/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
+++ b/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
@@ -121,6 +121,21 @@ def msg_type_to_cpp(type_):
     else:
         return cpp_type
 
+def cpp_type_of_array(array_type_):
+    """
+    Get the C++ type of an array message type.
+
+    Example input: uint32[3], std_msgs/String[5]
+    Example output: uint32_t, std_msgs::String_<ContainerAllocator>
+    @param array_type_ Array message type.
+    @type array_type_: rosidl_parser.Type
+    """
+    assert array_type_.is_array, "cpp_type_of_array must be called on an array type"
+    if array_type_.is_primitive_type():
+        return MSG_TYPE_TO_CPP[array_type_.type]
+    else:
+        return '%s::msg::%s_<ContainerAllocator>' % (array_type_.pkg_name, array_type_.type)
+
 
 def value_to_cpp(type_, value):
     assert type_.is_primitive_type()

--- a/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
+++ b/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
@@ -49,7 +49,7 @@ def generate_cpp(generator_arguments_file):
         extension = os.path.splitext(ros_interface_file)[1]
         subfolder = os.path.basename(os.path.dirname(ros_interface_file))
         if extension == '.msg':
-            spec = parse_message_file(args['package_name'], ros_interface_file)
+            spec = parse_message_file(args['package_name'], ros_interface_file, interface_dependencies=args['ros_interface_files'])
             for template_file, generated_filename in mapping_msgs.items():
                 data = {'spec': spec, 'subfolder': subfolder}
                 data.update(functions)

--- a/rosidl_parser/rosidl_parser/__init__.py
+++ b/rosidl_parser/rosidl_parser/__init__.py
@@ -269,14 +269,8 @@ class Type(BaseType):
         return s
 
     def is_unbounded_array(self):
-        # is_upper_bound is True: a dynamically sized, bounded array
-        # array_size is None: dynamically sized array
-        return self.array_size is None and not self.is_upper_bound and self.is_array
-
-#    def has_bounded_size(self):
-#        unbounded_array = self.is_array and (self.array_size is None or self.is_upper_bound is False)
-#        unbounded_string = super(Type, self).type == 'string' and super(Type, self).string_upper_bound is None
-#        return not (unbounded_array or unbounded_string)
+        return self.array_size is None and not self.is_upper_bound and \
+            self.is_array
 
 
 class Constant(object):
@@ -391,8 +385,10 @@ class MessageSpecification(object):
             self.constants == other.constants
 
     def has_bounded_size(self):
-        contains_unbounded_array = any([field.type.is_unbounded_array() for field in self.fields])
-        contains_unbounded_string = any([field.type.is_unbounded_string() for field in self.fields])
+        contains_unbounded_array = \
+            any([field.type.is_unbounded_array() for field in self.fields])
+        contains_unbounded_string = \
+            any([field.type.is_unbounded_string() for field in self.fields])
         return not (contains_unbounded_array or contains_unbounded_string)
 
 

--- a/rosidl_parser/rosidl_parser/__init__.py
+++ b/rosidl_parser/rosidl_parser/__init__.py
@@ -128,9 +128,10 @@ def is_valid_constant_name(name):
 
 class BaseType(object):
 
-    __slots__ = ['pkg_name', 'type', 'string_upper_bound']
+    __slots__ = ['pkg_name', 'type', 'string_upper_bound', 'spec']
 
-    def __init__(self, type_string, context_package_name=None):
+    def __init__(self, type_string, interface_dependencies=None, context_package_name=None):
+        self.spec = None
         # check for primitive types
         if type_string in PRIMITIVE_TYPES:
             self.pkg_name = None
@@ -173,6 +174,12 @@ class BaseType(object):
                 raise InvalidResourceName(self.type)
             self.string_upper_bound = None
 
+            if interface_dependencies is not None:
+                for dep in interface_dependencies:
+                    if self.type + '.msg' in dep:
+                        self.spec = parse_message_file(self.pkg_name, dep, interface_dependencies=interface_dependencies)
+                        break
+
     def is_primitive_type(self):
         return self.pkg_name is None
 
@@ -204,7 +211,7 @@ class Type(BaseType):
 
     __slots__ = ['is_array', 'array_size', 'is_upper_bound']
 
-    def __init__(self, type_string, context_package_name=None):
+    def __init__(self, type_string, context_package_name=None, interface_dependencies=None):
         # check for array brackets
         self.is_array = type_string[-1] == ']'
 
@@ -244,7 +251,7 @@ class Type(BaseType):
 
         super(Type, self).__init__(
             type_string,
-            context_package_name=context_package_name)
+            context_package_name=context_package_name, interface_dependencies=interface_dependencies)
 
     def __eq__(self, other):
         if other is None or not isinstance(other, Type):
@@ -342,7 +349,7 @@ class Field(object):
 
 class MessageSpecification(object):
 
-    def __init__(self, pkg_name, msg_name, fields, constants):
+    def __init__(self, pkg_name, msg_name, fields, constants, interface_dependencies=None):
         self.base_type = BaseType(
             pkg_name + PACKAGE_NAME_MESSAGE_TYPE_SEPARATOR + msg_name)
 
@@ -385,22 +392,26 @@ class MessageSpecification(object):
             self.constants == other.constants
 
     def has_bounded_size(self):
+        nested_fields_bounded = True
+        nested_fields_bounded = all([field.type.spec.has_bounded_size() for field in self.fields if field.type.spec is not None] )
+        # base case
         contains_unbounded_array = \
             any([field.type.is_unbounded_array() for field in self.fields])
         contains_unbounded_string = \
             any([field.type.is_unbounded_string() for field in self.fields])
-        return not (contains_unbounded_array or contains_unbounded_string)
+        all_fields_bounded = not (contains_unbounded_array or contains_unbounded_string)
+        return all_fields_bounded and nested_fields_bounded
 
 
-def parse_message_file(pkg_name, interface_filename):
+def parse_message_file(pkg_name, interface_filename, interface_dependencies=None):
     basename = os.path.basename(interface_filename)
     msg_name = os.path.splitext(basename)[0]
     with open(interface_filename, 'r') as h:
         return parse_message_string(
-            pkg_name, msg_name, h.read())
+            pkg_name, msg_name, h.read(), interface_dependencies=interface_dependencies)
 
 
-def parse_message_string(pkg_name, msg_name, message_string):
+def parse_message_string(pkg_name, msg_name, message_string, interface_dependencies=None):
     fields = []
     constants = []
 
@@ -431,7 +442,7 @@ def parse_message_string(pkg_name, msg_name, message_string):
                 default_value_string = None
             try:
                 fields.append(Field(
-                    Type(type_string, context_package_name=pkg_name),
+                    Type(type_string, context_package_name=pkg_name, interface_dependencies=interface_dependencies),
                     field_name, default_value_string))
             except Exception as err:
                 print("Error processing '{line}' of '{pkg}/{msg}': '{err}'".format(
@@ -445,7 +456,7 @@ def parse_message_string(pkg_name, msg_name, message_string):
             value = value.lstrip()
             constants.append(Constant(type_string, name, value))
 
-    return MessageSpecification(pkg_name, msg_name, fields, constants)
+    return MessageSpecification(pkg_name, msg_name, fields, constants, interface_dependencies=interface_dependencies)
 
 
 def parse_value_string(type_, value_string):

--- a/rosidl_parser/rosidl_parser/__init__.py
+++ b/rosidl_parser/rosidl_parser/__init__.py
@@ -265,6 +265,13 @@ class Type(BaseType):
             s += ']'
         return s
 
+    def is_dynamic(self):
+        if self.is_array and self.array_size is None:
+            return True
+        if self.type == 'string' and self.string_upper_bound == None:
+            return True
+        return False
+
 
 class Constant(object):
 
@@ -376,6 +383,10 @@ class MessageSpecification(object):
             self.fields == other.fields and \
             len(self.constants) == len(other.constants) and \
             self.constants == other.constants
+
+    def is_dynamic(self):
+        # If any of the fields are dynamically sized, return true.
+        return any([field.type.is_dynamic() for field in self.fields])
 
 
 def parse_message_file(pkg_name, interface_filename):


### PR DESCRIPTION
Adds helper functions to `rosidl_parser` to check if a message specification has a bounded size and incorporates them into the message template.

It looked to me like `rosidl_parser` does not recursively store the type information of nested types. So currently nested types call `has_bounded_size` recursively in the generated C++ code on their non-primitive sub-fields.