### PR TITLE
replace assert with minimal macro exiting

### DIFF
--- a/rosidl_generator_c/test/test_interfaces.c
+++ b/rosidl_generator_c/test/test_interfaces.c
@@ -77,6 +77,8 @@
 
 #define ARRAY_SIZE 7
 
+#define EXPECT_TRUE(expr) if (!(expr)) exit(1)
+
 void test_primitives(void);
 void test_primitives_default_value(void);
 void test_strings(void);
@@ -126,86 +128,86 @@ void test_primitives(void)
   rosidl_generator_c__msg__Uint64 uint64_msg;
 
   bool_msg.empty_bool = true;
-  assert(bool_msg.empty_bool == true);
+  EXPECT_TRUE(bool_msg.empty_bool == true);
 
   bool_msg.empty_bool = false;
-  assert(bool_msg.empty_bool == false);
+  EXPECT_TRUE(bool_msg.empty_bool == false);
 
   byte_msg.empty_byte = 0;
-  assert(byte_msg.empty_byte == 0);
+  EXPECT_TRUE(byte_msg.empty_byte == 0);
 
   byte_msg.empty_byte = 255;
-  assert(byte_msg.empty_byte == 255);
+  EXPECT_TRUE(byte_msg.empty_byte == 255);
 
-  assert(rosidl_generator_c__msg__Constants__X == 123);
-  assert(rosidl_generator_c__msg__Constants__Y == -123);
-  assert(strncmp(rosidl_generator_c__msg__Constants__FOO, "foo", 3) == 0);
+  EXPECT_TRUE(rosidl_generator_c__msg__Constants__X == 123);
+  EXPECT_TRUE(rosidl_generator_c__msg__Constants__Y == -123);
+  EXPECT_TRUE(strncmp(rosidl_generator_c__msg__Constants__FOO, "foo", 3) == 0);
 
   char_msg.empty_char = CHAR_MIN;
-  assert(char_msg.empty_char == CHAR_MIN);
+  EXPECT_TRUE(char_msg.empty_char == CHAR_MIN);
 
   char_msg.empty_char = CHAR_MAX;
-  assert(char_msg.empty_char == CHAR_MAX);
+  EXPECT_TRUE(char_msg.empty_char == CHAR_MAX);
 
   float32_msg.empty_float32 = FLT_MIN;
-  assert(float32_msg.empty_float32 == FLT_MIN);
+  EXPECT_TRUE(float32_msg.empty_float32 == FLT_MIN);
 
   float32_msg.empty_float32 = FLT_MAX;
-  assert(float32_msg.empty_float32 == FLT_MAX);
+  EXPECT_TRUE(float32_msg.empty_float32 == FLT_MAX);
 
   float64_msg.empty_float64 = DBL_MIN;
-  assert(float64_msg.empty_float64 == DBL_MIN);
+  EXPECT_TRUE(float64_msg.empty_float64 == DBL_MIN);
 
   float64_msg.empty_float64 = DBL_MAX;
-  assert(float64_msg.empty_float64 == DBL_MAX);
+  EXPECT_TRUE(float64_msg.empty_float64 == DBL_MAX);
 
   int8_msg.empty_int8 = INT8_MIN;
-  assert(int8_msg.empty_int8 == INT8_MIN);
+  EXPECT_TRUE(int8_msg.empty_int8 == INT8_MIN);
 
   int8_msg.empty_int8 = INT8_MAX;
-  assert(int8_msg.empty_int8 == INT8_MAX);
+  EXPECT_TRUE(int8_msg.empty_int8 == INT8_MAX);
 
   int16_msg.empty_int16 = INT16_MIN;
-  assert(int16_msg.empty_int16 == INT16_MIN);
+  EXPECT_TRUE(int16_msg.empty_int16 == INT16_MIN);
 
   int16_msg.empty_int16 = INT16_MAX;
-  assert(int16_msg.empty_int16 == INT16_MAX);
+  EXPECT_TRUE(int16_msg.empty_int16 == INT16_MAX);
 
   int32_msg.empty_int32 = INT32_MIN;
-  assert(int32_msg.empty_int32 == INT32_MIN);
+  EXPECT_TRUE(int32_msg.empty_int32 == INT32_MIN);
 
   int32_msg.empty_int32 = INT32_MAX;
-  assert(int32_msg.empty_int32 == INT32_MAX);
+  EXPECT_TRUE(int32_msg.empty_int32 == INT32_MAX);
 
   int64_msg.empty_int64 = INT64_MIN;
-  assert(int64_msg.empty_int64 == INT64_MIN);
+  EXPECT_TRUE(int64_msg.empty_int64 == INT64_MIN);
 
   int64_msg.empty_int64 = INT64_MAX;
-  assert(int64_msg.empty_int64 == INT64_MAX);
+  EXPECT_TRUE(int64_msg.empty_int64 == INT64_MAX);
 
   uint8_msg.empty_uint8 = 0;
-  assert(uint8_msg.empty_uint8 == 0);
+  EXPECT_TRUE(uint8_msg.empty_uint8 == 0);
 
   uint8_msg.empty_uint8 = UINT8_MAX;
-  assert(uint8_msg.empty_uint8 == UINT8_MAX);
+  EXPECT_TRUE(uint8_msg.empty_uint8 == UINT8_MAX);
 
   uint16_msg.empty_uint16 = 0;
-  assert(uint16_msg.empty_uint16 == 0);
+  EXPECT_TRUE(uint16_msg.empty_uint16 == 0);
 
   uint16_msg.empty_uint16 = UINT16_MAX;
-  assert(uint16_msg.empty_uint16 == UINT16_MAX);
+  EXPECT_TRUE(uint16_msg.empty_uint16 == UINT16_MAX);
 
   uint32_msg.empty_uint32 = 0;
-  assert(uint32_msg.empty_uint32 == 0);
+  EXPECT_TRUE(uint32_msg.empty_uint32 == 0);
 
   uint32_msg.empty_uint32 = UINT32_MAX;
-  assert(uint32_msg.empty_uint32 == UINT32_MAX);
+  EXPECT_TRUE(uint32_msg.empty_uint32 == UINT32_MAX);
 
   uint64_msg.empty_uint64 = 0;
-  assert(uint64_msg.empty_uint64 == 0);
+  EXPECT_TRUE(uint64_msg.empty_uint64 == 0);
 
   uint64_msg.empty_uint64 = UINT64_MAX;
-  assert(uint64_msg.empty_uint64 == UINT64_MAX);
+  EXPECT_TRUE(uint64_msg.empty_uint64 == UINT64_MAX);
 }
 
 /**
@@ -217,22 +219,22 @@ void test_primitives_default_value(void)
 
   primitive_values = rosidl_generator_c__msg__PrimitiveValues__create();
 
-  assert(primitive_values != NULL);
+  EXPECT_TRUE(primitive_values != NULL);
 
-  assert(true == primitive_values->def_bool_1);
-  assert(false == primitive_values->def_bool_2);
-  assert(66 == primitive_values->def_byte);
-  assert(-66 == primitive_values->def_char);
-  assert(3.1416f == primitive_values->def_float32);
-  assert(3.14159265 == primitive_values->def_float64);
-  assert(3 == primitive_values->def_int8);
-  assert(6 == primitive_values->def_int16);
-  assert(10 == primitive_values->def_int32);
-  assert(15 == primitive_values->def_int64);
-  assert(33 == primitive_values->def_uint8);
-  assert(36 == primitive_values->def_uint16);
-  assert(310 == primitive_values->def_uint32);
-  assert(315 == primitive_values->def_uint64);
+  EXPECT_TRUE(true == primitive_values->def_bool_1);
+  EXPECT_TRUE(false == primitive_values->def_bool_2);
+  EXPECT_TRUE(66 == primitive_values->def_byte);
+  EXPECT_TRUE(-66 == primitive_values->def_char);
+  EXPECT_TRUE(3.1416f == primitive_values->def_float32);
+  EXPECT_TRUE(3.14159265 == primitive_values->def_float64);
+  EXPECT_TRUE(3 == primitive_values->def_int8);
+  EXPECT_TRUE(6 == primitive_values->def_int16);
+  EXPECT_TRUE(10 == primitive_values->def_int32);
+  EXPECT_TRUE(15 == primitive_values->def_int64);
+  EXPECT_TRUE(33 == primitive_values->def_uint8);
+  EXPECT_TRUE(36 == primitive_values->def_uint16);
+  EXPECT_TRUE(310 == primitive_values->def_uint32);
+  EXPECT_TRUE(315 == primitive_values->def_uint64);
 
   rosidl_generator_c__msg__PrimitiveValues__destroy(primitive_values);
 }
@@ -246,17 +248,17 @@ void test_strings(void)
   rosidl_generator_c__msg__Strings * strings = NULL;
 
   strings = rosidl_generator_c__msg__Strings__create();
-  assert(strings != NULL);
+  EXPECT_TRUE(strings != NULL);
 
   res = rosidl_generator_c__String__assign(&strings->empty_string, TEST_STRING);
-  assert(true == res);
-  assert(0 == strcmp(strings->empty_string.data, TEST_STRING));
-  assert(0 == strcmp(strings->def_string.data, "Hello world!"));
+  EXPECT_TRUE(true == res);
+  EXPECT_TRUE(0 == strcmp(strings->empty_string.data, TEST_STRING));
+  EXPECT_TRUE(0 == strcmp(strings->def_string.data, "Hello world!"));
   // since upper-bound checking is not implemented yet, we restrict the string copying
   res = rosidl_generator_c__String__assignn(&strings->ub_string, TEST_STRING, 22);
-  assert(true == res);
-  assert(0 == strcmp(strings->ub_string.data, "Deep into that darknes"));
-  assert(0 == strcmp(strings->ub_def_string.data, "Upper bounded string."));
+  EXPECT_TRUE(true == res);
+  EXPECT_TRUE(0 == strcmp(strings->ub_string.data, "Deep into that darknes"));
+  EXPECT_TRUE(0 == strcmp(strings->ub_def_string.data, "Upper bounded string."));
 
   rosidl_generator_c__msg__Strings__destroy(strings);
 }
@@ -271,11 +273,11 @@ void test_primitives_unbounded_arrays(void)
   rosidl_generator_c__msg__PrimitivesUnboundedArrays * arrays = NULL;
 
   arrays = rosidl_generator_c__msg__PrimitivesUnboundedArrays__create();
-  assert(NULL != arrays);
+  EXPECT_TRUE(NULL != arrays);
 
   // bool_array
   res = rosidl_generator_c__bool__Array__init(&arrays->bool_array, ARRAY_SIZE);
-  assert(true == res);
+  EXPECT_TRUE(true == res);
   // load values
   for (i = 0; i < ARRAY_SIZE; i++) {
     if (0 == (i % 2)) {
@@ -287,40 +289,40 @@ void test_primitives_unbounded_arrays(void)
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
     if (0 == (i % 2)) {
-      assert(true == arrays->bool_array.data[i]);
+      EXPECT_TRUE(true == arrays->bool_array.data[i]);
     } else {
-      assert(false == arrays->bool_array.data[i]);
+      EXPECT_TRUE(false == arrays->bool_array.data[i]);
     }
   }
 
   // byte_array
   res = rosidl_generator_c__byte__Array__init(&arrays->byte_array, ARRAY_SIZE);
-  assert(true == res);
+  EXPECT_TRUE(true == res);
   uint8_t test_array_byte[7] = {0, 57, 110, 177, 201, 240, 255};
   for (i = 0; i < ARRAY_SIZE; i++) {
     arrays->byte_array.data[i] = test_array_byte[i];
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_byte[i] == arrays->byte_array.data[i]);
+    EXPECT_TRUE(test_array_byte[i] == arrays->byte_array.data[i]);
   }
 
 
   // char array
   res = rosidl_generator_c__char__Array__init(&arrays->char_array, ARRAY_SIZE);
-  assert(true == res);
+  EXPECT_TRUE(true == res);
   char test_array_char[7] = {'a', '5', '#', 'Z', '@', '-', ' '};
   for (i = 0; i < ARRAY_SIZE; i++) {
     arrays->char_array.data[i] = test_array_char[i];
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_char[i] == arrays->char_array.data[i]);
+    EXPECT_TRUE(test_array_char[i] == arrays->char_array.data[i]);
   }
 
   // float32 array
   res = rosidl_generator_c__float32__Array__init(&arrays->float32_array, ARRAY_SIZE);
-  assert(true == res);
+  EXPECT_TRUE(true == res);
   float test_array_float32[7] =
   {-3.000001f, 22143.541325f, 6331.00432f, -214.66241f, 0.000001f, 1415555.12345f,
    -1.11154f};
@@ -329,12 +331,12 @@ void test_primitives_unbounded_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_float32[i] == arrays->float32_array.data[i]);
+    EXPECT_TRUE(test_array_float32[i] == arrays->float32_array.data[i]);
   }
 
   // float64 array
   res = rosidl_generator_c__float64__Array__init(&arrays->float64_array, ARRAY_SIZE);
-  assert(true == res);
+  EXPECT_TRUE(true == res);
   double test_array_float64[7] =
   {-120310.00843902140001, 22143.54483920141325, 6331.0048392104432,
    -214.62850432596241, 0.0000000000001, 1415555.128294031432345,
@@ -344,24 +346,24 @@ void test_primitives_unbounded_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_float64[i] == arrays->float64_array.data[i]);
+    EXPECT_TRUE(test_array_float64[i] == arrays->float64_array.data[i]);
   }
 
   // int8 array
   res = rosidl_generator_c__int8__Array__init(&arrays->int8_array, ARRAY_SIZE);
-  assert(true == res);
+  EXPECT_TRUE(true == res);
   int8_t test_array_int8[7] = {-127, -55, -30, 0, 58, 100, 127};
   for (i = 0; i < ARRAY_SIZE; i++) {
     arrays->int8_array.data[i] = test_array_int8[i];
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_int8[i] == arrays->int8_array.data[i]);
+    EXPECT_TRUE(test_array_int8[i] == arrays->int8_array.data[i]);
   }
 
   // int16 array
   res = rosidl_generator_c__int16__Array__init(&arrays->int16_array, ARRAY_SIZE);
-  assert(true == res);
+  EXPECT_TRUE(true == res);
   int16_t test_array_int16[7] =
   {-32767, -22222, -11111, 0, 11111, 22222, 32767};
   for (i = 0; i < ARRAY_SIZE; i++) {
@@ -369,12 +371,12 @@ void test_primitives_unbounded_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_int16[i] == arrays->int16_array.data[i]);
+    EXPECT_TRUE(test_array_int16[i] == arrays->int16_array.data[i]);
   }
 
   // int32 array
   res = rosidl_generator_c__int32__Array__init(&arrays->int32_array, ARRAY_SIZE);
-  assert(true == res);
+  EXPECT_TRUE(true == res);
   int32_t test_array_int32[7] =
   {INT32_MIN, INT32_MIN / 2, INT32_MIN / 4, 0L, INT32_MAX / 4, INT32_MAX / 2, INT32_MAX};
   for (i = 0; i < ARRAY_SIZE; i++) {
@@ -382,12 +384,12 @@ void test_primitives_unbounded_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_int32[i] == arrays->int32_array.data[i]);
+    EXPECT_TRUE(test_array_int32[i] == arrays->int32_array.data[i]);
   }
 
   // int64 array
   res = rosidl_generator_c__int64__Array__init(&arrays->int64_array, ARRAY_SIZE);
-  assert(true == res);
+  EXPECT_TRUE(true == res);
   int64_t test_array_int64[7] =
   {-9223372036854775807LL, -5000000000000000000LL, -1111111111111111111LL, 0,
    1111111111111111111LL, 5000000000000000000LL, 9223372036854775807LL};
@@ -396,36 +398,36 @@ void test_primitives_unbounded_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_int64[i] == arrays->int64_array.data[i]);
+    EXPECT_TRUE(test_array_int64[i] == arrays->int64_array.data[i]);
   }
 
   // uint8 array
   res = rosidl_generator_c__uint8__Array__init(&arrays->uint8_array, ARRAY_SIZE);
-  assert(true == res);
+  EXPECT_TRUE(true == res);
   uint8_t test_array_uint8[7] = {0, 5, 70, 128, 180, 220, 255};
   for (i = 0; i < ARRAY_SIZE; i++) {
     arrays->uint8_array.data[i] = test_array_uint8[i];
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_uint8[i] == arrays->uint8_array.data[i]);
+    EXPECT_TRUE(test_array_uint8[i] == arrays->uint8_array.data[i]);
   }
 
   // uint16 array
   res = rosidl_generator_c__uint16__Array__init(&arrays->uint16_array, ARRAY_SIZE);
-  assert(true == res);
+  EXPECT_TRUE(true == res);
   uint16_t test_array_uint16[7] = {0U, 11111U, 22222U, 33333U, 44444U, 55555U, 65535U};
   for (i = 0; i < ARRAY_SIZE; i++) {
     arrays->uint16_array.data[i] = test_array_uint16[i];
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_uint16[i] == arrays->uint16_array.data[i]);
+    EXPECT_TRUE(test_array_uint16[i] == arrays->uint16_array.data[i]);
   }
 
   // uint32 array
   res = rosidl_generator_c__uint32__Array__init(&arrays->uint32_array, ARRAY_SIZE);
-  assert(true == res);
+  EXPECT_TRUE(true == res);
   uint32_t test_array_uint32[7] =
   {0UL, 100UL, 2000UL, 30000UL, 444444UL, 567890123UL, 4294967295UL};
   for (i = 0; i < ARRAY_SIZE; i++) {
@@ -433,12 +435,12 @@ void test_primitives_unbounded_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_uint32[i] == arrays->uint32_array.data[i]);
+    EXPECT_TRUE(test_array_uint32[i] == arrays->uint32_array.data[i]);
   }
 
   // uint64 array
   res = rosidl_generator_c__uint64__Array__init(&arrays->uint64_array, ARRAY_SIZE);
-  assert(true == res);
+  EXPECT_TRUE(true == res);
   uint64_t test_array_uint64[7] =
   {0ULL, 10000ULL, 30000000ULL, 444444444ULL, 567890123456789ULL, 429496729578901234ULL,
    18446744073709551615ULL};
@@ -447,7 +449,7 @@ void test_primitives_unbounded_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_uint64[i] == arrays->uint64_array.data[i]);
+    EXPECT_TRUE(test_array_uint64[i] == arrays->uint64_array.data[i]);
   }
 
   rosidl_generator_c__msg__PrimitivesUnboundedArrays__destroy(arrays);
@@ -463,11 +465,11 @@ void test_primitives_bounded_arrays(void)
   rosidl_generator_c__msg__PrimitivesBoundedArrays * arrays = NULL;
 
   arrays = rosidl_generator_c__msg__PrimitivesBoundedArrays__create();
-  assert(NULL != arrays);
+  EXPECT_TRUE(NULL != arrays);
 
   // bool_array
   res = rosidl_generator_c__bool__Array__init(&arrays->bool_array, ARRAY_SIZE);
-  assert(true == res);
+  EXPECT_TRUE(true == res);
   // load values
   for (i = 0; i < ARRAY_SIZE; i++) {
     if (0 == (i % 2)) {
@@ -479,28 +481,28 @@ void test_primitives_bounded_arrays(void)
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
     if (0 == (i % 2)) {
-      assert(true == arrays->bool_array.data[i]);
+      EXPECT_TRUE(true == arrays->bool_array.data[i]);
     } else {
-      assert(false == arrays->bool_array.data[i]);
+      EXPECT_TRUE(false == arrays->bool_array.data[i]);
     }
   }
 
   // byte_array
   res = rosidl_generator_c__byte__Array__init(&arrays->byte_array, ARRAY_SIZE);
-  assert(true == res);
+  EXPECT_TRUE(true == res);
   uint8_t test_array_byte[8] = {0, 57, 110, 177, 201, 240, 255, 111};
   for (i = 0; i < ARRAY_SIZE; i++) {
     arrays->byte_array.data[i] = test_array_byte[i];
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_byte[i] == arrays->byte_array.data[i]);
+    EXPECT_TRUE(test_array_byte[i] == arrays->byte_array.data[i]);
   }
 
 
   // char array
   res = rosidl_generator_c__char__Array__init(&arrays->char_array, ARRAY_SIZE);
-  assert(true == res);
+  EXPECT_TRUE(true == res);
   char test_array_char[7] = {'a', '5', '#', 'Z', '@', '-', ' '};
   for (i = 0; i < ARRAY_SIZE; i++) {
     arrays->char_array.data[i] = test_array_char[i];
@@ -508,12 +510,12 @@ void test_primitives_bounded_arrays(void)
 
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_char[i] == arrays->char_array.data[i]);
+    EXPECT_TRUE(test_array_char[i] == arrays->char_array.data[i]);
   }
 
   // float32 array
   res = rosidl_generator_c__float32__Array__init(&arrays->float32_array, ARRAY_SIZE);
-  assert(true == res);
+  EXPECT_TRUE(true == res);
   float test_array_float32[7] =
   {-3.000001f, 22143.541325f, 6331.00432f, -214.66241f, 0.000001f, 1415555.12345f,
    -1.11154f};
@@ -522,12 +524,12 @@ void test_primitives_bounded_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_float32[i] == arrays->float32_array.data[i]);
+    EXPECT_TRUE(test_array_float32[i] == arrays->float32_array.data[i]);
   }
 
   // float64 array
   res = rosidl_generator_c__float64__Array__init(&arrays->float64_array, ARRAY_SIZE);
-  assert(true == res);
+  EXPECT_TRUE(true == res);
   double test_array_float64[7] =
   {-120310.00843902140001, 22143.54483920141325, 6331.0048392104432,
    -214.62850432596241, 0.0000000000001, 1415555.128294031432345,
@@ -537,24 +539,24 @@ void test_primitives_bounded_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_float64[i] == arrays->float64_array.data[i]);
+    EXPECT_TRUE(test_array_float64[i] == arrays->float64_array.data[i]);
   }
 
   // int8 array
   res = rosidl_generator_c__int8__Array__init(&arrays->int8_array, ARRAY_SIZE);
-  assert(true == res);
+  EXPECT_TRUE(true == res);
   int8_t test_array_int8[7] = {-127, -55, -30, 0, 58, 100, 127};
   for (i = 0; i < ARRAY_SIZE; i++) {
     arrays->int8_array.data[i] = test_array_int8[i];
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_int8[i] == arrays->int8_array.data[i]);
+    EXPECT_TRUE(test_array_int8[i] == arrays->int8_array.data[i]);
   }
 
   // int16 array
   res = rosidl_generator_c__int16__Array__init(&arrays->int16_array, ARRAY_SIZE);
-  assert(true == res);
+  EXPECT_TRUE(true == res);
   int16_t test_array_int16[7] =
   {-32767, -22222, -11111, 0, 11111, 22222, 32767};
   for (i = 0; i < ARRAY_SIZE; i++) {
@@ -562,12 +564,12 @@ void test_primitives_bounded_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_int16[i] == arrays->int16_array.data[i]);
+    EXPECT_TRUE(test_array_int16[i] == arrays->int16_array.data[i]);
   }
 
   // int32 array
   res = rosidl_generator_c__int32__Array__init(&arrays->int32_array, ARRAY_SIZE);
-  assert(true == res);
+  EXPECT_TRUE(true == res);
   int32_t test_array_int32[7] =
   {INT32_MIN, INT32_MIN / 2, INT32_MIN / 4, 0L, INT32_MAX / 4, INT32_MAX / 2, INT32_MAX};
   for (i = 0; i < ARRAY_SIZE; i++) {
@@ -575,12 +577,12 @@ void test_primitives_bounded_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_int32[i] == arrays->int32_array.data[i]);
+    EXPECT_TRUE(test_array_int32[i] == arrays->int32_array.data[i]);
   }
 
   // int64 array
   res = rosidl_generator_c__int64__Array__init(&arrays->int64_array, ARRAY_SIZE);
-  assert(true == res);
+  EXPECT_TRUE(true == res);
   int64_t test_array_int64[7] =
   {-9223372036854775807LL, -5000000000000000000LL, -1111111111111111111, 0,
    1111111111111111111LL, 5000000000000000000LL, 9223372036854775807LL};
@@ -589,36 +591,36 @@ void test_primitives_bounded_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_int64[i] == arrays->int64_array.data[i]);
+    EXPECT_TRUE(test_array_int64[i] == arrays->int64_array.data[i]);
   }
 
   // uint8 array
   res = rosidl_generator_c__uint8__Array__init(&arrays->uint8_array, ARRAY_SIZE);
-  assert(true == res);
+  EXPECT_TRUE(true == res);
   uint8_t test_array_uint8[7] = {0, 5, 70, 128, 180, 220, 255};
   for (i = 0; i < ARRAY_SIZE; i++) {
     arrays->uint8_array.data[i] = test_array_uint8[i];
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_uint8[i] == arrays->uint8_array.data[i]);
+    EXPECT_TRUE(test_array_uint8[i] == arrays->uint8_array.data[i]);
   }
 
   // uint16 array
   res = rosidl_generator_c__uint16__Array__init(&arrays->uint16_array, ARRAY_SIZE);
-  assert(true == res);
+  EXPECT_TRUE(true == res);
   uint16_t test_array_uint16[7] = {0U, 11111U, 22222U, 33333U, 44444U, 55555U, 65535U};
   for (i = 0; i < ARRAY_SIZE; i++) {
     arrays->uint16_array.data[i] = test_array_uint16[i];
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_uint16[i] == arrays->uint16_array.data[i]);
+    EXPECT_TRUE(test_array_uint16[i] == arrays->uint16_array.data[i]);
   }
 
   // uint32 array
   res = rosidl_generator_c__uint32__Array__init(&arrays->uint32_array, ARRAY_SIZE);
-  assert(true == res);
+  EXPECT_TRUE(true == res);
   uint32_t test_array_uint32[7] =
   {0UL, 100UL, 2000UL, 30000UL, 444444UL, 567890123UL, 4294967295UL};
   for (i = 0; i < ARRAY_SIZE; i++) {
@@ -626,12 +628,12 @@ void test_primitives_bounded_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_uint32[i] == arrays->uint32_array.data[i]);
+    EXPECT_TRUE(test_array_uint32[i] == arrays->uint32_array.data[i]);
   }
 
   // uint64 array
   res = rosidl_generator_c__uint64__Array__init(&arrays->uint64_array, ARRAY_SIZE);
-  assert(true == res);
+  EXPECT_TRUE(true == res);
   uint64_t test_array_uint64[7] =
   {0ULL, 10000ULL, 30000000ULL, 444444444ULL, 567890123456789ULL, 429496729578901234ULL,
    18446744073709551615ULL};
@@ -640,7 +642,7 @@ void test_primitives_bounded_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_uint64[i] == arrays->uint64_array.data[i]);
+    EXPECT_TRUE(test_array_uint64[i] == arrays->uint64_array.data[i]);
   }
 
   rosidl_generator_c__msg__PrimitivesBoundedArrays__destroy(arrays);
@@ -655,7 +657,7 @@ void test_primitives_static_arrays(void)
   rosidl_generator_c__msg__PrimitivesStaticArrays * arrays = NULL;
 
   arrays = rosidl_generator_c__msg__PrimitivesStaticArrays__create();
-  assert(NULL != arrays);
+  EXPECT_TRUE(NULL != arrays);
 
   // bool_array
   // load values
@@ -670,9 +672,9 @@ void test_primitives_static_arrays(void)
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
     if (0 == (i % 2)) {
-      assert(true == arrays->bool_array[i]);
+      EXPECT_TRUE(true == arrays->bool_array[i]);
     } else {
-      assert(false == arrays->bool_array[i]);
+      EXPECT_TRUE(false == arrays->bool_array[i]);
     }
   }
 
@@ -683,7 +685,7 @@ void test_primitives_static_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_byte[i] == arrays->byte_array[i]);
+    EXPECT_TRUE(test_array_byte[i] == arrays->byte_array[i]);
   }
 
   // char array
@@ -694,7 +696,7 @@ void test_primitives_static_arrays(void)
 
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_char[i] == arrays->char_array[i]);
+    EXPECT_TRUE(test_array_char[i] == arrays->char_array[i]);
   }
 
   // float32 array
@@ -706,7 +708,7 @@ void test_primitives_static_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_float32[i] == arrays->float32_array[i]);
+    EXPECT_TRUE(test_array_float32[i] == arrays->float32_array[i]);
   }
 
   // float64 array
@@ -719,7 +721,7 @@ void test_primitives_static_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_float64[i] == arrays->float64_array[i]);
+    EXPECT_TRUE(test_array_float64[i] == arrays->float64_array[i]);
   }
 
   // int8 array
@@ -729,7 +731,7 @@ void test_primitives_static_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_int8[i] == arrays->int8_array[i]);
+    EXPECT_TRUE(test_array_int8[i] == arrays->int8_array[i]);
   }
 
   // int16 array
@@ -740,7 +742,7 @@ void test_primitives_static_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_int16[i] == arrays->int16_array[i]);
+    EXPECT_TRUE(test_array_int16[i] == arrays->int16_array[i]);
   }
 
   // int32 array
@@ -751,7 +753,7 @@ void test_primitives_static_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_int32[i] == arrays->int32_array[i]);
+    EXPECT_TRUE(test_array_int32[i] == arrays->int32_array[i]);
   }
 
   // int64 array
@@ -763,7 +765,7 @@ void test_primitives_static_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_int64[i] == arrays->int64_array[i]);
+    EXPECT_TRUE(test_array_int64[i] == arrays->int64_array[i]);
   }
 
   // uint8 array
@@ -773,7 +775,7 @@ void test_primitives_static_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_uint8[i] == arrays->uint8_array[i]);
+    EXPECT_TRUE(test_array_uint8[i] == arrays->uint8_array[i]);
   }
 
   // uint16 array
@@ -783,7 +785,7 @@ void test_primitives_static_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_uint16[i] == arrays->uint16_array[i]);
+    EXPECT_TRUE(test_array_uint16[i] == arrays->uint16_array[i]);
   }
 
   // uint32 array
@@ -794,7 +796,7 @@ void test_primitives_static_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_uint32[i] == arrays->uint32_array[i]);
+    EXPECT_TRUE(test_array_uint32[i] == arrays->uint32_array[i]);
   }
 
   // uint64 array
@@ -806,7 +808,7 @@ void test_primitives_static_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    assert(test_array_uint64[i] == arrays->uint64_array[i]);
+    EXPECT_TRUE(test_array_uint64[i] == arrays->uint64_array[i]);
   }
 
   rosidl_generator_c__msg__PrimitivesStaticArrays__destroy(arrays);
@@ -823,29 +825,29 @@ void test_submessages(void)
 
   for (i = 0; i < 3; i++) {
     res = rosidl_generator_c__String__assign(&wire_msg->cablegram1[i].text, TEST_STRING);
-    assert(true == res);
+    EXPECT_TRUE(true == res);
     wire_msg->cablegram1[i].number = 3.1415f;
   }
   res = rosidl_generator_c__String__assign(&wire_msg->cablegram2.text_array[0], "Test 1");
-  assert(true == res);
+  EXPECT_TRUE(true == res);
   res = rosidl_generator_c__String__assign(&wire_msg->cablegram2.text_array[1], "Test 2");
-  assert(true == res);
+  EXPECT_TRUE(true == res);
   res = rosidl_generator_c__String__assign(&wire_msg->cablegram2.text_array[2], "Test 3");
-  assert(true == res);
+  EXPECT_TRUE(true == res);
   wire_msg->cablegram2.number_array[0] = 3.1f;
   wire_msg->cablegram2.number_array[1] = 3.14f;
   wire_msg->cablegram2.number_array[2] = 3.141f;
 
   for (i = 0; i < 3; i++) {
-    assert(0 == strcmp(wire_msg->cablegram1[i].text.data, TEST_STRING));
-    assert(3.1415f == wire_msg->cablegram1[i].number);
+    EXPECT_TRUE(0 == strcmp(wire_msg->cablegram1[i].text.data, TEST_STRING));
+    EXPECT_TRUE(3.1415f == wire_msg->cablegram1[i].number);
   }
-  assert(0 == strcmp(wire_msg->cablegram2.text_array[0].data, "Test 1"));
-  assert(0 == strcmp(wire_msg->cablegram2.text_array[1].data, "Test 2"));
-  assert(0 == strcmp(wire_msg->cablegram2.text_array[2].data, "Test 3"));
-  assert(3.1f == wire_msg->cablegram2.number_array[0]);
-  assert(3.14f == wire_msg->cablegram2.number_array[1]);
-  assert(3.141f == wire_msg->cablegram2.number_array[2]);
+  EXPECT_TRUE(0 == strcmp(wire_msg->cablegram2.text_array[0].data, "Test 1"));
+  EXPECT_TRUE(0 == strcmp(wire_msg->cablegram2.text_array[1].data, "Test 2"));
+  EXPECT_TRUE(0 == strcmp(wire_msg->cablegram2.text_array[2].data, "Test 3"));
+  EXPECT_TRUE(3.1f == wire_msg->cablegram2.number_array[0]);
+  EXPECT_TRUE(3.14f == wire_msg->cablegram2.number_array[1]);
+  EXPECT_TRUE(3.141f == wire_msg->cablegram2.number_array[2]);
 
   rosidl_generator_c__msg__Wire__destroy(wire_msg);
 }


### PR DESCRIPTION
`assert` can not be used in a unit test. When build in release mode the check just goes away.

This will fix the following compiler warnings http://ci.ros2.org/job/ci_linux/1051/warnings17Result/category.-861405076/ and will actually do some testing when building in release mode.