### PR TITLE
Avoid name conflict on field called 'message'

### DIFF
--- a/rosidl_generator_cpp/resource/msg__struct.hpp.template
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.template
@@ -22,6 +22,12 @@ header_guard_variable = '__'.join([x.upper() for x in header_guard_parts]) + '_'
 #ifndef @(header_guard_variable)
 #define @(header_guard_variable)
 
+// Protect against ERROR being predefined on Windows, in case somebody defines a
+// constant by that name.
+#if defined(_WIN32) && defined(ERROR)
+  #undef ERROR
+#endif
+
 @{
 from rosidl_generator_cpp import escape_string
 from rosidl_generator_cpp import msg_type_to_cpp

--- a/rosidl_generator_py/resource/_msg_support.c.template
+++ b/rosidl_generator_py/resource/_msg_support.c.template
@@ -116,9 +116,9 @@ PyObject * @(spec.base_type.pkg_name)_@(module_name)__convert_to_py(void * raw_r
   PyObject *pymessage_class = PyObject_GetAttrString(pymessage_module, "@(spec.base_type.type)");
 
   /* NOTE(esteve): Call constructor of @(spec.base_type.type)*/
-  PyObject *pymessage = NULL;
-  pymessage = PyObject_CallObject(pymessage_class, NULL);
-  assert(pymessage != NULL);
+  PyObject *_pymessage = NULL;
+  _pymessage = PyObject_CallObject(pymessage_class, NULL);
+  assert(_pymessage != NULL);
 
 @[for field in spec.fields]@
   PyObject * py@(field.name) = NULL;
@@ -161,8 +161,8 @@ PyObject * @(spec.base_type.pkg_name)_@(module_name)__convert_to_py(void * raw_r
 @[end if]@
   assert(py@(field.name) != NULL);
   Py_INCREF(py@(field.name));
-  PyObject_SetAttrString(pymessage, "@(field.name)", py@(field.name));
+  PyObject_SetAttrString(_pymessage, "@(field.name)", py@(field.name));
 @[end for]@
-  assert(pymessage != NULL);
-  return pymessage;
+  assert(_pymessage != NULL);
+  return _pymessage;
 }


### PR DESCRIPTION
Change pymessage to _pymessage to avoid possible conflict when a message defines a field called 'message'. Exposed by turning on `diagnostics_msgs` in ros2/common_interfaces#14. Without this change, you get a compile error on the generated code like so:

~~~
/home/gerkey/code/ros12-joy/build/diagnostics_msgs/rosidl_generator_py/diagnostics_msgs/msg/_diagnostic_status_s.c: In function ‘diagnostics_msgs_diagnostic_status__convert_to_py’:
/home/gerkey/code/ros12-joy/build/diagnostics_msgs/rosidl_generator_py/diagnostics_msgs/msg/_diagnostic_status_s.c:94:14: error: redefinition of ‘pymessage’
   PyObject * pymessage = NULL;
              ^
/home/gerkey/code/ros12-joy/build/diagnostics_msgs/rosidl_generator_py/diagnostics_msgs/msg/_diagnostic_status_s.c:75:13: note: previous definition of ‘pymessage’ was here
   PyObject *pymessage = NULL;
~~~