### PR TITLE
Use std::integral_constant for has_fixed_size

### DIFF
--- a/rosidl_generator_cpp/CMakeLists.txt
+++ b/rosidl_generator_cpp/CMakeLists.txt
@@ -53,8 +53,7 @@ if(AMENT_ENABLE_TESTING)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
   endif()
 
-  add_executable(test_interfaces_cpp "test/test_interfaces.cpp")
-  add_dependencies(test_interfaces_cpp ${PROJECT_NAME} ${rosidl_generate_interfaces_TARGET})
+  ament_add_gtest(test_interfaces_cpp test/test_interfaces.cpp)
   # include the built files directly, instead of their install location
   include_directories("${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}")
 endif()

--- a/rosidl_generator_cpp/package.xml
+++ b/rosidl_generator_cpp/package.xml
@@ -16,6 +16,7 @@
 
   <exec_depend>rosidl_parser</exec_depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_nose</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rosidl_generator_cpp/resource/msg__traits.hpp.template
+++ b/rosidl_generator_cpp/resource/msg__traits.hpp.template
@@ -29,7 +29,7 @@ namespace rosidl_generator_traits
 #define __ROSIDL_GENERATOR_CPP_TRAITS
 
 template<typename T>
-struct has_fixed_size {};
+struct has_fixed_size : std::false_type {};
 
 #endif  /* __ROSIDL_GENERATOR_CPP_TRAITS */
 
@@ -59,10 +59,8 @@ else:
 }@
 
 template<>
-struct has_fixed_size<@(cpp_namespace)@(spec.base_type.type)>
-{
-  static const bool value = @(fixed_template_string);
-};
+struct has_fixed_size<@(cpp_namespace)@(spec.base_type.type)> :
+std::integral_constant<bool, @(fixed_template_string)> {};
 
 #endif  /* __@(spec.base_type.pkg_name)__@(subfolder)__@(get_header_filename_from_msg_name(spec.base_type.type))__traits__hpp__ */
 

--- a/rosidl_generator_cpp/resource/srv__traits.hpp.template
+++ b/rosidl_generator_cpp/resource/srv__traits.hpp.template
@@ -22,18 +22,18 @@ namespace rosidl_generator_traits
 #define __ROSIDL_GENERATOR_CPP_TRAITS
 
 template<typename T>
-struct has_fixed_size {};
+struct has_fixed_size : std::false_type {};
 
 #endif  /* __ROSIDL_GENERATOR_CPP_TRAITS */
 
 #ifndef __@(spec.pkg_name)__srv__@(get_header_filename_from_msg_name(spec.srv_name))__traits__hpp__
 #define __@(spec.pkg_name)__srv__@(get_header_filename_from_msg_name(spec.srv_name))__traits__hpp__
 template <>
-struct has_fixed_size<@(cpp_namespace)@(spec.srv_name)>
-{
-  static const bool value = has_fixed_size<@(cpp_namespace)@(spec.srv_name)_Request>::value
-    && has_fixed_size<@(cpp_namespace)@(spec.srv_name)_Response>::value;
-};
+struct has_fixed_size<@(cpp_namespace)@(spec.srv_name)> :
+std::integral_constant<
+  bool,
+  has_fixed_size<@(cpp_namespace)@(spec.srv_name)_Request>::value &&
+  has_fixed_size<@(cpp_namespace)@(spec.srv_name)_Response>::value> {};
 
 #endif  // __@(spec.pkg_name)__srv__@(get_header_filename_from_msg_name(spec.srv_name))__traits__hpp__
 }  /* rosidl_generator_traits */

--- a/rosidl_generator_cpp/test/test_interfaces.cpp
+++ b/rosidl_generator_cpp/test/test_interfaces.cpp
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <array>
-#include <cassert>
-#include <iostream>
-#include <type_traits>
+#include <gtest/gtest.h>
 
 #include "rosidl_generator_cpp/msg/empty.hpp"
 
@@ -37,110 +34,75 @@
 #include "rosidl_generator_cpp/msg/unbounded_array_static.hpp"
 #include "rosidl_generator_cpp/msg/unbounded_array_unbounded.hpp"
 
-template<typename T1, bool B>
-struct expect_fixed
-  : std::enable_if<rosidl_generator_traits::has_fixed_size<T1>::value == B, bool>{};
+TEST(Test_rosidl_generator_traits, has_fixed_size) {
+  static_assert(
+    rosidl_generator_traits::has_fixed_size<rosidl_generator_cpp::msg::Empty>::value,
+    "Empty::has_fixed_size is false");
 
-int main(int /*argc*/, char ** /*argv*/)
-{
-  {
-    const bool expectation = true;
-    expect_fixed<rosidl_generator_cpp::msg::Empty, expectation>::type x = expectation;
-    printf("Test passed: type Empty::has_fixed_size == %d\n", x);
-  }
+  static_assert(
+    rosidl_generator_traits::has_fixed_size<rosidl_generator_cpp::msg::PrimitivesStatic>::value,
+    "PrimitivesStatic::has_fixed_size is false");
 
-  {
-    const bool expectation = true;
-    expect_fixed<rosidl_generator_cpp::msg::PrimitivesStatic, expectation>::type x = expectation;
-    printf("Test passed: type PrimitivesStatic::has_fixed_size == %d\n", x);
-  }
+  static_assert(
+    !rosidl_generator_traits::has_fixed_size<rosidl_generator_cpp::msg::PrimitivesBounded>::value,
+    "PrimitivesBounded::has_fixed_size is true");
 
-  {
-    const bool expectation = false;
-    expect_fixed<rosidl_generator_cpp::msg::PrimitivesBounded, expectation>::type x = expectation;
-    printf("Test passed: type PrimitivesBounded::has_fixed_size == %d\n", x);
-  }
+  static_assert(
+    !rosidl_generator_traits::has_fixed_size<rosidl_generator_cpp::msg::PrimitivesUnbounded>::value,
+    "PrimitivesUnbounded::has_fixed_size is true");
 
-  {
-    const bool expectation = false;
-    expect_fixed<rosidl_generator_cpp::msg::PrimitivesUnbounded, expectation>::type x = expectation;
-    printf("Test passed: type PrimitivesUnbounded::has_fixed_size == %d\n", x);
-  }
+  static_assert(
+    rosidl_generator_traits::has_fixed_size<
+      rosidl_generator_cpp::msg::PrimitiveStaticArrays>::value,
+    "PrimitivesStaticArray::has_fixed_size is false");
 
-  {
-    const bool expectation = true;
-    expect_fixed<rosidl_generator_cpp::msg::PrimitiveStaticArrays,
-    expectation>::type x = expectation;
-    printf("Test passed: type PrimitivesStaticArrays::has_fixed_size == %d\n", x);
-  }
+  static_assert(
+    rosidl_generator_traits::has_fixed_size<rosidl_generator_cpp::msg::StaticArrayStatic>::value,
+    "StaticArrayStatic::has_fixed_size is false");
 
-  {
-    const bool expectation = true;
-    expect_fixed<rosidl_generator_cpp::msg::StaticArrayStatic, expectation>::type x = expectation;
-    printf("Test passed: type StaticArrayStatic::has_fixed_size == %d\n", x);
-  }
+  static_assert(
+    !rosidl_generator_traits::has_fixed_size<rosidl_generator_cpp::msg::StaticArrayBounded>::value,
+    "StaticArrayBounded::has_fixed_size is true");
 
-  {
-    const bool expectation = false;
-    expect_fixed<rosidl_generator_cpp::msg::StaticArrayBounded, expectation>::type x = expectation;
-    printf("Test passed: type StaticArrayBounded::has_fixed_size == %d\n", x);
-  }
+  static_assert(
+    !rosidl_generator_traits::has_fixed_size<
+      rosidl_generator_cpp::msg::StaticArrayUnbounded>::value,
+    "StaticArrayUnbounded::has_fixed_size is true");
 
-  {
-    const bool expectation = false;
-    expect_fixed<rosidl_generator_cpp::msg::StaticArrayUnbounded,
-    expectation>::type x = expectation;
-    printf("Test passed: type StaticArrayUnbounded::has_fixed_size == %d\n", x);
-  }
+  static_assert(
+    !rosidl_generator_traits::has_fixed_size<rosidl_generator_cpp::msg::BoundedArrayStatic>::value,
+    "BoundedArrayStatic::has_fixed_size is true");
 
-  {
-    const bool expectation = false;
-    expect_fixed<rosidl_generator_cpp::msg::BoundedArrayStatic, expectation>::type x = expectation;
-    printf("Test passed: type BoundedArrayStatic::has_fixed_size == %d\n", x);
-  }
+  static_assert(
+    !rosidl_generator_traits::has_fixed_size<rosidl_generator_cpp::msg::BoundedArrayBounded>::value,
+    "BoundedArrayBounded::has_fixed_size is true");
 
-  {
-    const bool expectation = false;
-    expect_fixed<rosidl_generator_cpp::msg::BoundedArrayBounded, expectation>::type x = expectation;
-    printf("Test passed: type BoundedArrayBounded::has_fixed_size == %d\n", x);
-  }
+  static_assert(
+    !rosidl_generator_traits::has_fixed_size<
+      rosidl_generator_cpp::msg::BoundedArrayUnbounded>::value,
+    "BoundedArrayUnbounded::has_fixed_size is true");
 
-  {
-    const bool expectation = false;
-    expect_fixed<rosidl_generator_cpp::msg::BoundedArrayUnbounded,
-    expectation>::type x = expectation;
-    printf("Test passed: type BoundedArrayUnbounded::has_fixed_size == %d\n", x);
-  }
+  static_assert(
+    !rosidl_generator_traits::has_fixed_size<
+      rosidl_generator_cpp::msg::UnboundedArrayStatic>::value,
+    "UnboundedArrayStatic::has_fixed_size is true");
 
-  {
-    const bool expectation = false;
-    expect_fixed<rosidl_generator_cpp::msg::UnboundedArrayStatic,
-    expectation>::type x = expectation;
-    printf("Test passed: type UnboundedArrayStatic::has_fixed_size == %d\n", x);
-  }
+  static_assert(
+    !rosidl_generator_traits::has_fixed_size<
+      rosidl_generator_cpp::msg::UnboundedArrayBounded>::value,
+    "UnboundedArrayBounded::has_fixed_size is true");
 
-  {
-    const bool expectation = false;
-    expect_fixed<rosidl_generator_cpp::msg::UnboundedArrayBounded,
-    expectation>::type x = expectation;
-    printf("Test passed: type UnboundedArrayBounded::has_fixed_size == %d\n", x);
-  }
-
-  {
-    const bool expectation = false;
-    expect_fixed<rosidl_generator_cpp::msg::UnboundedArrayUnbounded,
-    expectation>::type x = expectation;
-    printf("Test passed: type UnboundedArrayUnbounded::has_fixed_size == %d\n", x);
-  }
+  static_assert(
+    !rosidl_generator_traits::has_fixed_size<
+      rosidl_generator_cpp::msg::UnboundedArrayUnbounded>::value,
+    "UnboundedArrayUnbounded::has_fixed_size is true");
 
   // Showing that sizeof returns accurate values for messages containing static arrays
-  size_t primitive_size = sizeof(rosidl_generator_cpp::msg::PrimitivesStatic);
-  size_t array_primitives_size = sizeof(rosidl_generator_cpp::msg::StaticArrayStatic);
-  size_t primitive_static_array_size = sizeof(rosidl_generator_cpp::msg::PrimitiveStaticArrays);
+  constexpr size_t primitive_size = sizeof(rosidl_generator_cpp::msg::PrimitivesStatic);
+  constexpr size_t array_primitives_size = sizeof(rosidl_generator_cpp::msg::StaticArrayStatic);
+  constexpr size_t primitive_static_array_size =
+    sizeof(rosidl_generator_cpp::msg::PrimitiveStaticArrays);
 
-  assert(array_primitives_size == 3 * primitive_size);
-  assert(primitive_static_array_size == 3 * primitive_size);
-
-  fprintf(stderr, "All message tests passed.\n");
-  return 0;
+  static_assert(array_primitives_size == 3 * primitive_size, "Wrong size");
+  static_assert(primitive_static_array_size == 3 * primitive_size, "Wrong size");
 }


### PR DESCRIPTION
This makes `has_fixed_size` behave like `std::true_type` and `std::false_type` through `std::integral_constant` so that it can be integrated better with other type traits.