### PR TITLE
Fix generator being invoked multiple times

### DIFF
--- a/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
@@ -77,6 +77,9 @@ if(NOT "${_generated_msg_py_files} " STREQUAL " ")
   list(APPEND _generated_msg_py_files
     "${_parent_folder}/__init__.py"
   )
+  # TODO(dirk-thomas) since this are being generated at configure time
+  # it should not be a dependency of the custom command
+  file(WRITE "${_parent_folder}/__init__.py" "")
 endif()
 
 if(NOT "${_generated_srv_files} " STREQUAL " ")
@@ -85,6 +88,9 @@ if(NOT "${_generated_srv_files} " STREQUAL " ")
   list(APPEND _generated_srv_files
     "${_parent_folder}/__init__.py"
   )
+  # TODO(dirk-thomas) since this are being generated at configure time
+  # it should not be a dependency of the custom command
+  file(WRITE "${_parent_folder}/__init__.py" "")
 endif()
 
 set(_dependency_files "")

--- a/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
@@ -156,8 +156,6 @@ if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
   )
 endif()
 
-set(_generated_extension_files "")
-set(_extension_dependencies "")
 set(_target_suffix "__py")
 
 add_custom_command(
@@ -179,9 +177,6 @@ else()
     ${_generated_msg_py_files}
     ${_generated_msg_c_files}
     ${_generated_srv_files}
-    ${_generated_extension_files}
-    ${_extension_dependencies}
-    ${rosidl_generate_interfaces_TARGET}__rosidl_generator_c
   )
 endif()
 
@@ -229,10 +224,6 @@ foreach(_typesupport_impl ${_typesupport_impls})
     ${PROJECT_NAME}__${_typesupport_impl}
   )
 
-  list(APPEND _generated_extension_files
-    "$<TARGET_FILE:${_target_name}>"
-  )
-
   target_include_directories(${_target_name}
     PUBLIC
     ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_c
@@ -249,8 +240,6 @@ foreach(_typesupport_impl ${_typesupport_impls})
     "rosidl_generator_c"
     "${_typesupport_impl}"
   )
-
-  list(APPEND _extension_dependencies ${_target_name})
 
   ament_target_dependencies(${_target_name}
     ${_typesupport_impl}

--- a/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
+++ b/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
@@ -65,8 +65,7 @@ def generate_py(generator_arguments_file, typesupport_impls):
     for ros_interface_file in args['ros_interface_files']:
         extension = os.path.splitext(ros_interface_file)[1]
         subfolder = os.path.basename(os.path.dirname(ros_interface_file))
-        # TODO(mikael) remove subfolder condition when implementing services
-        if extension == '.msg' and subfolder == 'msg':
+        if extension == '.msg':
             spec = parse_message_file(args['package_name'], ros_interface_file)
             message_specs.append((spec, subfolder))
             mapping = mapping_msgs

--- a/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
+++ b/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
@@ -85,7 +85,6 @@ def generate_py(generator_arguments_file, typesupport_impls):
                     'module_name': module_name, 'package_name': args['package_name'],
                     'spec': spec, 'subfolder': subfolder,
                     'typesupport_impl': type_support_impl_by_filename.get(generated_filename, ''),
-                    'typesupport_impls': typesupport_impls
                 }
                 data.update(functions)
                 generated_file = os.path.join(
@@ -106,7 +105,6 @@ def generate_py(generator_arguments_file, typesupport_impls):
                 'package_name': args['package_name'],
                 'message_specs': message_specs,
                 'typesupport_impl': type_support_impl_by_filename.get(generated_filename, ''),
-                'typesupport_impls': typesupport_impls
             }
             data.update(functions)
             generated_file = os.path.join(


### PR DESCRIPTION
The reason the custom command was retriggered was that the files being promised to be generated included the Request / Response messages as well as the `__init__` files. But the generator didn't actually generate them.

Fixes #124.