### PR TITLE
fix PEP257 warning D211

### DIFF
--- a/rosidl_generator_py/rosidl_generator_py/import_type_support_impl.py
+++ b/rosidl_generator_py/rosidl_generator_py/import_type_support_impl.py
@@ -21,7 +21,6 @@ type_support_map = {
 
 
 class UnsupportedTypeSupport(Exception):
-
     """Raised when no supported type support can be found for a given rmw implementation."""
 
     def __init__(self, rmw_implementation):


### PR DESCRIPTION
Since we don't want to follow D203 (ament/ament_lint#47) I assume we will follow D211 (which is checked by newer versions of `pydocstyle`).