### PR TITLE
Fix python generator warnings

### DIFF
--- a/rosidl_generator_c/rosidl_generator_c/__init__.py
+++ b/rosidl_generator_c/rosidl_generator_c/__init__.py
@@ -90,6 +90,10 @@ def get_typename_of_base_type(type_):
     return 'rosidl_generator_c__' + suffix
 
 
+def primitive_msg_type_to_c(type_):
+    return MSG_TYPE_TO_C[type_]
+
+
 def msg_type_to_c(type_, name_):
     """
     Convert a message type into the C declaration.

--- a/rosidl_generator_py/resource/_msg_support.c.template
+++ b/rosidl_generator_py/resource/_msg_support.c.template
@@ -69,21 +69,29 @@ full_classname = "@(spec.base_type.pkg_name).@(subfolder)._@(module_name).@(spec
   ros_message->@(field.name) = (py@(field.name) == Py_True);
 @[elif field.type.type in ['float32', 'float64']]@
   assert(PyFloat_Check(py@(field.name)));
+@[if field.type.type == 'float32']@
+  ros_message->@(field.name) = (float)PyFloat_AS_DOUBLE(py@(field.name));
+@[else]@
   ros_message->@(field.name) = PyFloat_AS_DOUBLE(py@(field.name));
+@[end if]@
 @[elif field.type.type in [
         'int8',
         'int16',
         'int32',
     ]]@
   assert(PyLong_Check(py@(field.name)));
-  ros_message->@(field.name) = PyLong_AsLong(py@(field.name));
+  ros_message->@(field.name) = (@(primitive_msg_type_to_c(field.type.type)))PyLong_AsLong(py@(field.name));
 @[elif field.type.type in [
         'uint8',
         'uint16',
         'uint32',
     ]]@
   assert(PyLong_Check(py@(field.name)));
+@[if field.type.type == 'uint32']@
   ros_message->@(field.name) = PyLong_AsUnsignedLong(py@(field.name));
+@[else]@
+  ros_message->@(field.name) = (@(primitive_msg_type_to_c(field.type.type)))PyLong_AsUnsignedLong(py@(field.name));
+@[end if]
 @[elif field.type.type == 'int64']@
   assert(PyLong_Check(py@(field.name)));
   ros_message->@(field.name) = PyLong_AsLongLong(py@(field.name));

--- a/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
+++ b/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
@@ -19,6 +19,7 @@ from rosidl_cmake import convert_camel_case_to_lower_case_underscore
 from rosidl_cmake import expand_template
 from rosidl_cmake import get_newest_modification_time
 from rosidl_cmake import read_generator_arguments
+from rosidl_generator_c import primitive_msg_type_to_c
 from rosidl_parser import parse_message_file
 from rosidl_parser import parse_service_file
 
@@ -50,6 +51,7 @@ def generate_py(generator_arguments_file, typesupport_impl, typesupport_impls):
     functions = {
         'constant_value_to_py': constant_value_to_py,
         'get_python_type': get_python_type,
+        'primitive_msg_type_to_c': primitive_msg_type_to_c,
         'value_to_py': value_to_py,
     }
     latest_target_timestamp = get_newest_modification_time(args['target_dependencies'])


### PR DESCRIPTION
Attempts to fix all "possible loss of data" warnings for float32, int8, int16, uint8, uint16 data types in the generated Python C bindings.

http://ci.ros2.org/job/ci_windows/1120