### PR TITLE
Workaround constants

### DIFF
--- a/rosidl_generator_c/CMakeLists.txt
+++ b/rosidl_generator_c/CMakeLists.txt
@@ -59,6 +59,7 @@ if(AMENT_ENABLE_TESTING)
     "msg/Telegram1.msg"
     "msg/Telegram2.msg"
     "msg/Wire.msg"
+    "msg/Constants.msg"
   )
 
   include(cmake/register_c.cmake)

--- a/rosidl_generator_c/msg/Constants.msg
+++ b/rosidl_generator_c/msg/Constants.msg
@@ -1,0 +1,3 @@
+int32 X=123
+int32 Y=-123
+string FOO=foo

--- a/rosidl_generator_c/resource/msg__struct.h.template
+++ b/rosidl_generator_c/resource/msg__struct.h.template
@@ -55,16 +55,6 @@ for field in spec.fields:
             [])
         field_names.append(field.name)
 }@
-@[if includes]@
-// include message dependencies
-@[for header_file, field_names in includes.items()]@
-@[for field_name in field_names]@
-// @(field_name)
-@[end for]@
-#include "@(header_file)"
-@[end for]@
-
-@[end if]@
 @
 @#######################################################################
 @# constants defined in the message
@@ -87,6 +77,16 @@ for constant in spec.constants:
             primitive_value_to_c(constant.type, constant.value),
         ))
 }@
+@[if includes]@
+// include message dependencies
+@[for header_file, field_names in includes.items()]@
+@[for field_name in field_names]@
+// @(field_name)
+@[end for]@
+#include "@(header_file)"
+@[end for]@
+
+@[end if]@
 @[if constants]@
 // constants defined in the message
 @[for constant_type, constant_name, key, value in constants]@
@@ -96,6 +96,11 @@ enum
 {
   @(key) = @(value)
 };
+@[elif key.split()[0] == 'rosidl_generator_c__String']@
+@{
+name = key.split()[1]
+}@
+static const char * const @(name) = @(value);
 @[else]@
 static const @(key) = @(value);
 @[end if]@

--- a/rosidl_generator_c/test/test_interfaces.c
+++ b/rosidl_generator_c/test/test_interfaces.c
@@ -46,6 +46,7 @@
 #include "rosidl_generator_c/msg/telegram1__struct.h"
 #include "rosidl_generator_c/msg/telegram2__struct.h"
 #include "rosidl_generator_c/msg/wire__struct.h"
+#include "rosidl_generator_c/msg/constants__struct.h"
 
 #include "rosidl_generator_c/msg/various__functions.h"
 #include "rosidl_generator_c/msg/bool__functions.h"
@@ -69,6 +70,7 @@
 #include "rosidl_generator_c/msg/telegram1__functions.h"
 #include "rosidl_generator_c/msg/telegram2__functions.h"
 #include "rosidl_generator_c/msg/wire__functions.h"
+#include "rosidl_generator_c/msg/constants__functions.h"
 
 #define TEST_STRING \
   "Deep into that darkness peering, long I stood there wondering, fearing"
@@ -134,6 +136,10 @@ void test_primitives(void)
 
   byte_msg.empty_byte = 255;
   assert(byte_msg.empty_byte == 255);
+
+  assert(rosidl_generator_c__msg__Constants__X == 123);
+  assert(rosidl_generator_c__msg__Constants__Y == -123);
+  assert(strncmp(rosidl_generator_c__msg__Constants__FOO, "foo", 3) == 0);
 
   char_msg.empty_char = CHAR_MIN;
   assert(char_msg.empty_char == CHAR_MIN);


### PR DESCRIPTION
This PR adds a work around a bug initializing string constants.

This also fixes headers not being included if the message didn't define any fields.