### PR TITLE
Fail in rosidl_generator_py if no typesupport implementations found

### DIFF
--- a/rosidl_generator_py/CMakeLists.txt
+++ b/rosidl_generator_py/CMakeLists.txt
@@ -40,32 +40,43 @@ if(AMENT_ENABLE_TESTING)
   )
 
   include(cmake/register_py.cmake)
+  include(cmake/rosidl_generator_py_get_typesupports.cmake)
+
   set(rosidl_generator_py_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
+  # Need to call extras before get_typesupports, to register the extension
   rosidl_generator_py_extras(
     "${CMAKE_CURRENT_SOURCE_DIR}/bin/rosidl_generator_py"
     "${CMAKE_CURRENT_SOURCE_DIR}/rosidl_generator_py/__init__.py"
     "${CMAKE_CURRENT_SOURCE_DIR}/resource"
   )
 
-  rosidl_generate_interfaces(${PROJECT_NAME} ${message_files}
-    SKIP_INSTALL
-  )
+  # If no message files were generated, skip the test.
+  rosidl_generator_py_get_typesupports(_typesupport_impls)
+  if("${_typesupport_impls} " STREQUAL " ")
+    message(WARNING "No valid typesupport found for Python generator, skipping tests.")
+  else()
+    rosidl_generate_interfaces(${PROJECT_NAME} ${message_files}
+      SKIP_INSTALL
+    )
 
-  set(_append_library_dirs "")
-  if(WIN32)
-    set(_append_library_dirs "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIGURATION>")
+    set(_append_library_dirs "")
+    if(WIN32)
+      set(_append_library_dirs "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIGURATION>")
+    endif()
+
+    ament_add_nose_test(test_interfaces_py "test/test_interfaces.py"
+      APPEND_ENV PYTHONPATH="${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_py:${CMAKE_CURRENT_SOURCE_DIR}"
+      APPEND_LIBRARY_DIRS "${_append_library_dirs}"
+      WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_py"
+    )
   endif()
-
-  ament_add_nose_test(test_interfaces_py "test/test_interfaces.py"
-    APPEND_ENV PYTHONPATH="${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_py:${CMAKE_CURRENT_SOURCE_DIR}"
-    APPEND_LIBRARY_DIRS "${_append_library_dirs}"
-    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_py"
-  )
 endif()
 
 ament_package(
-  CONFIG_EXTRAS "cmake/register_py.cmake" "rosidl_generator_py-extras.cmake.in"
+  CONFIG_EXTRAS "cmake/rosidl_generator_py_get_typesupports.cmake"
+    "cmake/register_py.cmake"
+    "rosidl_generator_py-extras.cmake.in"
 )
 
 install(

--- a/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
@@ -26,24 +26,12 @@ find_package(PythonExtra MODULE)
 # TODO(esteve): force opensplice and connext C type supports only, uncomment
 # the following line when all typesupport implementations are ported to C
 #get_rmw_typesupport(_typesupport_impls ${rmw_implementation})
-set(_typesupport_impls "")
-foreach(_extension IN LISTS AMENT_EXTENSIONS_rosidl_generate_interfaces)
-  string(REPLACE ":" ";" _extension_list "${_extension}")
-  list(LENGTH _extension_list _length)
-  if(NOT _length EQUAL 2)
-    message(FATAL_ERROR "ament_execute_extensions(${extension_point}) "
-      "registered extension '${_extension}' can not be split into package "
-      "name and cmake filename")
-  endif()
-  list(GET _extension_list 0 _pkg_name)
-  list(GET _extension_list 1 _cmake_filename)
-  if("${_pkg_name} " STREQUAL "rosidl_typesupport_opensplice_c ")
-    list(APPEND _typesupport_impls "rosidl_typesupport_opensplice_c")
-  endif()
-  if("${_pkg_name} " STREQUAL "rosidl_typesupport_connext_c ")
-    list(APPEND _typesupport_impls "rosidl_typesupport_connext_c")
-  endif()
-endforeach()
+rosidl_generator_py_get_typesupports(_typesupport_impls)
+
+if("${_typesupport_impls} " STREQUAL " ")
+  message(WARNING "No valid typesupport for Python generator. Python messages will not be generated.")
+  return()
+endif()
 
 set(_output_path
   "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_py/${PROJECT_NAME}")

--- a/rosidl_generator_py/cmake/rosidl_generator_py_get_typesupports.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_get_typesupports.cmake
@@ -1,0 +1,34 @@
+# Copyright 2016 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+macro(rosidl_generator_py_get_typesupports TYPESUPPORT_IMPLS)
+  set(${TYPESUPPORT_IMPLS} "")
+  foreach(_extension IN LISTS AMENT_EXTENSIONS_rosidl_generate_interfaces)
+    string(REPLACE ":" ";" _extension_list "${_extension}")
+    list(LENGTH _extension_list _length)
+    if(NOT _length EQUAL 2)
+      message(FATAL_ERROR "ament_execute_extensions(${extension_point}) "
+        "registered extension '${_extension}' can not be split into package "
+        "name and cmake filename")
+    endif()
+    list(GET _extension_list 0 _pkg_name)
+    list(GET _extension_list 1 _cmake_filename)
+    if("${_pkg_name} " STREQUAL "rosidl_typesupport_opensplice_c ")
+      list(APPEND ${TYPESUPPORT_IMPLS} "rosidl_typesupport_opensplice_c")
+    endif()
+    if("${_pkg_name} " STREQUAL "rosidl_typesupport_connext_c ")
+      list(APPEND ${TYPESUPPORT_IMPLS} "rosidl_typesupport_connext_c")
+    endif()
+  endforeach()
+endmacro()


### PR DESCRIPTION
Fixes #99
this is possibly a fix for python messages appearing to fail to build in ros2/common_interfaces#11