### PR TITLE
add check that message package declares the interface files

### DIFF
--- a/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
@@ -131,6 +131,13 @@ macro(rosidl_generate_interfaces target)
     endforeach()
   endforeach()
 
+  # check that all dependencies are actually valid message packages
+  foreach(_dep ${_recursive_dependencies})
+    if (NOT DEFINED ${_dep}_INTERFACE_FILES)
+      message(FATAL_ERROR "The message package '${_dep}' does not declare the interface files")
+    endif()
+  endforeach()
+
   # generators must be executed in topological order
   # which is ensured by every generator finding its dependencies first
   # and then registering itself as an extension


### PR DESCRIPTION
Instead of failing while building the specific type support package this will fail early if e.g. a ROS 1 message package is found instead.