### PR TITLE
Get rid of faulty assumptions in test

### DIFF
--- a/rosidl_generator_cpp/test/test_interfaces.cpp
+++ b/rosidl_generator_cpp/test/test_interfaces.cpp
@@ -96,13 +96,4 @@ TEST(Test_rosidl_generator_traits, has_fixed_size) {
     !rosidl_generator_traits::has_fixed_size<
       rosidl_generator_cpp::msg::UnboundedArrayUnbounded>::value,
     "UnboundedArrayUnbounded::has_fixed_size is true");
-
-  // Showing that sizeof returns accurate values for messages containing static arrays
-  constexpr size_t primitive_size = sizeof(rosidl_generator_cpp::msg::PrimitivesStatic);
-  constexpr size_t array_primitives_size = sizeof(rosidl_generator_cpp::msg::StaticArrayStatic);
-  constexpr size_t primitive_static_array_size =
-    sizeof(rosidl_generator_cpp::msg::PrimitiveStaticArrays);
-
-  static_assert(array_primitives_size == 3 * primitive_size, "Wrong size");
-  static_assert(primitive_static_array_size == 3 * primitive_size, "Wrong size");
 }


### PR DESCRIPTION
Fixes #75

As I recall, when I added this test I was trying to show that a fixed-size message struct is predictable at compile time. However, as issue #75 shows, the `sizeof` operator can give different outputs between compilers and architectures, because structure alignment is implementation defined, not defined by the language. http://stackoverflow.com/questions/119123/why-isnt-sizeof-for-a-struct-equal-to-the-sum-of-sizeof-of-each-member

If anyone has better ideas for improving this test, let me know. I was considering something fancy with `__attribute__(packed)` (see here: http://stackoverflow.com/questions/7957363/effects-of-attribute-packed-on-nested-array-of-structures) but I decided it wasn't worth it, since it felt like I was writing tests for C++/gcc rather than ROS.

This kind of thing is important to consider for when we start addressing the entire ROS 2 stack on some of our target 32-bit platforms (e.g. STM32).

this whole thing reminds me that I need to address `has_bounded_size` (the pull request I abandoned way back in July) and figure out a way to implement bounded strings as specified in IDL as bounded in memory.