### PR TITLE
use macro names cpplint is happy with

### DIFF
--- a/rosidl_generator_c/test/test_interfaces.c
+++ b/rosidl_generator_c/test/test_interfaces.c
@@ -77,7 +77,8 @@
 
 #define ARRAY_SIZE 7
 
-#define EXPECT_TRUE(expr) if (!(expr)) exit(1)
+#define EXPECT_EQ(arg1, arg2) if (arg1 != arg2) exit(1)
+#define EXPECT_NE(arg1, arg2) if (arg1 == arg2) exit(1)
 
 void test_primitives(void);
 void test_primitives_default_value(void);
@@ -128,86 +129,86 @@ void test_primitives(void)
   rosidl_generator_c__msg__Uint64 uint64_msg;
 
   bool_msg.empty_bool = true;
-  EXPECT_TRUE(bool_msg.empty_bool == true);
+  EXPECT_EQ(bool_msg.empty_bool, true);
 
   bool_msg.empty_bool = false;
-  EXPECT_TRUE(bool_msg.empty_bool == false);
+  EXPECT_EQ(bool_msg.empty_bool, false);
 
   byte_msg.empty_byte = 0;
-  EXPECT_TRUE(byte_msg.empty_byte == 0);
+  EXPECT_EQ(byte_msg.empty_byte, 0);
 
   byte_msg.empty_byte = 255;
-  EXPECT_TRUE(byte_msg.empty_byte == 255);
+  EXPECT_EQ(byte_msg.empty_byte, 255);
 
-  EXPECT_TRUE(rosidl_generator_c__msg__Constants__X == 123);
-  EXPECT_TRUE(rosidl_generator_c__msg__Constants__Y == -123);
-  EXPECT_TRUE(strncmp(rosidl_generator_c__msg__Constants__FOO, "foo", 3) == 0);
+  EXPECT_EQ(rosidl_generator_c__msg__Constants__X, 123);
+  EXPECT_EQ(rosidl_generator_c__msg__Constants__Y, -123);
+  EXPECT_EQ(strncmp(rosidl_generator_c__msg__Constants__FOO, "foo", 3), 0);
 
   char_msg.empty_char = CHAR_MIN;
-  EXPECT_TRUE(char_msg.empty_char == CHAR_MIN);
+  EXPECT_EQ(char_msg.empty_char, CHAR_MIN);
 
   char_msg.empty_char = CHAR_MAX;
-  EXPECT_TRUE(char_msg.empty_char == CHAR_MAX);
+  EXPECT_EQ(char_msg.empty_char, CHAR_MAX);
 
   float32_msg.empty_float32 = FLT_MIN;
-  EXPECT_TRUE(float32_msg.empty_float32 == FLT_MIN);
+  EXPECT_EQ(float32_msg.empty_float32, FLT_MIN);
 
   float32_msg.empty_float32 = FLT_MAX;
-  EXPECT_TRUE(float32_msg.empty_float32 == FLT_MAX);
+  EXPECT_EQ(float32_msg.empty_float32, FLT_MAX);
 
   float64_msg.empty_float64 = DBL_MIN;
-  EXPECT_TRUE(float64_msg.empty_float64 == DBL_MIN);
+  EXPECT_EQ(float64_msg.empty_float64, DBL_MIN);
 
   float64_msg.empty_float64 = DBL_MAX;
-  EXPECT_TRUE(float64_msg.empty_float64 == DBL_MAX);
+  EXPECT_EQ(float64_msg.empty_float64, DBL_MAX);
 
   int8_msg.empty_int8 = INT8_MIN;
-  EXPECT_TRUE(int8_msg.empty_int8 == INT8_MIN);
+  EXPECT_EQ(int8_msg.empty_int8, INT8_MIN);
 
   int8_msg.empty_int8 = INT8_MAX;
-  EXPECT_TRUE(int8_msg.empty_int8 == INT8_MAX);
+  EXPECT_EQ(int8_msg.empty_int8, INT8_MAX);
 
   int16_msg.empty_int16 = INT16_MIN;
-  EXPECT_TRUE(int16_msg.empty_int16 == INT16_MIN);
+  EXPECT_EQ(int16_msg.empty_int16, INT16_MIN);
 
   int16_msg.empty_int16 = INT16_MAX;
-  EXPECT_TRUE(int16_msg.empty_int16 == INT16_MAX);
+  EXPECT_EQ(int16_msg.empty_int16, INT16_MAX);
 
   int32_msg.empty_int32 = INT32_MIN;
-  EXPECT_TRUE(int32_msg.empty_int32 == INT32_MIN);
+  EXPECT_EQ(int32_msg.empty_int32, INT32_MIN);
 
   int32_msg.empty_int32 = INT32_MAX;
-  EXPECT_TRUE(int32_msg.empty_int32 == INT32_MAX);
+  EXPECT_EQ(int32_msg.empty_int32, INT32_MAX);
 
   int64_msg.empty_int64 = INT64_MIN;
-  EXPECT_TRUE(int64_msg.empty_int64 == INT64_MIN);
+  EXPECT_EQ(int64_msg.empty_int64, INT64_MIN);
 
   int64_msg.empty_int64 = INT64_MAX;
-  EXPECT_TRUE(int64_msg.empty_int64 == INT64_MAX);
+  EXPECT_EQ(int64_msg.empty_int64, INT64_MAX);
 
   uint8_msg.empty_uint8 = 0;
-  EXPECT_TRUE(uint8_msg.empty_uint8 == 0);
+  EXPECT_EQ(uint8_msg.empty_uint8, 0);
 
   uint8_msg.empty_uint8 = UINT8_MAX;
-  EXPECT_TRUE(uint8_msg.empty_uint8 == UINT8_MAX);
+  EXPECT_EQ(uint8_msg.empty_uint8, UINT8_MAX);
 
   uint16_msg.empty_uint16 = 0;
-  EXPECT_TRUE(uint16_msg.empty_uint16 == 0);
+  EXPECT_EQ(uint16_msg.empty_uint16, 0);
 
   uint16_msg.empty_uint16 = UINT16_MAX;
-  EXPECT_TRUE(uint16_msg.empty_uint16 == UINT16_MAX);
+  EXPECT_EQ(uint16_msg.empty_uint16, UINT16_MAX);
 
   uint32_msg.empty_uint32 = 0;
-  EXPECT_TRUE(uint32_msg.empty_uint32 == 0);
+  EXPECT_EQ(uint32_msg.empty_uint32, 0);
 
   uint32_msg.empty_uint32 = UINT32_MAX;
-  EXPECT_TRUE(uint32_msg.empty_uint32 == UINT32_MAX);
+  EXPECT_EQ(uint32_msg.empty_uint32, UINT32_MAX);
 
   uint64_msg.empty_uint64 = 0;
-  EXPECT_TRUE(uint64_msg.empty_uint64 == 0);
+  EXPECT_EQ(uint64_msg.empty_uint64, 0);
 
   uint64_msg.empty_uint64 = UINT64_MAX;
-  EXPECT_TRUE(uint64_msg.empty_uint64 == UINT64_MAX);
+  EXPECT_EQ(uint64_msg.empty_uint64, UINT64_MAX);
 }
 
 /**
@@ -219,22 +220,22 @@ void test_primitives_default_value(void)
 
   primitive_values = rosidl_generator_c__msg__PrimitiveValues__create();
 
-  EXPECT_TRUE(primitive_values != NULL);
+  EXPECT_NE(primitive_values, NULL);
 
-  EXPECT_TRUE(true == primitive_values->def_bool_1);
-  EXPECT_TRUE(false == primitive_values->def_bool_2);
-  EXPECT_TRUE(66 == primitive_values->def_byte);
-  EXPECT_TRUE(-66 == primitive_values->def_char);
-  EXPECT_TRUE(3.1416f == primitive_values->def_float32);
-  EXPECT_TRUE(3.14159265 == primitive_values->def_float64);
-  EXPECT_TRUE(3 == primitive_values->def_int8);
-  EXPECT_TRUE(6 == primitive_values->def_int16);
-  EXPECT_TRUE(10 == primitive_values->def_int32);
-  EXPECT_TRUE(15 == primitive_values->def_int64);
-  EXPECT_TRUE(33 == primitive_values->def_uint8);
-  EXPECT_TRUE(36 == primitive_values->def_uint16);
-  EXPECT_TRUE(310 == primitive_values->def_uint32);
-  EXPECT_TRUE(315 == primitive_values->def_uint64);
+  EXPECT_EQ(true, primitive_values->def_bool_1);
+  EXPECT_EQ(false, primitive_values->def_bool_2);
+  EXPECT_EQ(66, primitive_values->def_byte);
+  EXPECT_EQ(-66, primitive_values->def_char);
+  EXPECT_EQ(3.1416f, primitive_values->def_float32);
+  EXPECT_EQ(3.14159265, primitive_values->def_float64);
+  EXPECT_EQ(3, primitive_values->def_int8);
+  EXPECT_EQ(6, primitive_values->def_int16);
+  EXPECT_EQ(10, primitive_values->def_int32);
+  EXPECT_EQ(15, primitive_values->def_int64);
+  EXPECT_EQ(33, primitive_values->def_uint8);
+  EXPECT_EQ(36, primitive_values->def_uint16);
+  EXPECT_EQ(310, primitive_values->def_uint32);
+  EXPECT_EQ(315, primitive_values->def_uint64);
 
   rosidl_generator_c__msg__PrimitiveValues__destroy(primitive_values);
 }
@@ -248,17 +249,17 @@ void test_strings(void)
   rosidl_generator_c__msg__Strings * strings = NULL;
 
   strings = rosidl_generator_c__msg__Strings__create();
-  EXPECT_TRUE(strings != NULL);
+  EXPECT_NE(strings, NULL);
 
   res = rosidl_generator_c__String__assign(&strings->empty_string, TEST_STRING);
-  EXPECT_TRUE(true == res);
-  EXPECT_TRUE(0 == strcmp(strings->empty_string.data, TEST_STRING));
-  EXPECT_TRUE(0 == strcmp(strings->def_string.data, "Hello world!"));
+  EXPECT_EQ(true, res);
+  EXPECT_EQ(0, strcmp(strings->empty_string.data, TEST_STRING));
+  EXPECT_EQ(0, strcmp(strings->def_string.data, "Hello world!"));
   // since upper-bound checking is not implemented yet, we restrict the string copying
   res = rosidl_generator_c__String__assignn(&strings->ub_string, TEST_STRING, 22);
-  EXPECT_TRUE(true == res);
-  EXPECT_TRUE(0 == strcmp(strings->ub_string.data, "Deep into that darknes"));
-  EXPECT_TRUE(0 == strcmp(strings->ub_def_string.data, "Upper bounded string."));
+  EXPECT_EQ(true, res);
+  EXPECT_EQ(0, strcmp(strings->ub_string.data, "Deep into that darknes"));
+  EXPECT_EQ(0, strcmp(strings->ub_def_string.data, "Upper bounded string."));
 
   rosidl_generator_c__msg__Strings__destroy(strings);
 }
@@ -273,11 +274,11 @@ void test_primitives_unbounded_arrays(void)
   rosidl_generator_c__msg__PrimitivesUnboundedArrays * arrays = NULL;
 
   arrays = rosidl_generator_c__msg__PrimitivesUnboundedArrays__create();
-  EXPECT_TRUE(NULL != arrays);
+  EXPECT_NE(NULL, arrays);
 
   // bool_array
   res = rosidl_generator_c__bool__Array__init(&arrays->bool_array, ARRAY_SIZE);
-  EXPECT_TRUE(true == res);
+  EXPECT_EQ(true, res);
   // load values
   for (i = 0; i < ARRAY_SIZE; i++) {
     if (0 == (i % 2)) {
@@ -289,40 +290,40 @@ void test_primitives_unbounded_arrays(void)
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
     if (0 == (i % 2)) {
-      EXPECT_TRUE(true == arrays->bool_array.data[i]);
+      EXPECT_EQ(true, arrays->bool_array.data[i]);
     } else {
-      EXPECT_TRUE(false == arrays->bool_array.data[i]);
+      EXPECT_EQ(false, arrays->bool_array.data[i]);
     }
   }
 
   // byte_array
   res = rosidl_generator_c__byte__Array__init(&arrays->byte_array, ARRAY_SIZE);
-  EXPECT_TRUE(true == res);
+  EXPECT_EQ(true, res);
   uint8_t test_array_byte[7] = {0, 57, 110, 177, 201, 240, 255};
   for (i = 0; i < ARRAY_SIZE; i++) {
     arrays->byte_array.data[i] = test_array_byte[i];
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_byte[i] == arrays->byte_array.data[i]);
+    EXPECT_EQ(test_array_byte[i], arrays->byte_array.data[i]);
   }
 
 
   // char array
   res = rosidl_generator_c__char__Array__init(&arrays->char_array, ARRAY_SIZE);
-  EXPECT_TRUE(true == res);
+  EXPECT_EQ(true, res);
   char test_array_char[7] = {'a', '5', '#', 'Z', '@', '-', ' '};
   for (i = 0; i < ARRAY_SIZE; i++) {
     arrays->char_array.data[i] = test_array_char[i];
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_char[i] == arrays->char_array.data[i]);
+    EXPECT_EQ(test_array_char[i], arrays->char_array.data[i]);
   }
 
   // float32 array
   res = rosidl_generator_c__float32__Array__init(&arrays->float32_array, ARRAY_SIZE);
-  EXPECT_TRUE(true == res);
+  EXPECT_EQ(true, res);
   float test_array_float32[7] =
   {-3.000001f, 22143.541325f, 6331.00432f, -214.66241f, 0.000001f, 1415555.12345f,
    -1.11154f};
@@ -331,12 +332,12 @@ void test_primitives_unbounded_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_float32[i] == arrays->float32_array.data[i]);
+    EXPECT_EQ(test_array_float32[i], arrays->float32_array.data[i]);
   }
 
   // float64 array
   res = rosidl_generator_c__float64__Array__init(&arrays->float64_array, ARRAY_SIZE);
-  EXPECT_TRUE(true == res);
+  EXPECT_EQ(true, res);
   double test_array_float64[7] =
   {-120310.00843902140001, 22143.54483920141325, 6331.0048392104432,
    -214.62850432596241, 0.0000000000001, 1415555.128294031432345,
@@ -346,24 +347,24 @@ void test_primitives_unbounded_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_float64[i] == arrays->float64_array.data[i]);
+    EXPECT_EQ(test_array_float64[i], arrays->float64_array.data[i]);
   }
 
   // int8 array
   res = rosidl_generator_c__int8__Array__init(&arrays->int8_array, ARRAY_SIZE);
-  EXPECT_TRUE(true == res);
+  EXPECT_EQ(true, res);
   int8_t test_array_int8[7] = {-127, -55, -30, 0, 58, 100, 127};
   for (i = 0; i < ARRAY_SIZE; i++) {
     arrays->int8_array.data[i] = test_array_int8[i];
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_int8[i] == arrays->int8_array.data[i]);
+    EXPECT_EQ(test_array_int8[i], arrays->int8_array.data[i]);
   }
 
   // int16 array
   res = rosidl_generator_c__int16__Array__init(&arrays->int16_array, ARRAY_SIZE);
-  EXPECT_TRUE(true == res);
+  EXPECT_EQ(true, res);
   int16_t test_array_int16[7] =
   {-32767, -22222, -11111, 0, 11111, 22222, 32767};
   for (i = 0; i < ARRAY_SIZE; i++) {
@@ -371,12 +372,12 @@ void test_primitives_unbounded_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_int16[i] == arrays->int16_array.data[i]);
+    EXPECT_EQ(test_array_int16[i], arrays->int16_array.data[i]);
   }
 
   // int32 array
   res = rosidl_generator_c__int32__Array__init(&arrays->int32_array, ARRAY_SIZE);
-  EXPECT_TRUE(true == res);
+  EXPECT_EQ(true, res);
   int32_t test_array_int32[7] =
   {INT32_MIN, INT32_MIN / 2, INT32_MIN / 4, 0L, INT32_MAX / 4, INT32_MAX / 2, INT32_MAX};
   for (i = 0; i < ARRAY_SIZE; i++) {
@@ -384,12 +385,12 @@ void test_primitives_unbounded_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_int32[i] == arrays->int32_array.data[i]);
+    EXPECT_EQ(test_array_int32[i], arrays->int32_array.data[i]);
   }
 
   // int64 array
   res = rosidl_generator_c__int64__Array__init(&arrays->int64_array, ARRAY_SIZE);
-  EXPECT_TRUE(true == res);
+  EXPECT_EQ(true, res);
   int64_t test_array_int64[7] =
   {-9223372036854775807LL, -5000000000000000000LL, -1111111111111111111LL, 0,
    1111111111111111111LL, 5000000000000000000LL, 9223372036854775807LL};
@@ -398,36 +399,36 @@ void test_primitives_unbounded_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_int64[i] == arrays->int64_array.data[i]);
+    EXPECT_EQ(test_array_int64[i], arrays->int64_array.data[i]);
   }
 
   // uint8 array
   res = rosidl_generator_c__uint8__Array__init(&arrays->uint8_array, ARRAY_SIZE);
-  EXPECT_TRUE(true == res);
+  EXPECT_EQ(true, res);
   uint8_t test_array_uint8[7] = {0, 5, 70, 128, 180, 220, 255};
   for (i = 0; i < ARRAY_SIZE; i++) {
     arrays->uint8_array.data[i] = test_array_uint8[i];
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_uint8[i] == arrays->uint8_array.data[i]);
+    EXPECT_EQ(test_array_uint8[i], arrays->uint8_array.data[i]);
   }
 
   // uint16 array
   res = rosidl_generator_c__uint16__Array__init(&arrays->uint16_array, ARRAY_SIZE);
-  EXPECT_TRUE(true == res);
+  EXPECT_EQ(true, res);
   uint16_t test_array_uint16[7] = {0U, 11111U, 22222U, 33333U, 44444U, 55555U, 65535U};
   for (i = 0; i < ARRAY_SIZE; i++) {
     arrays->uint16_array.data[i] = test_array_uint16[i];
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_uint16[i] == arrays->uint16_array.data[i]);
+    EXPECT_EQ(test_array_uint16[i], arrays->uint16_array.data[i]);
   }
 
   // uint32 array
   res = rosidl_generator_c__uint32__Array__init(&arrays->uint32_array, ARRAY_SIZE);
-  EXPECT_TRUE(true == res);
+  EXPECT_EQ(true, res);
   uint32_t test_array_uint32[7] =
   {0UL, 100UL, 2000UL, 30000UL, 444444UL, 567890123UL, 4294967295UL};
   for (i = 0; i < ARRAY_SIZE; i++) {
@@ -435,12 +436,12 @@ void test_primitives_unbounded_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_uint32[i] == arrays->uint32_array.data[i]);
+    EXPECT_EQ(test_array_uint32[i], arrays->uint32_array.data[i]);
   }
 
   // uint64 array
   res = rosidl_generator_c__uint64__Array__init(&arrays->uint64_array, ARRAY_SIZE);
-  EXPECT_TRUE(true == res);
+  EXPECT_EQ(true, res);
   uint64_t test_array_uint64[7] =
   {0ULL, 10000ULL, 30000000ULL, 444444444ULL, 567890123456789ULL, 429496729578901234ULL,
    18446744073709551615ULL};
@@ -449,7 +450,7 @@ void test_primitives_unbounded_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_uint64[i] == arrays->uint64_array.data[i]);
+    EXPECT_EQ(test_array_uint64[i], arrays->uint64_array.data[i]);
   }
 
   rosidl_generator_c__msg__PrimitivesUnboundedArrays__destroy(arrays);
@@ -465,11 +466,11 @@ void test_primitives_bounded_arrays(void)
   rosidl_generator_c__msg__PrimitivesBoundedArrays * arrays = NULL;
 
   arrays = rosidl_generator_c__msg__PrimitivesBoundedArrays__create();
-  EXPECT_TRUE(NULL != arrays);
+  EXPECT_NE(NULL, arrays);
 
   // bool_array
   res = rosidl_generator_c__bool__Array__init(&arrays->bool_array, ARRAY_SIZE);
-  EXPECT_TRUE(true == res);
+  EXPECT_EQ(true, res);
   // load values
   for (i = 0; i < ARRAY_SIZE; i++) {
     if (0 == (i % 2)) {
@@ -481,28 +482,28 @@ void test_primitives_bounded_arrays(void)
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
     if (0 == (i % 2)) {
-      EXPECT_TRUE(true == arrays->bool_array.data[i]);
+      EXPECT_EQ(true, arrays->bool_array.data[i]);
     } else {
-      EXPECT_TRUE(false == arrays->bool_array.data[i]);
+      EXPECT_EQ(false, arrays->bool_array.data[i]);
     }
   }
 
   // byte_array
   res = rosidl_generator_c__byte__Array__init(&arrays->byte_array, ARRAY_SIZE);
-  EXPECT_TRUE(true == res);
+  EXPECT_EQ(true, res);
   uint8_t test_array_byte[8] = {0, 57, 110, 177, 201, 240, 255, 111};
   for (i = 0; i < ARRAY_SIZE; i++) {
     arrays->byte_array.data[i] = test_array_byte[i];
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_byte[i] == arrays->byte_array.data[i]);
+    EXPECT_EQ(test_array_byte[i], arrays->byte_array.data[i]);
   }
 
 
   // char array
   res = rosidl_generator_c__char__Array__init(&arrays->char_array, ARRAY_SIZE);
-  EXPECT_TRUE(true == res);
+  EXPECT_EQ(true, res);
   char test_array_char[7] = {'a', '5', '#', 'Z', '@', '-', ' '};
   for (i = 0; i < ARRAY_SIZE; i++) {
     arrays->char_array.data[i] = test_array_char[i];
@@ -510,12 +511,12 @@ void test_primitives_bounded_arrays(void)
 
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_char[i] == arrays->char_array.data[i]);
+    EXPECT_EQ(test_array_char[i], arrays->char_array.data[i]);
   }
 
   // float32 array
   res = rosidl_generator_c__float32__Array__init(&arrays->float32_array, ARRAY_SIZE);
-  EXPECT_TRUE(true == res);
+  EXPECT_EQ(true, res);
   float test_array_float32[7] =
   {-3.000001f, 22143.541325f, 6331.00432f, -214.66241f, 0.000001f, 1415555.12345f,
    -1.11154f};
@@ -524,12 +525,12 @@ void test_primitives_bounded_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_float32[i] == arrays->float32_array.data[i]);
+    EXPECT_EQ(test_array_float32[i], arrays->float32_array.data[i]);
   }
 
   // float64 array
   res = rosidl_generator_c__float64__Array__init(&arrays->float64_array, ARRAY_SIZE);
-  EXPECT_TRUE(true == res);
+  EXPECT_EQ(true, res);
   double test_array_float64[7] =
   {-120310.00843902140001, 22143.54483920141325, 6331.0048392104432,
    -214.62850432596241, 0.0000000000001, 1415555.128294031432345,
@@ -539,24 +540,24 @@ void test_primitives_bounded_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_float64[i] == arrays->float64_array.data[i]);
+    EXPECT_EQ(test_array_float64[i], arrays->float64_array.data[i]);
   }
 
   // int8 array
   res = rosidl_generator_c__int8__Array__init(&arrays->int8_array, ARRAY_SIZE);
-  EXPECT_TRUE(true == res);
+  EXPECT_EQ(true, res);
   int8_t test_array_int8[7] = {-127, -55, -30, 0, 58, 100, 127};
   for (i = 0; i < ARRAY_SIZE; i++) {
     arrays->int8_array.data[i] = test_array_int8[i];
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_int8[i] == arrays->int8_array.data[i]);
+    EXPECT_EQ(test_array_int8[i], arrays->int8_array.data[i]);
   }
 
   // int16 array
   res = rosidl_generator_c__int16__Array__init(&arrays->int16_array, ARRAY_SIZE);
-  EXPECT_TRUE(true == res);
+  EXPECT_EQ(true, res);
   int16_t test_array_int16[7] =
   {-32767, -22222, -11111, 0, 11111, 22222, 32767};
   for (i = 0; i < ARRAY_SIZE; i++) {
@@ -564,12 +565,12 @@ void test_primitives_bounded_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_int16[i] == arrays->int16_array.data[i]);
+    EXPECT_EQ(test_array_int16[i], arrays->int16_array.data[i]);
   }
 
   // int32 array
   res = rosidl_generator_c__int32__Array__init(&arrays->int32_array, ARRAY_SIZE);
-  EXPECT_TRUE(true == res);
+  EXPECT_EQ(true, res);
   int32_t test_array_int32[7] =
   {INT32_MIN, INT32_MIN / 2, INT32_MIN / 4, 0L, INT32_MAX / 4, INT32_MAX / 2, INT32_MAX};
   for (i = 0; i < ARRAY_SIZE; i++) {
@@ -577,12 +578,12 @@ void test_primitives_bounded_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_int32[i] == arrays->int32_array.data[i]);
+    EXPECT_EQ(test_array_int32[i], arrays->int32_array.data[i]);
   }
 
   // int64 array
   res = rosidl_generator_c__int64__Array__init(&arrays->int64_array, ARRAY_SIZE);
-  EXPECT_TRUE(true == res);
+  EXPECT_EQ(true, res);
   int64_t test_array_int64[7] =
   {-9223372036854775807LL, -5000000000000000000LL, -1111111111111111111, 0,
    1111111111111111111LL, 5000000000000000000LL, 9223372036854775807LL};
@@ -591,36 +592,36 @@ void test_primitives_bounded_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_int64[i] == arrays->int64_array.data[i]);
+    EXPECT_EQ(test_array_int64[i], arrays->int64_array.data[i]);
   }
 
   // uint8 array
   res = rosidl_generator_c__uint8__Array__init(&arrays->uint8_array, ARRAY_SIZE);
-  EXPECT_TRUE(true == res);
+  EXPECT_EQ(true, res);
   uint8_t test_array_uint8[7] = {0, 5, 70, 128, 180, 220, 255};
   for (i = 0; i < ARRAY_SIZE; i++) {
     arrays->uint8_array.data[i] = test_array_uint8[i];
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_uint8[i] == arrays->uint8_array.data[i]);
+    EXPECT_EQ(test_array_uint8[i], arrays->uint8_array.data[i]);
   }
 
   // uint16 array
   res = rosidl_generator_c__uint16__Array__init(&arrays->uint16_array, ARRAY_SIZE);
-  EXPECT_TRUE(true == res);
+  EXPECT_EQ(true, res);
   uint16_t test_array_uint16[7] = {0U, 11111U, 22222U, 33333U, 44444U, 55555U, 65535U};
   for (i = 0; i < ARRAY_SIZE; i++) {
     arrays->uint16_array.data[i] = test_array_uint16[i];
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_uint16[i] == arrays->uint16_array.data[i]);
+    EXPECT_EQ(test_array_uint16[i], arrays->uint16_array.data[i]);
   }
 
   // uint32 array
   res = rosidl_generator_c__uint32__Array__init(&arrays->uint32_array, ARRAY_SIZE);
-  EXPECT_TRUE(true == res);
+  EXPECT_EQ(true, res);
   uint32_t test_array_uint32[7] =
   {0UL, 100UL, 2000UL, 30000UL, 444444UL, 567890123UL, 4294967295UL};
   for (i = 0; i < ARRAY_SIZE; i++) {
@@ -628,12 +629,12 @@ void test_primitives_bounded_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_uint32[i] == arrays->uint32_array.data[i]);
+    EXPECT_EQ(test_array_uint32[i], arrays->uint32_array.data[i]);
   }
 
   // uint64 array
   res = rosidl_generator_c__uint64__Array__init(&arrays->uint64_array, ARRAY_SIZE);
-  EXPECT_TRUE(true == res);
+  EXPECT_EQ(true, res);
   uint64_t test_array_uint64[7] =
   {0ULL, 10000ULL, 30000000ULL, 444444444ULL, 567890123456789ULL, 429496729578901234ULL,
    18446744073709551615ULL};
@@ -642,7 +643,7 @@ void test_primitives_bounded_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_uint64[i] == arrays->uint64_array.data[i]);
+    EXPECT_EQ(test_array_uint64[i], arrays->uint64_array.data[i]);
   }
 
   rosidl_generator_c__msg__PrimitivesBoundedArrays__destroy(arrays);
@@ -657,7 +658,7 @@ void test_primitives_static_arrays(void)
   rosidl_generator_c__msg__PrimitivesStaticArrays * arrays = NULL;
 
   arrays = rosidl_generator_c__msg__PrimitivesStaticArrays__create();
-  EXPECT_TRUE(NULL != arrays);
+  EXPECT_NE(NULL, arrays);
 
   // bool_array
   // load values
@@ -672,9 +673,9 @@ void test_primitives_static_arrays(void)
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
     if (0 == (i % 2)) {
-      EXPECT_TRUE(true == arrays->bool_array[i]);
+      EXPECT_EQ(true, arrays->bool_array[i]);
     } else {
-      EXPECT_TRUE(false == arrays->bool_array[i]);
+      EXPECT_EQ(false, arrays->bool_array[i]);
     }
   }
 
@@ -685,7 +686,7 @@ void test_primitives_static_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_byte[i] == arrays->byte_array[i]);
+    EXPECT_EQ(test_array_byte[i], arrays->byte_array[i]);
   }
 
   // char array
@@ -696,7 +697,7 @@ void test_primitives_static_arrays(void)
 
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_char[i] == arrays->char_array[i]);
+    EXPECT_EQ(test_array_char[i], arrays->char_array[i]);
   }
 
   // float32 array
@@ -708,7 +709,7 @@ void test_primitives_static_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_float32[i] == arrays->float32_array[i]);
+    EXPECT_EQ(test_array_float32[i], arrays->float32_array[i]);
   }
 
   // float64 array
@@ -721,7 +722,7 @@ void test_primitives_static_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_float64[i] == arrays->float64_array[i]);
+    EXPECT_EQ(test_array_float64[i], arrays->float64_array[i]);
   }
 
   // int8 array
@@ -731,7 +732,7 @@ void test_primitives_static_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_int8[i] == arrays->int8_array[i]);
+    EXPECT_EQ(test_array_int8[i], arrays->int8_array[i]);
   }
 
   // int16 array
@@ -742,7 +743,7 @@ void test_primitives_static_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_int16[i] == arrays->int16_array[i]);
+    EXPECT_EQ(test_array_int16[i], arrays->int16_array[i]);
   }
 
   // int32 array
@@ -753,7 +754,7 @@ void test_primitives_static_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_int32[i] == arrays->int32_array[i]);
+    EXPECT_EQ(test_array_int32[i], arrays->int32_array[i]);
   }
 
   // int64 array
@@ -765,7 +766,7 @@ void test_primitives_static_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_int64[i] == arrays->int64_array[i]);
+    EXPECT_EQ(test_array_int64[i], arrays->int64_array[i]);
   }
 
   // uint8 array
@@ -775,7 +776,7 @@ void test_primitives_static_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_uint8[i] == arrays->uint8_array[i]);
+    EXPECT_EQ(test_array_uint8[i], arrays->uint8_array[i]);
   }
 
   // uint16 array
@@ -785,7 +786,7 @@ void test_primitives_static_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_uint16[i] == arrays->uint16_array[i]);
+    EXPECT_EQ(test_array_uint16[i], arrays->uint16_array[i]);
   }
 
   // uint32 array
@@ -796,7 +797,7 @@ void test_primitives_static_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_uint32[i] == arrays->uint32_array[i]);
+    EXPECT_EQ(test_array_uint32[i], arrays->uint32_array[i]);
   }
 
   // uint64 array
@@ -808,7 +809,7 @@ void test_primitives_static_arrays(void)
   }
   // test values
   for (i = 0; i < ARRAY_SIZE; i++) {
-    EXPECT_TRUE(test_array_uint64[i] == arrays->uint64_array[i]);
+    EXPECT_EQ(test_array_uint64[i], arrays->uint64_array[i]);
   }
 
   rosidl_generator_c__msg__PrimitivesStaticArrays__destroy(arrays);
@@ -825,29 +826,29 @@ void test_submessages(void)
 
   for (i = 0; i < 3; i++) {
     res = rosidl_generator_c__String__assign(&wire_msg->cablegram1[i].text, TEST_STRING);
-    EXPECT_TRUE(true == res);
+    EXPECT_EQ(true, res);
     wire_msg->cablegram1[i].number = 3.1415f;
   }
   res = rosidl_generator_c__String__assign(&wire_msg->cablegram2.text_array[0], "Test 1");
-  EXPECT_TRUE(true == res);
+  EXPECT_EQ(true, res);
   res = rosidl_generator_c__String__assign(&wire_msg->cablegram2.text_array[1], "Test 2");
-  EXPECT_TRUE(true == res);
+  EXPECT_EQ(true, res);
   res = rosidl_generator_c__String__assign(&wire_msg->cablegram2.text_array[2], "Test 3");
-  EXPECT_TRUE(true == res);
+  EXPECT_EQ(true, res);
   wire_msg->cablegram2.number_array[0] = 3.1f;
   wire_msg->cablegram2.number_array[1] = 3.14f;
   wire_msg->cablegram2.number_array[2] = 3.141f;
 
   for (i = 0; i < 3; i++) {
-    EXPECT_TRUE(0 == strcmp(wire_msg->cablegram1[i].text.data, TEST_STRING));
-    EXPECT_TRUE(3.1415f == wire_msg->cablegram1[i].number);
+    EXPECT_EQ(0, strcmp(wire_msg->cablegram1[i].text.data, TEST_STRING));
+    EXPECT_EQ(3.1415f, wire_msg->cablegram1[i].number);
   }
-  EXPECT_TRUE(0 == strcmp(wire_msg->cablegram2.text_array[0].data, "Test 1"));
-  EXPECT_TRUE(0 == strcmp(wire_msg->cablegram2.text_array[1].data, "Test 2"));
-  EXPECT_TRUE(0 == strcmp(wire_msg->cablegram2.text_array[2].data, "Test 3"));
-  EXPECT_TRUE(3.1f == wire_msg->cablegram2.number_array[0]);
-  EXPECT_TRUE(3.14f == wire_msg->cablegram2.number_array[1]);
-  EXPECT_TRUE(3.141f == wire_msg->cablegram2.number_array[2]);
+  EXPECT_EQ(0, strcmp(wire_msg->cablegram2.text_array[0].data, "Test 1"));
+  EXPECT_EQ(0, strcmp(wire_msg->cablegram2.text_array[1].data, "Test 2"));
+  EXPECT_EQ(0, strcmp(wire_msg->cablegram2.text_array[2].data, "Test 3"));
+  EXPECT_EQ(3.1f, wire_msg->cablegram2.number_array[0]);
+  EXPECT_EQ(3.14f, wire_msg->cablegram2.number_array[1]);
+  EXPECT_EQ(3.141f, wire_msg->cablegram2.number_array[2]);
 
   rosidl_generator_c__msg__Wire__destroy(wire_msg);
 }


### PR DESCRIPTION
Follow up of #103. `cpplint` "known" about `EXPECT_TRUE` and complains. So using custom `EXPECT_EQ` and `EXPECT_NE` now.

http://ci.ros2.org/job/ci_linux/1056/