### PR TITLE
add rosidl_default_runtime package

### DIFF
--- a/rosidl_default_runtime/CMakeLists.txt
+++ b/rosidl_default_runtime/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 2.8.3)
+
+project(rosidl_default_runtime NONE)
+
+find_package(ament_cmake REQUIRED)
+
+ament_export_dependencies(rosidl_typesupport_introspection_c)
+ament_export_dependencies(rosidl_typesupport_introspection_cpp)
+
+if(AMENT_ENABLE_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/rosidl_default_runtime/package.xml
+++ b/rosidl_default_runtime/package.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>rosidl_default_runtime</name>
+  <version>0.0.0</version>
+  <description>A configuration package defining the runtime for the ROS interfaces.</description>
+  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <buildtool_export_depend>rosidl_typesupport_introspection_c</buildtool_export_depend>
+  <buildtool_export_depend>rosidl_typesupport_introspection_cpp</buildtool_export_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
Based on our discussion on the whiteboard this is the right way to fix ros2/rclcpp#181.

Connects to ros2/rclcpp#181

Without this the test failed: http://ci.ros2.org/job/ci_osx/656/
With this the test doesn't fail due to the not found library: http://ci.ros2.org/job/ci_osx/657/