### PR TITLE
Fix pyflakes complaining of imported but unused module.

### DIFF
--- a/rosidl_generator_py/rosidl_generator_py/__init__.py
+++ b/rosidl_generator_py/rosidl_generator_py/__init__.py
@@ -21,6 +21,7 @@ __all__ = ['import_type_support']
 
 try:
     from .generate_py_impl import generate_py
+    assert generate_py
     __all__.append('generate_py')
 except ImportError:
     logger = logging.getLogger('rosidl_generator_py')


### PR DESCRIPTION
Fixes the following error:
```
-- run_test.py: invoking following command in '/home/rosbuild/ci_scripts/ws/src/ros2/rosidl/rosidl_generator_py':
 - /home/rosbuild/ci_scripts/ws/install/ament_pyflakes/bin/ament_pyflakes --xunit-file /home/rosbuild/ci_scripts/ws/build/rosidl_generator_py/test_results/rosidl_generator_py/pyflakes.xunit.xml
rosidl_generator_py/__init__.py:23: 'generate_py' imported but unused
1 errors
rosidl_generator_py/__init__.py

rosidl_generator_py/generate_py_impl.py

rosidl_generator_py/import_type_support_impl.py

test/test_interfaces.py

-- run_test.py: return code 1
-- run_test.py: verify result file '/home/rosbuild/ci_scripts/ws/build/rosidl_generator_py/test_results/rosidl_generator_py/pyflakes.xunit.xml'
```