### PR TITLE
Implement has_fixed_size and test

### DIFF
--- a/rosidl_generator_cpp/CMakeLists.txt
+++ b/rosidl_generator_cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 
-project(rosidl_generator_cpp NONE)
+project(rosidl_generator_cpp)
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
@@ -13,10 +13,54 @@ ament_python_install_package(${PROJECT_NAME})
 if(AMENT_ENABLE_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  set(message_files
+    "msg/BoundedArrayBounded.msg"
+    "msg/BoundedArrayStatic.msg"
+    "msg/BoundedArrayUnbounded.msg"
+
+    "msg/Empty.msg"
+
+    "msg/PrimitiveStaticArrays.msg"
+
+    "msg/PrimitivesBounded.msg"
+    "msg/PrimitivesStatic.msg"
+    "msg/PrimitivesUnbounded.msg"
+
+    "msg/StaticArrayBounded.msg"
+    "msg/StaticArrayStatic.msg"
+    "msg/StaticArrayUnbounded.msg"
+
+    "msg/UnboundedArrayBounded.msg"
+    "msg/UnboundedArrayStatic.msg"
+    "msg/UnboundedArrayUnbounded.msg"
+  )
+
+  include(cmake/register_cpp.cmake)
+  set(rosidl_generator_cpp_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+  rosidl_generator_cpp_extras(
+    "${CMAKE_CURRENT_SOURCE_DIR}/bin/rosidl_generator_cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/rosidl_generator_cpp/__init__.py"
+    "${CMAKE_CURRENT_SOURCE_DIR}/resource"
+  )
+
+  rosidl_generate_interfaces(${PROJECT_NAME} ${message_files}
+    SKIP_INSTALL
+  )
+
+  if(NOT WIN32)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
+  endif()
+
+  add_executable(test_interfaces_cpp "test/test_interfaces.cpp")
+  add_dependencies(test_interfaces_cpp ${PROJECT_NAME} ${rosidl_generate_interfaces_TARGET})
+  # include the built files directly, instead of their install location
+  include_directories("${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}")
 endif()
 
 ament_package(
-  CONFIG_EXTRAS "rosidl_generator_cpp-extras.cmake.in"
+  CONFIG_EXTRAS "cmake/register_cpp.cmake" "rosidl_generator_cpp-extras.cmake.in"
 )
 
 install(

--- a/rosidl_generator_cpp/bin/rosidl_generator_cpp
+++ b/rosidl_generator_cpp/bin/rosidl_generator_cpp
@@ -3,8 +3,16 @@
 import argparse
 import sys
 
-from rosidl_generator_cpp import generate_cpp
-
+try:
+    from rosidl_generator_cpp import generate_cpp
+except ImportError:
+    # If rosidl_generator_cpp was not installed, find the source relative to this file
+    rosidl_generator_cpp_root = os.path.dirname(os.path.dirname(__file__))
+    rosidl_generator_cpp_package = os.path.join(rosidl_generator_cpp_root, 'rosidl_generator_cpp')
+    if not os.path.exists(rosidl_generator_cpp_package):
+        raise
+    sys.path.insert(0, os.path.abspath(rosidl_generator_cpp_root))
+    from rosidl_generator_cpp import generate_cpp
 
 def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser(

--- a/rosidl_generator_cpp/cmake/register_cpp.cmake
+++ b/rosidl_generator_cpp/cmake/register_cpp.cmake
@@ -1,0 +1,16 @@
+macro(rosidl_generator_cpp_extras BIN GENERATOR_FILES TEMPLATE_DIR)
+  find_package(ament_cmake_core QUIET REQUIRED)
+  ament_register_extension(
+    "rosidl_generate_interfaces"
+    "rosidl_generator_cpp"
+    "rosidl_generator_cpp_generate_interfaces.cmake")
+
+  normalize_path(BIN "${BIN}")
+  set(rosidl_generator_cpp_BIN "${BIN}")
+
+  normalize_path(GENERATOR_FILES "${GENERATOR_FILES}")
+  set(rosidl_generator_cpp_GENERATOR_FILES "${GENERATOR_FILES}")
+
+  normalize_path(TEMPLATE_DIR "${TEMPLATE_DIR}")
+  set(rosidl_generator_cpp_TEMPLATE_DIR "${TEMPLATE_DIR}")
+endmacro()

--- a/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_interfaces.cmake
+++ b/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_interfaces.cmake
@@ -26,11 +26,13 @@ foreach(_idl_file ${rosidl_generate_interfaces_IDL_FILES})
     list(APPEND _generated_msg_files
       "${_output_path}/${_parent_folder}/${_header_name}.hpp"
       "${_output_path}/${_parent_folder}/${_header_name}__struct.hpp"
+      "${_output_path}/${_parent_folder}/${_header_name}__traits.hpp"
     )
   elseif("${_parent_folder} " STREQUAL "srv ")
     list(APPEND _generated_srv_files
       "${_output_path}/${_parent_folder}/${_header_name}.hpp"
       "${_output_path}/${_parent_folder}/${_header_name}__struct.hpp"
+      "${_output_path}/${_parent_folder}/${_header_name}__traits.hpp"
     )
   else()
     message(FATAL_ERROR "Interface file with unknown parent folder: ${_idl_file}")
@@ -53,8 +55,10 @@ set(target_dependencies
   ${rosidl_generator_cpp_GENERATOR_FILES}
   "${rosidl_generator_cpp_TEMPLATE_DIR}/msg.hpp.template"
   "${rosidl_generator_cpp_TEMPLATE_DIR}/msg__struct.hpp.template"
+  "${rosidl_generator_cpp_TEMPLATE_DIR}/msg__traits.hpp.template"
   "${rosidl_generator_cpp_TEMPLATE_DIR}/srv.hpp.template"
   "${rosidl_generator_cpp_TEMPLATE_DIR}/srv__struct.hpp.template"
+  "${rosidl_generator_cpp_TEMPLATE_DIR}/srv__traits.hpp.template"
   ${rosidl_generate_interfaces_IDL_FILES}
   ${_dependency_files})
 foreach(dep ${target_dependencies})
@@ -83,11 +87,16 @@ add_custom_command(
   VERBATIM
 )
 
-add_custom_target(
+if (TARGET ${rosidl_generate_interfaces_TARGET}__cpp)
+  message(WARNING "Custom target ${rosidl_generate_interfaces_TARGET}__cpp already exists")
+else()
+  add_custom_target(
   ${rosidl_generate_interfaces_TARGET}__cpp
   DEPENDS
   ${_generated_msg_files} ${_generated_srv_files}
 )
+endif()
+
 add_dependencies(
   ${rosidl_generate_interfaces_TARGET}
   ${rosidl_generate_interfaces_TARGET}__cpp

--- a/rosidl_generator_cpp/msg/BoundedArrayBounded.msg
+++ b/rosidl_generator_cpp/msg/BoundedArrayBounded.msg
@@ -1,0 +1,1 @@
+PrimitivesBounded[<=3] primitive_values

--- a/rosidl_generator_cpp/msg/BoundedArrayStatic.msg
+++ b/rosidl_generator_cpp/msg/BoundedArrayStatic.msg
@@ -1,0 +1,1 @@
+PrimitivesStatic[<=3] primitive_values

--- a/rosidl_generator_cpp/msg/BoundedArrayUnbounded.msg
+++ b/rosidl_generator_cpp/msg/BoundedArrayUnbounded.msg
@@ -1,0 +1,1 @@
+PrimitivesUnbounded[<=3] primitive_values

--- a/rosidl_generator_cpp/msg/PrimitiveStaticArrays.msg
+++ b/rosidl_generator_cpp/msg/PrimitiveStaticArrays.msg
@@ -1,0 +1,13 @@
+bool[3] bool_value
+byte[3] byte_value
+char[3] char_value
+float32[3] float32_value
+float64[3] float64_value
+int8[3] int8_value
+uint8[3] uint8_value
+int16[3] int16_value
+uint16[3] uint16_value
+int32[3] int32_value
+uint32[3] uint32_value
+int64[3] int64_value
+uint64[3] uint64_value

--- a/rosidl_generator_cpp/msg/PrimitivesBounded.msg
+++ b/rosidl_generator_cpp/msg/PrimitivesBounded.msg
@@ -1,0 +1,14 @@
+bool[<=10] bool_value
+byte[<=10] byte_value
+char[<=10] char_value
+float32[<=10] float32_value
+float64[<=10] float64_value
+int8[<=10] int8_value
+uint8[<=10] uint8_value
+int16[<=10] int16_value
+uint16[<=10] uint16_value
+int32[<=10] int32_value
+uint32[<=10] uint32_value
+int64[<=10] int64_value
+uint64[<=10] uint64_value
+string<=10 string_value

--- a/rosidl_generator_cpp/msg/PrimitivesStatic.msg
+++ b/rosidl_generator_cpp/msg/PrimitivesStatic.msg
@@ -1,0 +1,13 @@
+bool bool_value
+byte byte_value
+char char_value
+float32 float32_value
+float64 float64_value
+int8 int8_value
+uint8 uint8_value
+int16 int16_value
+uint16 uint16_value
+int32 int32_value
+uint32 uint32_value
+int64 int64_value
+uint64 uint64_value

--- a/rosidl_generator_cpp/msg/PrimitivesUnbounded.msg
+++ b/rosidl_generator_cpp/msg/PrimitivesUnbounded.msg
@@ -1,0 +1,14 @@
+bool[] bool_value
+byte[] byte_value
+char[] char_value
+float32[] float32_value
+float64[] float64_value
+int8[] int8_value
+uint8[] uint8_value
+int16[] int16_value
+uint16[] uint16_value
+int32[] int32_value
+uint32[] uint32_value
+int64[] int64_value
+uint64[] uint64_value
+string string_value

--- a/rosidl_generator_cpp/msg/StaticArrayBounded.msg
+++ b/rosidl_generator_cpp/msg/StaticArrayBounded.msg
@@ -1,0 +1,1 @@
+PrimitivesBounded[3] primitive_values

--- a/rosidl_generator_cpp/msg/StaticArrayStatic.msg
+++ b/rosidl_generator_cpp/msg/StaticArrayStatic.msg
@@ -1,0 +1,1 @@
+PrimitivesStatic[3] primitive_values

--- a/rosidl_generator_cpp/msg/StaticArrayUnbounded.msg
+++ b/rosidl_generator_cpp/msg/StaticArrayUnbounded.msg
@@ -1,0 +1,1 @@
+PrimitivesUnbounded[3] primitive_values

--- a/rosidl_generator_cpp/msg/UnboundedArrayBounded.msg
+++ b/rosidl_generator_cpp/msg/UnboundedArrayBounded.msg
@@ -1,0 +1,1 @@
+PrimitivesBounded[] primitive_values

--- a/rosidl_generator_cpp/msg/UnboundedArrayStatic.msg
+++ b/rosidl_generator_cpp/msg/UnboundedArrayStatic.msg
@@ -1,0 +1,1 @@
+PrimitivesStatic[] primitive_values

--- a/rosidl_generator_cpp/msg/UnboundedArrayUnbounded.msg
+++ b/rosidl_generator_cpp/msg/UnboundedArrayUnbounded.msg
@@ -1,0 +1,1 @@
+PrimitivesUnbounded[] primitive_values

--- a/rosidl_generator_cpp/package.xml
+++ b/rosidl_generator_cpp/package.xml
@@ -16,6 +16,9 @@
 
   <exec_depend>rosidl_parser</exec_depend>
 
+  <test_depend>ament_cmake_nose</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>rosidl_cmake</test_depend>
+  <test_depend>rosidl_generator_c</test_depend>
 </package>

--- a/rosidl_generator_cpp/resource/msg.hpp.template
+++ b/rosidl_generator_cpp/resource/msg.hpp.template
@@ -16,5 +16,6 @@
 #define __@(spec.base_type.pkg_name)__@(subfolder)__@(get_header_filename_from_msg_name(spec.base_type.type))__hpp__
 
 #include "@(spec.base_type.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.base_type.type))__struct.hpp"
+#include "@(spec.base_type.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.base_type.type))__traits.hpp"
 
 #endif  // __@(spec.base_type.pkg_name)__@(subfolder)__@(get_header_filename_from_msg_name(spec.base_type.type))__hpp__

--- a/rosidl_generator_cpp/resource/msg__traits.hpp.template
+++ b/rosidl_generator_cpp/resource/msg__traits.hpp.template
@@ -1,0 +1,69 @@
+// generated from rosidl_generator_cpp/resource/msg__traits.hpp.template
+
+@#######################################################################
+@# EmPy template for generating <msg>__traits.hpp files
+@#
+@# Context:
+@#  - spec (rosidl_parser.MessageSpecification)
+@#    Parsed specification of the .msg file
+@#  - subfolder (string)
+@#    The subfolder / subnamespace of the message
+@#    Either 'msg' or 'srv'
+@#  - get_header_filename_from_msg_name (function)
+@#######################################################################
+@
+@{
+from rosidl_generator_cpp import MSG_TYPE_TO_CPP
+
+cpp_namespace = '%s::%s::' % (spec.base_type.pkg_name, subfolder)
+}@
+#include <array>
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+namespace rosidl_generator_traits
+{
+
+#ifndef __ROSIDL_GENERATOR_CPP_TRAITS
+#define __ROSIDL_GENERATOR_CPP_TRAITS
+
+template<typename T>
+struct has_fixed_size {};
+
+#endif  /* __ROSIDL_GENERATOR_CPP_TRAITS */
+
+#ifndef __@(spec.base_type.pkg_name)__@(subfolder)__@(get_header_filename_from_msg_name(spec.base_type.type))__traits__hpp__
+#define __@(spec.base_type.pkg_name)__@(subfolder)__@(get_header_filename_from_msg_name(spec.base_type.type))__traits__hpp__
+
+#include "@(spec.base_type.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.base_type.type))__struct.hpp"
+
+@{
+fixed_template_strings = []
+fixed = True
+
+for field in spec.fields:
+   if field.type.type == 'string':
+       fixed = False
+       break
+   elif field.type.is_array and (field.type.is_upper_bound or field.type.array_size is None):
+       fixed = False
+       break
+   elif not field.type.is_primitive_type():
+       fixed_template_strings.append("has_fixed_size<{}::msg::{}>::value".format(field.type.pkg_name, field.type.type))
+
+if fixed:
+    fixed_template_string = ' && '.join(fixed_template_strings) if fixed_template_strings else 'true'
+else:
+    fixed_template_string = 'false'
+}@
+
+template<>
+struct has_fixed_size<@(cpp_namespace)@(spec.base_type.type)>
+{
+  static const bool value = @(fixed_template_string);
+};
+
+#endif  /* __@(spec.base_type.pkg_name)__@(subfolder)__@(get_header_filename_from_msg_name(spec.base_type.type))__traits__hpp__ */
+
+}  /* rosidl_generator_cpp_traits */

--- a/rosidl_generator_cpp/resource/srv.hpp.template
+++ b/rosidl_generator_cpp/resource/srv.hpp.template
@@ -12,6 +12,7 @@
 #ifndef __@(spec.pkg_name)__srv__@(get_header_filename_from_msg_name(spec.srv_name))__hpp__
 #define __@(spec.pkg_name)__srv__@(get_header_filename_from_msg_name(spec.srv_name))__hpp__
 
+#include "@(spec.pkg_name)/srv/@(get_header_filename_from_msg_name(spec.srv_name))__traits.hpp"
 #include "@(spec.pkg_name)/srv/@(get_header_filename_from_msg_name(spec.srv_name))__struct.hpp"
 
 #endif  // __@(spec.pkg_name)__srv__@(get_header_filename_from_msg_name(spec.srv_name))__hpp__

--- a/rosidl_generator_cpp/resource/srv__traits.hpp.template
+++ b/rosidl_generator_cpp/resource/srv__traits.hpp.template
@@ -1,0 +1,39 @@
+// generated from rosidl_generator_cpp/resource/srv__traits.hpp.template
+
+@#######################################################################
+@# EmPy template for generating <srv>__traits.hpp files
+@#
+@# Context:
+@#  - spec (rosidl_parser.ServiceSpecification)
+@#    Parsed specification of the .srv file
+@#  - get_header_filename_from_msg_name (function)
+@#######################################################################
+@
+@{
+cpp_namespace = '%s::srv::' % (spec.pkg_name)
+}@
+
+#include "@(spec.pkg_name)/srv/@(get_header_filename_from_msg_name(spec.srv_name))__struct.hpp"
+
+namespace rosidl_generator_traits
+{
+
+#ifndef __ROSIDL_GENERATOR_CPP_TRAITS
+#define __ROSIDL_GENERATOR_CPP_TRAITS
+
+template<typename T>
+struct has_fixed_size {};
+
+#endif  /* __ROSIDL_GENERATOR_CPP_TRAITS */
+
+#ifndef __@(spec.pkg_name)__srv__@(get_header_filename_from_msg_name(spec.srv_name))__traits__hpp__
+#define __@(spec.pkg_name)__srv__@(get_header_filename_from_msg_name(spec.srv_name))__traits__hpp__
+template <>
+struct has_fixed_size<@(cpp_namespace)@(spec.srv_name)>
+{
+  static const bool value = has_fixed_size<@(cpp_namespace)@(spec.srv_name)_Request>::value
+    && has_fixed_size<@(cpp_namespace)@(spec.srv_name)_Response>::value;
+};
+
+#endif  // __@(spec.pkg_name)__srv__@(get_header_filename_from_msg_name(spec.srv_name))__traits__hpp__
+}  /* rosidl_generator_traits */

--- a/rosidl_generator_cpp/rosidl_generator_cpp-extras.cmake.in
+++ b/rosidl_generator_cpp/rosidl_generator_cpp-extras.cmake.in
@@ -1,21 +1,7 @@
 # generated from rosidl_generator_cpp/rosidl_generator_cpp-extras.cmake
-
-find_package(ament_cmake_core QUIET REQUIRED)
-ament_register_extension(
-  "rosidl_generate_interfaces"
-  "rosidl_generator_cpp"
-  "rosidl_generator_cpp_generate_interfaces.cmake")
-
-set(rosidl_generator_cpp_BIN
-  "${rosidl_generator_cpp_DIR}/../../../lib/rosidl_generator_cpp/rosidl_generator_cpp")
-normalize_path(rosidl_generator_cpp_BIN "${rosidl_generator_cpp_BIN}")
-
-set(rosidl_generator_cpp_GENERATOR_FILES
-  "${rosidl_generator_cpp_DIR}/../../../@PYTHON_INSTALL_DIR@/rosidl_generator_cpp/__init__.py")
-normalize_path(rosidl_generator_cpp_GENERATOR_FILES
-  "${rosidl_generator_cpp_GENERATOR_FILES}")
-
-set(rosidl_generator_cpp_TEMPLATE_DIR
-  "${rosidl_generator_cpp_DIR}/../resource")
-normalize_path(rosidl_generator_cpp_TEMPLATE_DIR
-  "${rosidl_generator_cpp_TEMPLATE_DIR}")
+include("${CMAKE_CURRENT_LIST_DIR}/register_cpp.cmake")
+rosidl_generator_cpp_extras(
+  "${rosidl_generator_cpp_DIR}/../../../lib/rosidl_generator_cpp/rosidl_generator_cpp"
+  "${rosidl_generator_cpp_DIR}/../../../@PYTHON_INSTALL_DIR@/rosidl_generator_cpp/__init__.py"
+  "${rosidl_generator_cpp_DIR}/../resource"
+)

--- a/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
+++ b/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
@@ -29,11 +29,13 @@ def generate_cpp(generator_arguments_file):
     mapping_msgs = {
         os.path.join(template_dir, 'msg.hpp.template'): '%s.hpp',
         os.path.join(template_dir, 'msg__struct.hpp.template'): '%s__struct.hpp',
+        os.path.join(template_dir, 'msg__traits.hpp.template'): '%s__traits.hpp',
     }
 
     mapping_srvs = {
         os.path.join(template_dir, 'srv.hpp.template'): '%s.hpp',
         os.path.join(template_dir, 'srv__struct.hpp.template'): '%s__struct.hpp',
+        os.path.join(template_dir, 'srv__traits.hpp.template'): '%s__traits.hpp',
     }
     for template_file in mapping_msgs.keys():
         assert os.path.exists(template_file)

--- a/rosidl_generator_cpp/test/test_interfaces.cpp
+++ b/rosidl_generator_cpp/test/test_interfaces.cpp
@@ -1,0 +1,146 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <array>
+#include <cassert>
+#include <iostream>
+#include <type_traits>
+
+#include <rosidl_generator_cpp/msg/empty.hpp>
+
+#include <rosidl_generator_cpp/msg/bounded_array_bounded.hpp>
+#include <rosidl_generator_cpp/msg/bounded_array_static.hpp>
+#include <rosidl_generator_cpp/msg/bounded_array_unbounded.hpp>
+
+#include <rosidl_generator_cpp/msg/primitive_static_arrays.hpp>
+
+#include <rosidl_generator_cpp/msg/primitives_bounded.hpp>
+#include <rosidl_generator_cpp/msg/primitives_static.hpp>
+#include <rosidl_generator_cpp/msg/primitives_unbounded.hpp>
+
+#include <rosidl_generator_cpp/msg/static_array_bounded.hpp>
+#include <rosidl_generator_cpp/msg/static_array_static.hpp>
+#include <rosidl_generator_cpp/msg/static_array_unbounded.hpp>
+
+#include <rosidl_generator_cpp/msg/unbounded_array_bounded.hpp>
+#include <rosidl_generator_cpp/msg/unbounded_array_static.hpp>
+#include <rosidl_generator_cpp/msg/unbounded_array_unbounded.hpp>
+
+template<typename T1, bool B>
+struct expect_fixed
+  : std::enable_if<rosidl_generator_traits::has_fixed_size<T1>::value == B, bool>{};
+
+int main(int /*argc*/, char ** /*argv*/)
+{
+  {
+    const bool expectation = true;
+    expect_fixed<rosidl_generator_cpp::msg::Empty, expectation>::type x = expectation;
+    printf("Test passed: type Empty::has_fixed_size == %d\n", x);
+  }
+
+  {
+    const bool expectation = true;
+    expect_fixed<rosidl_generator_cpp::msg::PrimitivesStatic, expectation>::type x = expectation;
+    printf("Test passed: type PrimitivesStatic::has_fixed_size == %d\n", x);
+  }
+
+  {
+    const bool expectation = false;
+    expect_fixed<rosidl_generator_cpp::msg::PrimitivesBounded, expectation>::type x = expectation;
+    printf("Test passed: type PrimitivesBounded::has_fixed_size == %d\n", x);
+  }
+
+  {
+    const bool expectation = false;
+    expect_fixed<rosidl_generator_cpp::msg::PrimitivesUnbounded, expectation>::type x = expectation;
+    printf("Test passed: type PrimitivesUnbounded::has_fixed_size == %d\n", x);
+  }
+
+  {
+    const bool expectation = true;
+    expect_fixed<rosidl_generator_cpp::msg::PrimitiveStaticArrays,
+    expectation>::type x = expectation;
+    printf("Test passed: type PrimitivesStaticArrays::has_fixed_size == %d\n", x);
+  }
+
+  {
+    const bool expectation = true;
+    expect_fixed<rosidl_generator_cpp::msg::StaticArrayStatic, expectation>::type x = expectation;
+    printf("Test passed: type StaticArrayStatic::has_fixed_size == %d\n", x);
+  }
+
+  {
+    const bool expectation = false;
+    expect_fixed<rosidl_generator_cpp::msg::StaticArrayBounded, expectation>::type x = expectation;
+    printf("Test passed: type StaticArrayBounded::has_fixed_size == %d\n", x);
+  }
+
+  {
+    const bool expectation = false;
+    expect_fixed<rosidl_generator_cpp::msg::StaticArrayUnbounded,
+    expectation>::type x = expectation;
+    printf("Test passed: type StaticArrayUnbounded::has_fixed_size == %d\n", x);
+  }
+
+  {
+    const bool expectation = false;
+    expect_fixed<rosidl_generator_cpp::msg::BoundedArrayStatic, expectation>::type x = expectation;
+    printf("Test passed: type BoundedArrayStatic::has_fixed_size == %d\n", x);
+  }
+
+  {
+    const bool expectation = false;
+    expect_fixed<rosidl_generator_cpp::msg::BoundedArrayBounded, expectation>::type x = expectation;
+    printf("Test passed: type BoundedArrayBounded::has_fixed_size == %d\n", x);
+  }
+
+  {
+    const bool expectation = false;
+    expect_fixed<rosidl_generator_cpp::msg::BoundedArrayUnbounded,
+    expectation>::type x = expectation;
+    printf("Test passed: type BoundedArrayUnbounded::has_fixed_size == %d\n", x);
+  }
+
+  {
+    const bool expectation = false;
+    expect_fixed<rosidl_generator_cpp::msg::UnboundedArrayStatic,
+    expectation>::type x = expectation;
+    printf("Test passed: type UnboundedArrayStatic::has_fixed_size == %d\n", x);
+  }
+
+  {
+    const bool expectation = false;
+    expect_fixed<rosidl_generator_cpp::msg::UnboundedArrayBounded,
+    expectation>::type x = expectation;
+    printf("Test passed: type UnboundedArrayBounded::has_fixed_size == %d\n", x);
+  }
+
+  {
+    const bool expectation = false;
+    expect_fixed<rosidl_generator_cpp::msg::UnboundedArrayUnbounded,
+    expectation>::type x = expectation;
+    printf("Test passed: type UnboundedArrayUnbounded::has_fixed_size == %d\n", x);
+  }
+
+  // Showing that sizeof returns accurate values for messages containing static arrays
+  size_t primitive_size = sizeof(rosidl_generator_cpp::msg::PrimitivesStatic);
+  size_t array_primitives_size = sizeof(rosidl_generator_cpp::msg::StaticArrayStatic);
+  size_t primitive_static_array_size = sizeof(rosidl_generator_cpp::msg::PrimitiveStaticArrays);
+
+  assert(array_primitives_size == 3 * primitive_size);
+  assert(primitive_static_array_size == 3 * primitive_size);
+
+  fprintf(stderr, "All message tests passed.\n");
+  return 0;
+}


### PR DESCRIPTION
This pull request adds the ability to check if a message has fixed size at compile time. It adds a test for `has_fixed_size`, enables `rosidl_generator_cpp` to register itself as a generator before installation to be used in the test, and adds several messages to be used in the test. It also demonstrates in the test that `sizeof` is sufficient to calculate the fixed size of a messages.