### PR TITLE
Temporarily add extra dependencies to workaround linking issue on OS X

### DIFF
--- a/rosidl_default_runtime/package.xml
+++ b/rosidl_default_runtime/package.xml
@@ -8,8 +8,15 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <buildtool_export_depend>rosidl_typesupport_introspection_c</buildtool_export_depend>
-  <buildtool_export_depend>rosidl_typesupport_introspection_cpp</buildtool_export_depend>
+  <build_export_depend>rosidl_typesupport_introspection_c</build_export_depend>
+  <build_export_depend>rosidl_typesupport_introspection_cpp</build_export_depend>
+
+  <!-- These two dependencies cannot stay here. -->
+  <!-- This is a workaround for: https://github.com/ros2/ros2/issues/174 -->
+  <!-- Once that issue is properly resolved this needs to be removed. -->
+  <build_export_depend>rosidl_typesupport_connext_cpp</build_export_depend>
+  <build_export_depend>rosidl_typesupport_opensplice_cpp</build_export_depend>
+  <!--  -->
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
We need a more complete solution, but for now we'll have to workaround linking issues in tests on OS X with these changes.

See: ros2/ros2#174