### PR TITLE
fix SKIP_INSTALL to affect generated files

### DIFF
--- a/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
@@ -128,6 +128,7 @@ macro(rosidl_generate_interfaces target)
   set(rosidl_generate_interfaces_TARGET ${target})
   set(rosidl_generate_interfaces_IDL_FILES ${_idl_files})
   set(rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES ${_ARG_DEPENDENCIES})
+  set(rosidl_generate_interfaces_SKIP_INSTALL ${_ARG_SKIP_INSTALL})
   ament_execute_extensions("rosidl_generate_interfaces")
 
   if(NOT _ARG_SKIP_INSTALL)

--- a/rosidl_generator_c/cmake/rosidl_generator_c_generate_interfaces.cmake
+++ b/rosidl_generator_c/cmake/rosidl_generator_c_generate_interfaces.cmake
@@ -94,10 +94,12 @@ if(NOT "${_generated_msg_files} " STREQUAL " ")
     ${rosidl_generate_interfaces_TARGET}__c
   )
 
-  install(
-    FILES ${_generated_msg_files}
-    DESTINATION "include/${PROJECT_NAME}/msg"
-  )
+  if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
+    install(
+      FILES ${_generated_msg_files}
+      DESTINATION "include/${PROJECT_NAME}/msg"
+    )
+  endif()
 
   ament_export_include_directories(include)
 endif()

--- a/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_interfaces.cmake
+++ b/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_interfaces.cmake
@@ -93,17 +93,19 @@ add_dependencies(
   ${rosidl_generate_interfaces_TARGET}__cpp
 )
 
-if(NOT "${_generated_msg_files} " STREQUAL " ")
-  install(
-    FILES ${_generated_msg_files}
-    DESTINATION "include/${PROJECT_NAME}/msg"
-  )
-endif()
-if(NOT "${_generated_srv_files} " STREQUAL " ")
-  install(
-    FILES ${_generated_srv_files}
-    DESTINATION "include/${PROJECT_NAME}/srv"
-  )
+if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
+  if(NOT "${_generated_msg_files} " STREQUAL " ")
+    install(
+      FILES ${_generated_msg_files}
+      DESTINATION "include/${PROJECT_NAME}/msg"
+    )
+  endif()
+  if(NOT "${_generated_srv_files} " STREQUAL " ")
+    install(
+      FILES ${_generated_srv_files}
+      DESTINATION "include/${PROJECT_NAME}/srv"
+    )
+  endif()
 endif()
 
 ament_export_include_directories(include)


### PR DESCRIPTION
Discovered in #33 that it was not working for generated files but only for the `.msg` / `.srv` files before.