### PR TITLE
make typesupport dependencies not required

### DIFF
--- a/rosidl_default_generators/CMakeLists.txt
+++ b/rosidl_default_generators/CMakeLists.txt
@@ -9,14 +9,11 @@ ament_export_dependencies(rosidl_cmake)
 ament_export_dependencies(rosidl_generator_c)
 ament_export_dependencies(rosidl_generator_cpp)
 
-ament_export_dependencies(rosidl_typesupport_introspection_cpp)
-
-ament_export_dependencies(rosidl_typesupport_connext_cpp)
-ament_export_dependencies(rosidl_typesupport_opensplice_cpp)
-
 if(AMENT_ENABLE_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_package()
+ament_package(
+  CONFIG_EXTRAS "rosidl_default_generators-extras.cmake.in"
+)

--- a/rosidl_default_generators/rosidl_default_generators-extras.cmake.in
+++ b/rosidl_default_generators/rosidl_default_generators-extras.cmake.in
@@ -1,0 +1,27 @@
+# generated from
+# rosidl_default_generators/rosidl_default_generators-extras.cmake.in
+
+set(_exported_dependencies
+  "rosidl_typesupport_introspection_cpp"
+  "rosidl_typesupport_connext_cpp"
+  "rosidl_typesupport_opensplice_cpp"
+)
+
+# find_package() all dependencies (if available)
+# and append their DEFINITIONS INCLUDE_DIRS and LIBRARIES variables
+# to @PROJECT_NAME@_DEFINITIONS , @PROJECT_NAME@_INCLUDE_DIRS and
+# @PROJECT_NAME@_LIBRARIES.
+foreach(_dep ${_exported_dependencies})
+  find_package("${_dep}" QUIET)
+  if(${_dep}_FOUND)
+    if(${_dep}_DEFINITIONS)
+      list(APPEND @PROJECT_NAME@_DEFINITIONS "${${_dep}_DEFINITIONS}")
+    endif()
+    if(${_dep}_INCLUDE_DIRS)
+      list(APPEND @PROJECT_NAME@_INCLUDE_DIRS "${${_dep}_INCLUDE_DIRS}")
+    endif()
+    if(${_dep}_LIBRARIES)
+      list(APPEND @PROJECT_NAME@_LIBRARIES "${${_dep}_LIBRARIES}")
+    endif()
+  endif()
+endforeach()


### PR DESCRIPTION
Without this patch it is not possible to place an `AMENT_IGNORE` file into the `rmw_connext` / `rmw_opensplice` folder.

http://ci.ros2.org/job/ros2_batch_ci_linux/579/
http://ci.ros2.org/job/ros2_batch_ci_osx/463/