### PR TITLE
Share enums for fields with rosidl_typesupport_introspection_c

### DIFF
--- a/rosidl_typesupport_introspection_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_introspection_cpp/CMakeLists.txt
@@ -8,10 +8,13 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
+find_package(rosidl_typesupport_introspection_c REQUIRED)
 
 ament_export_dependencies(rosidl_cmake)
 ament_export_dependencies(rosidl_generator_c)
 ament_export_dependencies(rosidl_generator_cpp)
+ament_export_dependencies(rosidl_typesupport_introspection_c)
+
 # The reason the impl folder is exported is that it contains the
 # implementation for the get_*_type_support_handle functions and defines the
 # rosidl_typesupport_introspection_cpp specific version of these functions.

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/field_types.hpp
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/field_types.hpp
@@ -15,27 +15,29 @@
 #ifndef ROSIDL_TYPESUPPORT_INTROSPECTION_CPP__FIELD_TYPES_HPP_
 #define ROSIDL_TYPESUPPORT_INTROSPECTION_CPP__FIELD_TYPES_HPP_
 
+#include <rosidl_typesupport_introspection_c/field_types.h>
 #include <cstdint>
 
 namespace rosidl_typesupport_introspection_cpp
 {
 
-const uint8_t ROS_TYPE_BOOL = 1;
-const uint8_t ROS_TYPE_BYTE = 2;
-const uint8_t ROS_TYPE_CHAR = 3;
-const uint8_t ROS_TYPE_FLOAT32 = 4;
-const uint8_t ROS_TYPE_FLOAT64 = 5;
-const uint8_t ROS_TYPE_INT8 = 6;
-const uint8_t ROS_TYPE_UINT8 = 7;
-const uint8_t ROS_TYPE_INT16 = 8;
-const uint8_t ROS_TYPE_UINT16 = 9;
-const uint8_t ROS_TYPE_INT32 = 10;
-const uint8_t ROS_TYPE_UINT32 = 11;
-const uint8_t ROS_TYPE_INT64 = 12;
-const uint8_t ROS_TYPE_UINT64 = 13;
-const uint8_t ROS_TYPE_STRING = 14;
 
-const uint8_t ROS_TYPE_MESSAGE = 15;
+const uint8_t ROS_TYPE_BOOL = rosidl_typesupport_introspection_c__ROS_TYPE_BOOL;
+const uint8_t ROS_TYPE_BYTE = rosidl_typesupport_introspection_c__ROS_TYPE_BYTE;
+const uint8_t ROS_TYPE_CHAR = rosidl_typesupport_introspection_c__ROS_TYPE_CHAR;
+const uint8_t ROS_TYPE_FLOAT32 = rosidl_typesupport_introspection_c__ROS_TYPE_FLOAT32;
+const uint8_t ROS_TYPE_FLOAT64 = rosidl_typesupport_introspection_c__ROS_TYPE_FLOAT64;
+const uint8_t ROS_TYPE_INT8 = rosidl_typesupport_introspection_c__ROS_TYPE_INT8;
+const uint8_t ROS_TYPE_UINT8 = rosidl_typesupport_introspection_c__ROS_TYPE_UINT8;
+const uint8_t ROS_TYPE_INT16 = rosidl_typesupport_introspection_c__ROS_TYPE_INT16;
+const uint8_t ROS_TYPE_UINT16 = rosidl_typesupport_introspection_c__ROS_TYPE_UINT16;
+const uint8_t ROS_TYPE_INT32 = rosidl_typesupport_introspection_c__ROS_TYPE_INT32;
+const uint8_t ROS_TYPE_UINT32 = rosidl_typesupport_introspection_c__ROS_TYPE_UINT32;
+const uint8_t ROS_TYPE_INT64 = rosidl_typesupport_introspection_c__ROS_TYPE_INT64;
+const uint8_t ROS_TYPE_UINT64 = rosidl_typesupport_introspection_c__ROS_TYPE_UINT64;
+const uint8_t ROS_TYPE_STRING = rosidl_typesupport_introspection_c__ROS_TYPE_STRING;
+
+const uint8_t ROS_TYPE_MESSAGE = rosidl_typesupport_introspection_c__ROS_TYPE_MESSAGE;
 
 }  // namespace rosidl_typesupport_introspection_cpp
 

--- a/rosidl_typesupport_introspection_cpp/package.xml
+++ b/rosidl_typesupport_introspection_cpp/package.xml
@@ -13,10 +13,13 @@
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
 
+  <build_depend>rosidl_typesupport_introspection_c</build_depend>
+
   <exec_depend>rosidl_cmake</exec_depend>
   <exec_depend>rosidl_generator_c</exec_depend>
   <exec_depend>rosidl_generator_cpp</exec_depend>
   <exec_depend>rosidl_parser</exec_depend>
+  <exec_depend>rosidl_typesupport_introspection_c</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
As discussed in ros2/rmw_connext#133

These enum types should be shared between introspection_c and introspection_cpp to simplify supporting both C and C++ typesupport in an rmw implementation.

Currently, sharing these enums works because the fields happen to have the same underlying int values.

However, if the definitions are reordered in some way (the int values are changed) in one package, code paths shared for C and C++ introspection will stop work.

This PR creates a dependency of introspection_cpp on introspection_c so that it can directly map its field definitions to introspection_c's field enums.