### PR TITLE
Generate service header including request and response message

### DIFF
--- a/rosidl_generator_c/cmake/rosidl_generator_c_generate_interfaces.cmake
+++ b/rosidl_generator_c/cmake/rosidl_generator_c_generate_interfaces.cmake
@@ -49,8 +49,9 @@ foreach(_idl_file ${rosidl_generate_interfaces_c_IDL_FILES})
       )
     endif()
   elseif("${_extension} " STREQUAL ".srv ")
-    # no generated code for services
-    # only for the request / response messages
+    list(APPEND _generated_srv_headers
+      "${_output_path}/${_parent_folder}/${_header_name}.h"
+    )
   else()
     list(REMOVE_ITEM rosidl_generate_interfaces_c_IDL_FILES ${_idl_file})
   endif()
@@ -78,6 +79,7 @@ set(target_dependencies
   "${rosidl_generator_c_TEMPLATE_DIR}/msg__functions.h.template"
   "${rosidl_generator_c_TEMPLATE_DIR}/msg__struct.h.template"
   "${rosidl_generator_c_TEMPLATE_DIR}/msg__type_support.h.template"
+  "${rosidl_generator_c_TEMPLATE_DIR}/srv.h.template"
   ${rosidl_generate_interfaces_c_IDL_FILES}
   ${_dependency_files})
 foreach(dep ${target_dependencies})
@@ -114,6 +116,7 @@ configure_file(
   "${_visibility_control_file}"
   @ONLY
 )
+
 list(APPEND _generated_msg_headers "${_visibility_control_file}")
 
 set(_target_suffix "__rosidl_generator_c")

--- a/rosidl_generator_c/resource/srv.h.template
+++ b/rosidl_generator_c/resource/srv.h.template
@@ -1,0 +1,47 @@
+// generated from rosidl_generator_c/resource/srv.h.template
+// generated code does not contain a copyright notice
+
+@#######################################################################
+@# EmPy template for generating <srv>-c.h files
+@#
+@# Context:
+@#  - spec (rosidl_parser.ServiceSpecification)
+@#    Parsed specification of the .srv file
+@#  - get_header_filename_from_srv_name (function)
+@#######################################################################
+@
+@{
+header_guard_parts = [
+    spec.pkg_name, 'srv',
+    get_header_filename_from_msg_name(spec.srv_name) + '_h']
+header_guard_variable = '__'.join([x.upper() for x in header_guard_parts]) + '_'
+pkg = spec.pkg_name
+}@
+#ifndef @(header_guard_variable)
+#define @(header_guard_variable)
+
+#include "@(spec.pkg_name)/srv/@(get_header_filename_from_msg_name(spec.srv_name))__request.h"
+#include "@(spec.pkg_name)/srv/@(get_header_filename_from_msg_name(spec.srv_name))__response.h"
+
+// This header is provided by the rmw implementation specific type support
+// package, and defines macros which expand to get type support functions.
+#include "rosidl_generator_c/message_type_support.h"
+
+// This header provides a definition for the rosidl_service_type_support_t struct.
+#include "rosidl_generator_c/service_type_support.h"
+
+#if defined(__cplusplus)
+extern "C"
+{
+#endif
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_@(spec.pkg_name)
+const rosidl_service_type_support_t *
+ROSIDL_GET_TYPE_SUPPORT_FUNCTION(@(spec.pkg_name), srv, @(spec.srv_name))();
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif  // @(header_guard_variable)

--- a/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/impl/rosidl_generator_c/message_type_support.h
+++ b/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/impl/rosidl_generator_c/message_type_support.h
@@ -26,8 +26,8 @@
  * which defines a given message will provide the symbol to which this macro
  * expands.
  *
- * These macros also generate OpenSplice specific symbols so they only match
- * the OpenSplice shared library symbols.
+ * These macros also generate introspection-specific symbols so they only match
+ * the introspection C shared library symbols.
  */
 #define ROSIDL_GET_MSG_TYPE_SUPPORT(PkgName, MsgName) \
   ROSIDL_GET_TYPE_SUPPORT(PkgName, msg, MsgName)

--- a/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/service_introspection.h
+++ b/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/service_introspection.h
@@ -23,7 +23,7 @@
 
 #include "rosidl_typesupport_introspection_c/message_introspection.h"
 
-typedef struct ROSIDL_PUBLIC rosidl_typesupport_introspection_c__ServiceMembers
+typedef struct ROSIDL_PUBLIC_TYPE rosidl_typesupport_introspection_c__ServiceMembers
 {
   const char * package_name_;
   const char * service_name_;

--- a/rosidl_typesupport_introspection_c/resource/msg__introspection_type_support.h.template
+++ b/rosidl_typesupport_introspection_c/resource/msg__introspection_type_support.h.template
@@ -27,6 +27,8 @@ function_prefix = '%s__%s__rosidl_typesupport_introspection_c' % (spec.base_type
 
 #include "@(spec.base_type.pkg_name)/msg/rosidl_typesupport_introspection_c__visibility_control.h"
 
+@[if subfolder == 'msg']@
 static rosidl_message_type_support_t @(function_prefix)__@(spec.base_type.type)_message_type_support_handle;
+@[end if]@
 
 #endif  // @(header_guard_variable)

--- a/rosidl_typesupport_introspection_c/resource/msg__type_support.c.template
+++ b/rosidl_typesupport_introspection_c/resource/msg__type_support.c.template
@@ -199,7 +199,7 @@ static rosidl_message_type_support_t @(function_prefix)__@(spec.base_type.type)_
 
 ROSIDL_TYPESUPPORT_INTROSPECTION_C_EXPORT_@(spec.base_type.pkg_name)
 const rosidl_message_type_support_t *
-ROSIDL_GET_TYPE_SUPPORT_FUNCTION(@(spec.base_type.pkg_name), msg, @(spec.msg_name))()
+ROSIDL_GET_TYPE_SUPPORT_FUNCTION(@(spec.base_type.pkg_name), @(subfolder), @(spec.msg_name))()
 {
   if (!@(function_prefix)__@(spec.base_type.type)_message_type_support_handle.typesupport_identifier) {
     @(function_prefix)__@(spec.base_type.type)_message_type_support_handle.typesupport_identifier =

--- a/rosidl_typesupport_introspection_c/resource/srv__introspection_type_support.h.template
+++ b/rosidl_typesupport_introspection_c/resource/srv__introspection_type_support.h.template
@@ -1,0 +1,29 @@
+// generated from rosidl_typesupport_introspection_c/resource/srv__introspection_type_support.h.template
+
+@#######################################################################
+@# EmPy template for generating <srv>__introspection_type_support.h files
+@#
+@# Context:
+@#  - spec (rosidl_parser.MessageSpecification)
+@#    Parsed specification of the .srv file
+@#  - get_header_filename_from_msg_name (function)
+@#######################################################################
+@
+@{
+header_guard_parts = [
+    spec.pkg_name, 'srv',
+    get_header_filename_from_msg_name(spec.srv_name) + '__introspection__type_support_h']
+header_guard_variable = '__'.join([x.upper() for x in header_guard_parts]) + '_'
+
+function_prefix = '%s__%s__rosidl_typesupport_introspection_c' % (spec.pkg_name, 'srv')
+}@
+#ifndef @(header_guard_variable)
+#define @(header_guard_variable)
+
+#include <rosidl_generator_c/service_type_support.h>
+
+#include "@(spec.pkg_name)/msg/rosidl_generator_c__visibility_control.h"
+
+static rosidl_service_type_support_t @(function_prefix)__@(spec.srv_name)_service_type_support_handle;
+
+#endif  // @(header_guard_variable)

--- a/rosidl_typesupport_introspection_c/resource/srv__type_support.c.template
+++ b/rosidl_typesupport_introspection_c/resource/srv__type_support.c.template
@@ -22,33 +22,58 @@ function_prefix = '%s__srv__rosidl_typesupport_introspection_c' % spec.pkg_name
 
 #include <rosidl_generator_c/service_type_support.h>
 
+#include "@(spec.pkg_name)/srv/@(get_header_filename_from_msg_name(spec.srv_name))__introspection_type_support.h"
+#include "@(spec.pkg_name)/srv/@(get_header_filename_from_msg_name(spec.request.base_type.type))__introspection_type_support.h"
+#include "@(spec.pkg_name)/srv/@(get_header_filename_from_msg_name(spec.response.base_type.type))__introspection_type_support.h"
+
 #include "rosidl_typesupport_introspection_c/identifier.h"
 #include "rosidl_typesupport_introspection_c/service_introspection.h"
-
-#include "@(spec.pkg_name)/srv/@(get_header_filename_from_msg_name(spec.request.base_type.type))__struct.h"
-#include "@(spec.pkg_name)/srv/@(get_header_filename_from_msg_name(spec.response.base_type.type))__struct.h"
-#include "@(spec.pkg_name)/msg/rosidl_typesupport_introspection_c__visibility_control.h"
 
 // this is intentionally not const to allow initialization later to prevent an initialization race
 static rosidl_typesupport_introspection_c__ServiceMembers @(function_prefix)__@(spec.srv_name)_service_members = {
   "@(spec.pkg_name)",  // package name
   "@(spec.srv_name)",  // service name
   // these two fields are initialized below on the first access
-  // see get_service_type_support_handle_introspection<@(spec.pkg_name)::@(spec.srv_name)>()
   NULL,  // request message
   // @(function_prefix)__@(spec.request.base_type.type)_message_type_support_handle,
   NULL  // response message
   // @(function_prefix)__@(spec.request.base_type.type)_message_type_support_handle
 };
 
-static const rosidl_service_type_support_t @(function_prefix)__@(spec.srv_name)_service_type_support_handle = {
-  rosidl_typesupport_introspection_c__identifier,
+static rosidl_service_type_support_t @(function_prefix)__@(spec.srv_name)_service_type_support_handle = {
+  0,
   &@(function_prefix)__@(spec.srv_name)_service_members
 };
 
+// Forward declaration of request/response type support functions
 const rosidl_service_type_support_t *
-rosidl_get_service_type_support__@(spec.pkg_name)__srv____@(spec.srv_name)()
+ROSIDL_GET_TYPE_SUPPORT_FUNCTION(@(spec.pkg_name), srv, @(spec.srv_name)_Request)();
+
+const rosidl_service_type_support_t *
+ROSIDL_GET_TYPE_SUPPORT_FUNCTION(@(spec.pkg_name), srv, @(spec.srv_name)_Response)();
+
+ROSIDL_TYPESUPPORT_INTROSPECTION_C_EXPORT_@(spec.pkg_name)
+const rosidl_service_type_support_t *
+ROSIDL_GET_TYPE_SUPPORT_FUNCTION(@(spec.pkg_name), srv, @(spec.srv_name))()
 {
+  if (!@(function_prefix)__@(spec.srv_name)_service_type_support_handle.typesupport_identifier) {
+    @(function_prefix)__@(spec.srv_name)_service_type_support_handle.typesupport_identifier =
+      rosidl_typesupport_introspection_c__identifier;
+  }
+  rosidl_typesupport_introspection_c__ServiceMembers * service_members =
+    (rosidl_typesupport_introspection_c__ServiceMembers *)@(function_prefix)__@(spec.srv_name)_service_type_support_handle.data;
+
+  if (!service_members->request_members_) {
+    service_members->request_members_ =
+      (const rosidl_typesupport_introspection_c__MessageMembers *)
+        ROSIDL_GET_TYPE_SUPPORT_FUNCTION(@(spec.pkg_name), srv, @(spec.srv_name)_Request)()->data;
+  }
+  if (!service_members->response_members_) {
+    service_members->response_members_ =
+      (const rosidl_typesupport_introspection_c__MessageMembers *)
+        ROSIDL_GET_TYPE_SUPPORT_FUNCTION(@(spec.pkg_name), srv, @(spec.srv_name)_Response)()->data;
+  }
+
   return &@(function_prefix)__@(spec.srv_name)_service_type_support_handle;
 }
 

--- a/rosidl_typesupport_introspection_c/rosidl_typesupport_introspection_c/__init__.py
+++ b/rosidl_typesupport_introspection_c/rosidl_typesupport_introspection_c/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2015 Open Source Robotics Foundation, Inc.
+# Copyright 2014-2016 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,12 +29,14 @@ def generate_c(generator_arguments_file):
 
     template_dir = args['template_dir']
     mapping_msgs = {
-        os.path.join(template_dir, 'msg__type_support.c.template'):
-        '%s__type_support.c',
         os.path.join(template_dir, 'msg__introspection_type_support.h.template'):
         '%s__introspection_type_support.h',
+        os.path.join(template_dir, 'msg__type_support.c.template'):
+        '%s__type_support.c',
     }
     mapping_srvs = {
+        os.path.join(template_dir, 'srv__introspection_type_support.h.template'):
+        '%s__introspection_type_support.h',
         os.path.join(template_dir, 'srv__type_support.c.template'):
         '%s__type_support.c',
     }


### PR DESCRIPTION
Connects to ros2/rcl#27

Bit of a bikeshed question, should srv.h be a pass-through header that only includes files, and should there additionally be a srv__type_support header with the ROSIDL_GET_TYPESUPPORT_FUNCTION definition?