### PR TITLE
Rename identifiers

### DIFF
--- a/rosidl_typesupport_introspection_c/src/identifier.c
+++ b/rosidl_typesupport_introspection_c/src/identifier.c
@@ -14,4 +14,4 @@
 
 #include "rosidl_typesupport_introspection_c/identifier.h"
 
-const char * rosidl_typesupport_introspection_c__identifier = "introspection";
+const char * rosidl_typesupport_introspection_c__identifier = "introspection_c";

--- a/rosidl_typesupport_introspection_cpp/src/identifier.cpp
+++ b/rosidl_typesupport_introspection_cpp/src/identifier.cpp
@@ -18,6 +18,6 @@ namespace rosidl_typesupport_introspection_cpp
 {
 
 ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_EXPORT
-const char * typesupport_introspection_identifier = "introspection";
+const char * typesupport_introspection_identifier = "introspection_cpp";
 
 }  // namespace rosidl_typesupport_introspection_cpp


### PR DESCRIPTION
This just uses a different value for the identifiers of each of the introspection implementations.