### PR TITLE
fix hardcoded rmw impl names

### DIFF
--- a/rosidl_generator_py/rosidl_generator_py/import_type_support_impl.py
+++ b/rosidl_generator_py/rosidl_generator_py/import_type_support_impl.py
@@ -15,8 +15,8 @@
 import importlib
 
 type_support_map = {
-    'connext_static': 'rosidl_typesupport_connext_c',
-    'opensplice_static': 'rosidl_typesupport_opensplice_c',
+    'rmw_connext_cpp': 'rosidl_typesupport_connext_c',
+    'rmw_opensplice_cpp': 'rosidl_typesupport_opensplice_c',
 }
 
 


### PR DESCRIPTION
The build is broken right now because I changed the identifier names. After the register language of typesupport branches are merged (see ros2/rmw#63) this map can be replaced with the ament index.