### PR TITLE
Resize for C arrays

### DIFF
--- a/rosidl_generator_c/include/rosidl_generator_c/string_functions.h
+++ b/rosidl_generator_c/include/rosidl_generator_c/string_functions.h
@@ -62,12 +62,6 @@ void
 rosidl_generator_c__String__Array__destroy(
   rosidl_generator_c__String__Array * array);
 
-ROSIDL_GENERATOR_C_PUBLIC
-bool
-rosidl_generator_c__String__Array__resize(
-  rosidl_generator_c__String__Array * array, size_t size);
-
-
 #if __cplusplus
 }
 #endif

--- a/rosidl_generator_c/include/rosidl_generator_c/string_functions.h
+++ b/rosidl_generator_c/include/rosidl_generator_c/string_functions.h
@@ -62,6 +62,12 @@ void
 rosidl_generator_c__String__Array__destroy(
   rosidl_generator_c__String__Array * array);
 
+ROSIDL_GENERATOR_C_PUBLIC
+bool
+rosidl_generator_c__String__Array__resize(
+  rosidl_generator_c__String__Array * array, size_t size);
+
+
 #if __cplusplus
 }
 #endif

--- a/rosidl_generator_c/resource/msg__functions.c.template
+++ b/rosidl_generator_c/resource/msg__functions.c.template
@@ -211,14 +211,14 @@ void
 @# array functions
 @#######################################################################
 bool
-@(array_typename)__init(@(array_typename) * array, size_t size, size_t capacity)
+@(array_typename)__init(@(array_typename) * array, size_t size)
 {
   if (!array) {
     return false;
   }
   @(msg_typename) * data = NULL;
   if (size) {
-    data = (@(msg_typename) *)malloc(sizeof(@(msg_typename)) * capacity);
+    data = (@(msg_typename) *)malloc(sizeof(@(msg_typename)) * size);
     if (!data) {
       return false;
     }
@@ -238,13 +238,10 @@ bool
       free(data);
       return false;
     }
-    for (i = size; i < capacity; ++i) {
-      data[i] = {0};  // ???
-    }
   }
   array->data = data;
   array->size = size;
-  array->capacity = capacity;
+  array->capacity = size;
   return true;
 }
 
@@ -255,7 +252,7 @@ void
     return;
   }
   if (array->data) {
-    // ensure that data and capacity values are consistent
+    // ensure that data acapacity values are consistent
     assert(array->capacity > 0);
     // finalize all array elements
     for (size_t i = 0; i < array->capacity; ++i) {
@@ -270,16 +267,6 @@ void
     assert(0 == array->size);
     assert(0 == array->capacity);
   }
-}
-
-bool
-@(array_typename)__resize(@(array_typename) * array, size_t size, size_t capacity)
-{
-  if (!array) {
-    return false;
-  }
-  @(array_typename)__fini(array);
-  return @(array_typename)__init(array, capacity);
 }
 
 @(array_typename) *
@@ -304,4 +291,15 @@ void
     @(array_typename)__fini(array);
   }
   free(array);
+}
+
+bool
+@(array_typename)__resize(@(array_typename) * array, size_t size)
+{
+  if (!array)
+  {
+    return false;
+  }
+  @(array_typename)__fini(array);
+  return @(array_typename)__init(array, size);
 }

--- a/rosidl_generator_c/resource/msg__functions.c.template
+++ b/rosidl_generator_c/resource/msg__functions.c.template
@@ -207,19 +207,18 @@ void
   free(msg);
 }
 
-
 @#######################################################################
 @# array functions
 @#######################################################################
 bool
-@(array_typename)__init(@(array_typename) * array, size_t size)
+@(array_typename)__init(@(array_typename) * array, size_t size, size_t capacity)
 {
   if (!array) {
     return false;
   }
   @(msg_typename) * data = NULL;
   if (size) {
-    data = (@(msg_typename) *)malloc(sizeof(@(msg_typename)) * size);
+    data = (@(msg_typename) *)malloc(sizeof(@(msg_typename)) * capacity);
     if (!data) {
       return false;
     }
@@ -239,10 +238,13 @@ bool
       free(data);
       return false;
     }
+    for (i = size; i < capacity; ++i) {
+      data[i] = {0};  // ???
+    }
   }
   array->data = data;
   array->size = size;
-  array->capacity = size;
+  array->capacity = capacity;
   return true;
 }
 
@@ -268,6 +270,16 @@ void
     assert(0 == array->size);
     assert(0 == array->capacity);
   }
+}
+
+bool
+@(array_typename)__resize(@(array_typename) * array, size_t size, size_t capacity)
+{
+  if (!array) {
+    return false;
+  }
+  @(array_typename)__fini(array);
+  return @(array_typename)__init(array, capacity);
 }
 
 @(array_typename) *

--- a/rosidl_generator_c/resource/msg__functions.h.template
+++ b/rosidl_generator_c/resource/msg__functions.h.template
@@ -86,6 +86,17 @@ ROSIDL_GENERATOR_C_PUBLIC_@(spec.base_type.pkg_name)
 void
 @(msg_typename)__destroy(@(msg_typename) * msg);
 
+@# If the message contains an unbounded array subfield, declare a resize function for that type
+@[for field in spec.fields]@
+@{
+    if not field.type.is_array:
+        continue
+    if field.type.is_fixed_size_array():
+        continue
+}@
+
+
+
 
 @#######################################################################
 @# array functions
@@ -102,7 +113,7 @@ void
  */
 ROSIDL_GENERATOR_C_PUBLIC_@(spec.base_type.pkg_name)
 bool
-@(array_typename)__init(@(array_typename) * array, size_t size);
+@(array_typename)__init(@(array_typename) * array, size_t size, size_t capacity);
 
 /// Finalize array of @(spec.base_type.pkg_name)/@(spec.base_type.type) messages.
 /**
@@ -113,6 +124,21 @@ bool
 ROSIDL_GENERATOR_C_PUBLIC_@(spec.base_type.pkg_name)
 void
 @(array_typename)__fini(@(array_typename) * array);
+
+// TODO Enable only for unbounded messages
+/// Resize array of @(spec.base_type.pkg_name)/@(spec.base_type.type) messages.
+/**
+ * Convenience method for deallocating and reallocating the array.
+ * The existing contents of the array will be erased.
+ * 
+ * \param[in] array The initialized array pointer.
+ * \param[in] capacity The new capacity of the array.
+ * \return The reallocated pointer. NULL if reallocating was not successful
+ * or if the array input was NULL.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_@(spec.base_type.pkg_name)
+@(array_typename) * array
+@(array_typename)__resize(@(array_typename) * array, size_t capacity);
 
 /// Create array of @(spec.base_type.pkg_name)/@(spec.base_type.type) messages.
 /**

--- a/rosidl_generator_c/resource/msg__functions.h.template
+++ b/rosidl_generator_c/resource/msg__functions.h.template
@@ -86,14 +86,63 @@ ROSIDL_GENERATOR_C_PUBLIC_@(spec.base_type.pkg_name)
 void
 @(msg_typename)__destroy(@(msg_typename) * msg);
 
-@# If the message contains an unbounded array subfield, declare a resize function for that type
-@[for field in spec.fields]@
+@# If the message contains an unbounded non-primitive array subfield, declare a resize function
 @{
+unbounded_array_fields = []
+for field in spec.fields:
     if not field.type.is_array:
         continue
     if field.type.is_fixed_size_array():
         continue
+#    if field.type.is_primitive_type():
+#        continue
+
+    unbounded_array_fields.append(field)
 }@
+
+@[for field in unbounded_array_fields]
+@{
+if field.type.is_primitive_type():
+    subfield_pkg_name = 'rosidl_generator_c'
+    if field.type.type == 'string':
+        subfield_type_name = 'String'
+    else:
+        subfield_type_name = field.type.type
+
+    subfield_array_typename = '%s__%s__Array' % (subfield_pkg_name, subfield_type_name)
+else:
+    subfield_pkg_name = field.type.pkg_name
+    subfield_type_name = field.type.type
+    subfield_array_typename = '%s__msg__%s__Array' % (subfield_pkg_name, subfield_type_name)
+
+subfield_array_decl_guard = '%s__%s__UNBOUNDED_ARRAY__RESIZE_DECL' % (subfield_pkg_name, subfield_type_name)
+}@
+#ifndef @(subfield_array_decl_guard)
+#define @(subfield_array_decl_guard)
+@[if field.type.is_primitive_type()]
+@[  if field.type.type is 'string']
+#include "rosidl_generator_c/string_functions.h"
+@[  else]
+#include "rosidl_generator_c/primitives_array_functions.h"
+@[  end if]
+@[else]
+@{
+subfield_header_file = '%s/msg/%s__functions.h' % (subfield_pkg_name, get_header_filename_from_msg_name(subfield_type_name))
+}@
+#include "@(subfield_header_file)"
+@[end if]
+
+@[if field.type.is_primitive_type()]@
+ROSIDL_GENERATOR_C_PUBLIC
+@[else]
+ROSIDL_GENERATOR_C_PUBLIC_@(subfield_pkg_name)
+@[end if]
+bool
+@(subfield_array_typename)__resize(@(subfield_array_typename) * array, size_t size);
+
+#endif  // @(subfield_array_decl_guard)
+
+@[end for]
 
 
 
@@ -113,7 +162,7 @@ void
  */
 ROSIDL_GENERATOR_C_PUBLIC_@(spec.base_type.pkg_name)
 bool
-@(array_typename)__init(@(array_typename) * array, size_t size, size_t capacity);
+@(array_typename)__init(@(array_typename) * array, size_t size);
 
 /// Finalize array of @(spec.base_type.pkg_name)/@(spec.base_type.type) messages.
 /**
@@ -136,9 +185,11 @@ void
  * \return The reallocated pointer. NULL if reallocating was not successful
  * or if the array input was NULL.
  */
+/*
 ROSIDL_GENERATOR_C_PUBLIC_@(spec.base_type.pkg_name)
 @(array_typename) * array
 @(array_typename)__resize(@(array_typename) * array, size_t capacity);
+*/
 
 /// Create array of @(spec.base_type.pkg_name)/@(spec.base_type.type) messages.
 /**

--- a/rosidl_generator_c/src/primitives_array_functions.c
+++ b/rosidl_generator_c/src/primitives_array_functions.c
@@ -56,6 +56,16 @@
       assert(0 == array->size); \
       assert(0 == array->capacity); \
     } \
+  } \
+  bool rosidl_generator_c__ ## STRUCT_NAME ## __Array__resize( \
+    rosidl_generator_c__ ## STRUCT_NAME ## __Array * array, size_t size) \
+  { \
+    if (!array) \
+    { \
+      return false; \
+    } \
+    rosidl_generator_c__ ## STRUCT_NAME ## __Array__fini(array); \
+    return rosidl_generator_c__ ## STRUCT_NAME ## __Array__init(array, size); \
   }
 
 // array functions for all primitive types

--- a/rosidl_generator_c/src/string_functions.c
+++ b/rosidl_generator_c/src/string_functions.c
@@ -166,3 +166,15 @@ rosidl_generator_c__String__Array__destroy(
   }
   free(array);
 }
+
+bool
+rosidl_generator_c__String__Array__resize(
+  rosidl_generator_c__String__Array * array,
+  size_t size)
+{
+  //if (array) {
+  rosidl_generator_c__String__Array__fini(array);
+  //}
+  //free(array);
+  return rosidl_generator_c__String__Array__init(array, size);
+}


### PR DESCRIPTION
This is a work in progress. Here are some issues I thought of while working on this. Tagging @wjwwood since he wrote `rosidl_generator_c` originally, in case he finds this thought-provoking.

It would be convenient to have a "resize" function for `rosidl_generator_c` arrays, especially since unbounded arrays are initialized to have a size of zero.

The Parameter API uses unbounded arrays of `ParameterValue` messages, so I was motivated to look into this while sketching out use cases for C parameters.

The most basic case of "resize" simply calls `fini` then `init` on an existing Array message structure with a new `size` parameter. You can think of another case where the existing data is copied into the newly allocated data but I think it's okay not to implement that for now.

It is consistent with the intention of the design of the message interfaces to make `resize` only available for unbounded arrays.

However the existing array struct definitions do not distinguish between bounded and unbounded arrays.

This initial implementation introduces a very brittle and hackish pattern in which:

If message A has a subfield B where B is an unbounded array, then the header for message A declares a resize method for message B.
All messages define a "resize" method in their .c file.

This prototype compiles, but my question is: is this pattern OK? Should we instead move towards an implementation that distinguishes Bounded and Unbounded arrays (then bounded arrays could enforce a limit on their capacities)? The bounded/unbounded/static definition seems poorly defined in both `rosidl_generator_c` and `rosidl_generator_cpp`.

As a side note, `resize` implicitly calls `malloc` and free because that's what `init` and `fini` use. Should `rosidl_generator_c` have an allocator interface like rcl? I'm ok with not addressing this right now, but it's something to consider.
