### PR TITLE
Fix CMAKE_CXX_FLAGS usage

### DIFF
--- a/rosidl_generator_cpp/CMakeLists.txt
+++ b/rosidl_generator_cpp/CMakeLists.txt
@@ -2,10 +2,6 @@ cmake_minimum_required(VERSION 2.8.3)
 
 project(rosidl_generator_cpp)
 
-if(NOT WIN32)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
-endif()
-
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 

--- a/rosidl_typesupport_introspection_cpp/cmake/rosidl_typesupport_introspection_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_introspection_cpp/cmake/rosidl_typesupport_introspection_cpp_generate_interfaces.cmake
@@ -85,6 +85,10 @@ if(WIN32)
   target_compile_definitions(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     PRIVATE "ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_BUILDING_DLL")
 endif()
+if(NOT WIN32)
+  set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    PROPERTIES COMPILE_FLAGS "-std=c++11 -Wall -Wextra")
+endif()
 target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   PUBLIC
   ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp


### PR DESCRIPTION
rosidl_generator_py was not building due to missing --std=c++11

```
[ 13%] /usr/bin/c++   -Drosidl_generator_py__rosidl_typesupport_introspection_cpp_EXPORTS -fPIC -I/root/ros2_ws/build/rosidl_generator_py/rosidl_generator_cpp -I/root/ros2_ws/install/include -I/root/ros2_ws/install/include/rosidl_typesupport_introspection_cpp/impl    -o CMakeFiles/rosidl_generator_py__rosidl_typesupport_introspection_cpp.dir/rosidl_typesupport_introspection_cpp/rosidl_generator_py/msg/constants__type_support.cpp.o -c /root/ros2_ws/build/rosidl_generator_py/rosidl_typesupport_introspection_cpp/rosidl_generator_py/msg/constants__type_support.cpp
Built target rosidl_generator_py__rosidl_typesupport_introspection_c
In file included from /usr/include/c++/4.8/array:35:0,
                 from /root/ros2_ws/build/rosidl_generator_py/rosidl_generator_cpp/rosidl_generator_py/msg/empty__struct.hpp:7,
                 from /root/ros2_ws/build/rosidl_generator_py/rosidl_typesupport_introspection_cpp/rosidl_generator_py/msg/empty__type_support.cpp:14:
/usr/include/c++/4.8/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2011 standard. This support is currently experimental, and must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
 #error This file requires compiler and library support for the \
  ^
In file included from /usr/include/c++/4.8/array:35:0,
                 from /root/ros2_ws/build/rosidl_generator_py/rosidl_generator_cpp/rosidl_generator_py/msg/bool__struct.hpp:7,
                 from /root/ros2_ws/build/rosidl_generator_py/rosidl_typesupport_introspection_cpp/rosidl_generator_py/msg/bool__type_support.cpp:14:
/usr/include/c++/4.8/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2011 standard. This support is currently experimental, and must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
 #error This file requires compiler and library support for the \
  ^
```

And when I was comparing to `rosidl_generator_cpp` I noticed the duplicate code. 