### PR TITLE
Fixed the include for [arrays.h] in C.

### DIFF
--- a/rosidl_generator_c/include/rosidl_generator_c/arrays.h
+++ b/rosidl_generator_c/include/rosidl_generator_c/arrays.h
@@ -19,7 +19,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <string>
+#include <string.h>
 
 #ifdef __cplusplus
 #define ROSIDL_ALLOC(Type) static_cast<Type *>(malloc(sizeof(Type)))


### PR DESCRIPTION
Fixes #47. Very simple fix: just added the C header instead of the C++ one. Otherwise compiling for c99 couldn't find the library.