### PR TITLE
fix dependencies in Python generator

### DIFF
--- a/rosidl_generator_py/bin/rosidl_generator_py
+++ b/rosidl_generator_py/bin/rosidl_generator_py
@@ -28,16 +28,12 @@ def main(argv=sys.argv[1:]):
         required=True,
         help='The location of the file containing the generator arguments')
     parser.add_argument(
-        '--typesupport-impl',
-        required=True,
-        help='The typesupport implementation targeted by the C interface')
-    parser.add_argument(
         '--typesupport-impls',
         required=True,
         help='All the available typesupport implementations')
     args = parser.parse_args(argv)
 
-    return generate_py(args.generator_arguments_file, args.typesupport_impl, args.typesupport_impls)
+    return generate_py(args.generator_arguments_file, args.typesupport_impls.split(';'))
 
 
 if __name__ == '__main__':

--- a/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
@@ -162,7 +162,6 @@ add_custom_command(
   OUTPUT ${_generated_msg_py_files} ${_generated_msg_c_files} ${_generated_srv_files}
   COMMAND ${PYTHON_EXECUTABLE} ${rosidl_generator_py_BIN}
   --generator-arguments-file "${generator_arguments_file}"
-  --typesupport-impl "${_typesupport_impl}"
   --typesupport-impls "${_typesupport_impls}"
   DEPENDS ${target_dependencies}
   COMMENT "Generating Python code for ROS interfaces"

--- a/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
@@ -168,6 +168,18 @@ add_custom_command(
   VERBATIM
 )
 
+if(TARGET ${rosidl_generate_interfaces_TARGET}${_target_suffix})
+  message(WARNING "Custom target ${rosidl_generate_interfaces_TARGET}${_target_suffix} already exists")
+else()
+  add_custom_target(
+    ${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    DEPENDS
+    ${_generated_msg_py_files}
+    ${_generated_msg_c_files}
+    ${_generated_srv_files}
+  )
+endif()
+
 macro(set_properties _build_type)
   set_target_properties(${_msg_name}${_pyext_suffix} PROPERTIES
     COMPILE_FLAGS "${_extension_compile_flags}"
@@ -210,6 +222,7 @@ foreach(_generated_msg_c_ts_file ${_generated_msg_c_ts_files})
 
     add_dependencies(
       ${_msg_name}${_pyext_suffix}
+      ${rosidl_generate_interfaces_TARGET}${_target_suffix}
       ${rosidl_generate_interfaces_TARGET}__rosidl_generator_c
     )
 
@@ -266,18 +279,3 @@ foreach(_generated_msg_c_ts_file ${_generated_msg_c_ts_files})
       DESTINATION "${PYTHON_INSTALL_DIR}/${PROJECT_NAME}/${_msg_package_dir2}")
   endif()
 endforeach()
-
-if(TARGET ${rosidl_generate_interfaces_TARGET}${_target_suffix})
-  message(WARNING "Custom target ${rosidl_generate_interfaces_TARGET}${_target_suffix} already exists")
-else()
-  add_custom_target(
-    ${rosidl_generate_interfaces_TARGET}${_target_suffix}
-    DEPENDS
-    ${_generated_msg_py_files}
-    ${_generated_msg_c_files}
-    ${_generated_srv_files}
-    ${_generated_extension_files}
-    ${_extension_dependencies}
-    ${rosidl_generate_interfaces_TARGET}__rosidl_generator_c
-  )
-endif()

--- a/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
+++ b/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
@@ -24,9 +24,8 @@ from rosidl_parser import parse_message_file
 from rosidl_parser import parse_service_file
 
 
-def generate_py(generator_arguments_file, typesupport_impl, typesupport_impls):
+def generate_py(generator_arguments_file, typesupport_impls):
     args = read_generator_arguments(generator_arguments_file)
-    typesupport_impls = typesupport_impls.split(';')
 
     template_dir = args['template_dir']
     type_support_impl_by_filename = {


### PR DESCRIPTION
The first commit just removes an unused argument / parameter which I ran into when debugging this.

The second commit adds the missing target dependency. Otherwise when built with multiple threads each library target can trigger the custom command invoking the code generator. Commonly the code generator gets executed N times where N is the number of threads.

The patch does likely not only fix race conditions like http://ci.ros2.org/job/ci_linux/1111/console but also significantly reduces the resource usage. E.g. building only `rosidl_generator_py` without this patch:

    real  1m49.139s
    user  8m4.513s
    sys   0m18.413s

With this patch:

    real  1m6.204s
    user  2m51.971s
    sys   0m17.512s

* http://ci.ros2.org/job/ci_linux/1117/
* http://ci.ros2.org/job/ci_osx/897/
* http://ci.ros2.org/job/ci_windows/1180/