### PR TITLE
Lint generated code

### DIFF
--- a/rosidl_cmake/rosidl_cmake/__init__.py
+++ b/rosidl_cmake/rosidl_cmake/__init__.py
@@ -17,6 +17,7 @@ from io import StringIO
 import json
 import os
 import re
+import sys
 
 from rosidl_parser import BaseType
 from rosidl_parser import PACKAGE_NAME_MESSAGE_TYPE_SEPARATOR
@@ -90,6 +91,7 @@ def expand_template(template_file, data, output_file, minimum_timestamp=None):
         except Exception:
             if os.path.exists(output_file):
                 os.remove(output_file)
+            print('Exception when processing template: %s' % template_file, file=sys.stderr)
             raise
     content = output.getvalue()
     interpreter.shutdown()

--- a/rosidl_generator_c/cmake/rosidl_generator_c_generate_interfaces.cmake
+++ b/rosidl_generator_c/cmake/rosidl_generator_c_generate_interfaces.cmake
@@ -111,6 +111,7 @@ add_custom_command(
 # generate header to switch between export and import for a specific package
 set(_visibility_control_file
   "${_output_path}/msg/rosidl_generator_c__visibility_control.h")
+string(TOUPPER "${PROJECT_NAME}" PROJECT_NAME_UPPER)
 configure_file(
   "${rosidl_generator_c_TEMPLATE_DIR}/rosidl_generator_c__visibility_control.h.in"
   "${_visibility_control_file}"

--- a/rosidl_generator_c/cmake/rosidl_generator_c_generate_interfaces.cmake
+++ b/rosidl_generator_c/cmake/rosidl_generator_c_generate_interfaces.cmake
@@ -172,3 +172,30 @@ if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
   )
   ament_export_include_directories(include)
 endif()
+
+if(NOT "${_generated_msg_headers}${_generated_msg_sources}${_generated_srv_headers}${_generated_srv_sources} " STREQUAL " ")
+  find_package(ament_cmake_cppcheck)
+  if(ament_cmake_cppcheck_FOUND)
+    ament_cppcheck(
+      TESTNAME "cppcheck_rosidl_generated_c"
+      "${_output_path}")
+  endif()
+  find_package(ament_cmake_cpplint)
+  if(ament_cmake_cpplint_FOUND)
+    get_filename_component(_cpplint_root "${_output_path}" DIRECTORY)
+    ament_cpplint(
+      TESTNAME "cpplint_rosidl_generated_c"
+      # the generated code might contain longer lines for templated types
+      MAX_LINE_LENGTH 999
+      ROOT "${_cpplint_root}"
+      "${_output_path}")
+  endif()
+  find_package(ament_cmake_uncrustify)
+  if(ament_cmake_uncrustify_FOUND)
+    ament_uncrustify(
+      TESTNAME "uncrustify_rosidl_generated_c"
+      # the generated code might contain longer lines for templated types
+      MAX_LINE_LENGTH 999
+      "${_output_path}")
+  endif()
+endif()

--- a/rosidl_generator_c/resource/msg__functions.h.template
+++ b/rosidl_generator_c/resource/msg__functions.h.template
@@ -20,7 +20,7 @@ from rosidl_generator_c import value_to_c
 header_guard_parts = [
     spec.base_type.pkg_name, subfolder,
     get_header_filename_from_msg_name(spec.base_type.type) + '__functions_h']
-header_guard_variable = '__'.join([x for x in header_guard_parts]) + '_'
+header_guard_variable = '__'.join([x.upper() for x in header_guard_parts]) + '_'
 
 msg_typename = '%s__%s__%s' % (spec.base_type.pkg_name, subfolder, spec.base_type.type)
 array_typename = '%s__Array' % msg_typename

--- a/rosidl_generator_c/resource/msg__type_support.h.template
+++ b/rosidl_generator_c/resource/msg__type_support.h.template
@@ -46,7 +46,7 @@ extern "C"
 // Forward declare the get type support functions for this type.
 ROSIDL_GENERATOR_C_PUBLIC_@(spec.base_type.pkg_name)
 const rosidl_message_type_support_t *
-ROSIDL_GET_TYPE_SUPPORT_FUNCTION(@(pkg), @(subfolder), @(type))();
+  ROSIDL_GET_TYPE_SUPPORT_FUNCTION(@(pkg), @(subfolder), @(type))();
 
 #if __cplusplus
 }

--- a/rosidl_generator_c/resource/rosidl_generator_c__visibility_control.h.in
+++ b/rosidl_generator_c/resource/rosidl_generator_c__visibility_control.h.in
@@ -1,7 +1,8 @@
 // generated from rosidl_generator_c/resource/rosidl_generator_c__visibility_control.h.in
+// generated code does not contain a copyright notice
 
-#ifndef @PROJECT_NAME@__MSG__ROSIDL_GENERATOR_C__VISIBILITY_CONTROL__H_
-#define @PROJECT_NAME@__MSG__ROSIDL_GENERATOR_C__VISIBILITY_CONTROL__H_
+#ifndef @PROJECT_NAME_UPPER@__MSG__ROSIDL_GENERATOR_C__VISIBILITY_CONTROL_H_
+#define @PROJECT_NAME_UPPER@__MSG__ROSIDL_GENERATOR_C__VISIBILITY_CONTROL_H_
 
 #if __cplusplus
 extern "C"
@@ -13,30 +14,22 @@ extern "C"
 
 #if defined _WIN32 || defined __CYGWIN__
   #ifdef __GNUC__
-    #define ROSIDL_GENERATOR_C_EXPORT_@PROJECT_NAME@ \
-      __attribute__ ((dllexport))
-    #define ROSIDL_GENERATOR_C_IMPORT_@PROJECT_NAME@ \
-      __attribute__ ((dllimport))
+    #define ROSIDL_GENERATOR_C_EXPORT_@PROJECT_NAME@ __attribute__ ((dllexport))
+    #define ROSIDL_GENERATOR_C_IMPORT_@PROJECT_NAME@ __attribute__ ((dllimport))
   #else
-    #define ROSIDL_GENERATOR_C_EXPORT_@PROJECT_NAME@ \
-      __declspec(dllexport)
-    #define ROSIDL_GENERATOR_C_IMPORT_@PROJECT_NAME@ \
-      __declspec(dllimport)
+    #define ROSIDL_GENERATOR_C_EXPORT_@PROJECT_NAME@ __declspec(dllexport)
+    #define ROSIDL_GENERATOR_C_IMPORT_@PROJECT_NAME@ __declspec(dllimport)
   #endif
   #ifdef ROSIDL_GENERATOR_C_BUILDING_DLL_@PROJECT_NAME@
-    #define ROSIDL_GENERATOR_C_PUBLIC_@PROJECT_NAME@ \
-      ROSIDL_GENERATOR_C_EXPORT_@PROJECT_NAME@
+    #define ROSIDL_GENERATOR_C_PUBLIC_@PROJECT_NAME@ ROSIDL_GENERATOR_C_EXPORT_@PROJECT_NAME@
   #else
-    #define ROSIDL_GENERATOR_C_PUBLIC_@PROJECT_NAME@ \
-      ROSIDL_GENERATOR_C_IMPORT_@PROJECT_NAME@
+    #define ROSIDL_GENERATOR_C_PUBLIC_@PROJECT_NAME@ ROSIDL_GENERATOR_C_IMPORT_@PROJECT_NAME@
   #endif
 #else
-  #define ROSIDL_GENERATOR_C_EXPORT_@PROJECT_NAME@ \
-    __attribute__ ((visibility("default")))
+  #define ROSIDL_GENERATOR_C_EXPORT_@PROJECT_NAME@ __attribute__ ((visibility("default")))
   #define ROSIDL_GENERATOR_C_IMPORT_@PROJECT_NAME@
   #if __GNUC__ >= 4
-    #define ROSIDL_GENERATOR_C_PUBLIC_@PROJECT_NAME@ \
-      __attribute__ ((visibility("default")))
+    #define ROSIDL_GENERATOR_C_PUBLIC_@PROJECT_NAME@ __attribute__ ((visibility("default")))
   #else
     #define ROSIDL_GENERATOR_C_PUBLIC_@PROJECT_NAME@
   #endif
@@ -46,4 +39,4 @@ extern "C"
 }
 #endif
 
-#endif  // @PROJECT_NAME@__MSG__ROSIDL_GENERATOR_C__VISIBILITY_CONTROL__H_
+#endif  // @PROJECT_NAME_UPPER@__MSG__ROSIDL_GENERATOR_C__VISIBILITY_CONTROL_H_

--- a/rosidl_generator_c/resource/srv.h.template
+++ b/rosidl_generator_c/resource/srv.h.template
@@ -38,7 +38,7 @@ extern "C"
 // Forward declare the get type support functions for this type.
 ROSIDL_GENERATOR_C_PUBLIC_@(spec.pkg_name)
 const rosidl_service_type_support_t *
-ROSIDL_GET_TYPE_SUPPORT_FUNCTION(@(spec.pkg_name), srv, @(spec.srv_name))();
+  ROSIDL_GET_TYPE_SUPPORT_FUNCTION(@(spec.pkg_name), srv, @(spec.srv_name))();
 
 #if defined(__cplusplus)
 }

--- a/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_interfaces.cmake
+++ b/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_interfaces.cmake
@@ -117,3 +117,30 @@ if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
   endif()
   ament_export_include_directories(include)
 endif()
+
+if(NOT "${_generated_msg_files}${_generated_srv_files} " STREQUAL " ")
+  find_package(ament_cmake_cppcheck)
+  if(ament_cmake_cppcheck_FOUND)
+    ament_cppcheck(
+      TESTNAME "cppcheck_rosidl_generated_cpp"
+      "${_output_path}")
+  endif()
+  find_package(ament_cmake_cpplint)
+  if(ament_cmake_cpplint_FOUND)
+    get_filename_component(_cpplint_root "${_output_path}" DIRECTORY)
+    ament_cpplint(
+      TESTNAME "cpplint_rosidl_generated_cpp"
+      # the generated code might contain longer lines for templated types
+      MAX_LINE_LENGTH 999
+      ROOT "${_cpplint_root}"
+      "${_output_path}")
+  endif()
+  find_package(ament_cmake_uncrustify)
+  if(ament_cmake_uncrustify_FOUND)
+    ament_uncrustify(
+      TESTNAME "uncrustify_rosidl_generated_cpp"
+      # the generated code might contain longer lines for templated types
+      MAX_LINE_LENGTH 999
+      "${_output_path}")
+  endif()
+endif()

--- a/rosidl_generator_cpp/resource/msg__struct.hpp.template
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.template
@@ -46,11 +46,16 @@ cpp_full_name_with_alloc = '%s<ContainerAllocator>' % (cpp_full_name)
 
 // include message dependencies
 @{
+includes = {}
 for field in spec.fields:
     if not field.type.is_primitive_type():
-        print(
-            '#include "%s/msg/%s.hpp"  // %s' %
-            (field.type.pkg_name, get_header_filename_from_msg_name(field.type.type), field.name))
+        key = '%s/msg/%s.hpp' % \
+            (field.type.pkg_name, get_header_filename_from_msg_name(field.type.type))
+        if key not in includes:
+            includes[key] = set([])
+        includes[key].add(field.name)
+for key in sorted(includes.keys()):
+    print('#include "%s"  // %s' % (key, ', '.join(includes[key])))
 }@
 
 @{
@@ -149,31 +154,31 @@ for field in spec.fields:
 
   // pointer types
   using RawPtr =
-    @(cpp_full_name)<ContainerAllocator> *;
+      @(cpp_full_name)<ContainerAllocator> *;
   using ConstRawPtr =
-    const @(cpp_full_name)<ContainerAllocator> *;
+      const @(cpp_full_name)<ContainerAllocator> *;
   using SharedPtr =
-    std::shared_ptr<@(cpp_full_name)<ContainerAllocator>>;
+      std::shared_ptr<@(cpp_full_name)<ContainerAllocator>>;
   using ConstSharedPtr =
-    std::shared_ptr<@(cpp_full_name)<ContainerAllocator> const>;
+      std::shared_ptr<@(cpp_full_name)<ContainerAllocator> const>;
 
   template<typename Deleter = std::default_delete<
     @(cpp_full_name)<ContainerAllocator>>>
   using UniquePtrWithDeleter =
-    std::unique_ptr<@(cpp_full_name)<ContainerAllocator>, Deleter>;
+      std::unique_ptr<@(cpp_full_name)<ContainerAllocator>, Deleter>;
 
   using UniquePtr = UniquePtrWithDeleter<>;
 
   template<typename Deleter = std::default_delete<
     @(cpp_full_name)<ContainerAllocator>>>
   using ConstUniquePtrWithDeleter =
-    std::unique_ptr<@(cpp_full_name)<ContainerAllocator> const, Deleter>;
+      std::unique_ptr<@(cpp_full_name)<ContainerAllocator> const, Deleter>;
   using ConstUniquePtr = ConstUniquePtrWithDeleter<>;
 
   using WeakPtr =
-    std::weak_ptr<@(cpp_full_name)<ContainerAllocator>>;
+      std::weak_ptr<@(cpp_full_name)<ContainerAllocator>>;
   using ConstWeakPtr =
-    std::weak_ptr<@(cpp_full_name)<ContainerAllocator> const>;
+      std::weak_ptr<@(cpp_full_name)<ContainerAllocator> const>;
 
   // pointer types similar to ROS 1, use SharedPtr / ConstSharedPtr instead
   // NOTE: Can't use 'using' here because GNU C++ can't parse attributes properly

--- a/rosidl_generator_cpp/resource/msg__struct.hpp.template
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.template
@@ -84,6 +84,9 @@ struct @(spec.base_type.type)_
 @[for (alloc_type, alloc_name) in [['', ''], ['const ContainerAllocator & ', '_alloc']]]@
   @('explicit ' if alloc_type else '')@(spec.base_type.type)_(@(alloc_type + alloc_name))
 @# generate initializer lists
+@[if alloc_name == '_alloc']@
+// *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
+@[end if]@
 @{
 used_alloc_name = False
 leading_colon = ':'
@@ -107,6 +110,9 @@ for field in spec.fields:
 if leading_colon == ' ':
     print()
 }@
+@[if alloc_name == '_alloc']@
+// *INDENT-ON*
+@[end if]@
   {
 @# generate constructor body
 @[if alloc_name and not used_alloc_name]@

--- a/rosidl_generator_cpp/resource/msg__traits.hpp.template
+++ b/rosidl_generator_cpp/resource/msg__traits.hpp.template
@@ -67,8 +67,8 @@ else:
 }@
 
 template<>
-struct has_fixed_size<@(cpp_namespace)@(spec.base_type.type)> :
-std::integral_constant<bool, @(fixed_template_string)> {};
+struct has_fixed_size<@(cpp_namespace)@(spec.base_type.type)>
+  : std::integral_constant<bool, @(fixed_template_string)>{};
 
 }  // namespace rosidl_generator_traits
 

--- a/rosidl_generator_cpp/resource/srv.hpp.template
+++ b/rosidl_generator_cpp/resource/srv.hpp.template
@@ -1,4 +1,5 @@
 // generated from rosidl_generator_cpp/resource/srv.hpp.template
+// generated code does not contain a copyright notice
 
 @#######################################################################
 @# EmPy template for generating <srv>.hpp files
@@ -9,10 +10,16 @@
 @#  - get_header_filename_from_msg_name (function)
 @#######################################################################
 @
-#ifndef __@(spec.pkg_name)__srv__@(get_header_filename_from_msg_name(spec.srv_name))__hpp__
-#define __@(spec.pkg_name)__srv__@(get_header_filename_from_msg_name(spec.srv_name))__hpp__
+@{
+header_guard_parts = [
+    spec.pkg_name, 'srv',
+    get_header_filename_from_msg_name(spec.srv_name) + '_hpp']
+header_guard_variable = '__'.join([x.upper() for x in header_guard_parts]) + '_'
+}@
+#ifndef @(header_guard_variable)
+#define @(header_guard_variable)
 
 #include "@(spec.pkg_name)/srv/@(get_header_filename_from_msg_name(spec.srv_name))__traits.hpp"
 #include "@(spec.pkg_name)/srv/@(get_header_filename_from_msg_name(spec.srv_name))__struct.hpp"
 
-#endif  // __@(spec.pkg_name)__srv__@(get_header_filename_from_msg_name(spec.srv_name))__hpp__
+#endif  // @(header_guard_variable)

--- a/rosidl_generator_cpp/resource/srv__struct.hpp.template
+++ b/rosidl_generator_cpp/resource/srv__struct.hpp.template
@@ -1,4 +1,5 @@
 // generated from rosidl_generator_cpp/resource/msg__struct.hpp.template
+// generated code does not contain a copyright notice
 
 @#######################################################################
 @# EmPy template for generating <srv>__struct.hpp files
@@ -9,8 +10,14 @@
 @#  - get_header_filename_from_msg_name (function)
 @#######################################################################
 @
-#ifndef __@(spec.pkg_name)__srv__@(get_header_filename_from_msg_name(spec.srv_name))__struct__hpp__
-#define __@(spec.pkg_name)__srv__@(get_header_filename_from_msg_name(spec.srv_name))__struct__hpp__
+@{
+header_guard_parts = [
+    spec.pkg_name, 'srv',
+    get_header_filename_from_msg_name(spec.srv_name) + '__struct_hpp']
+header_guard_variable = '__'.join([x.upper() for x in header_guard_parts]) + '_'
+}@
+#ifndef @(header_guard_variable)
+#define @(header_guard_variable)
 
 #include "@(spec.pkg_name)/srv/@(get_header_filename_from_msg_name(spec.srv_name))__request.hpp"
 #include "@(spec.pkg_name)/srv/@(get_header_filename_from_msg_name(spec.srv_name))__response.hpp"
@@ -31,4 +38,4 @@ struct @(spec.srv_name)
 
 }  // namespace @(spec.pkg_name)
 
-#endif  // __@(spec.pkg_name)__srv__@(get_header_filename_from_msg_name(spec.srv_name))__struct__hpp__
+#endif  // @(header_guard_variable)

--- a/rosidl_generator_cpp/resource/srv__traits.hpp.template
+++ b/rosidl_generator_cpp/resource/srv__traits.hpp.template
@@ -1,4 +1,5 @@
 // generated from rosidl_generator_cpp/resource/srv__traits.hpp.template
+// generated code does not contain a copyright notice
 
 @#######################################################################
 @# EmPy template for generating <srv>__traits.hpp files
@@ -10,10 +11,17 @@
 @#######################################################################
 @
 @{
+header_guard_parts = [
+    spec.pkg_name, 'srv',
+    get_header_filename_from_msg_name(spec.srv_name) + '__traits_hpp']
+header_guard_variable = '__'.join([x.upper() for x in header_guard_parts]) + '_'
 cpp_namespace = '%s::srv::' % (spec.pkg_name)
 }@
 
 #include "@(spec.pkg_name)/srv/@(get_header_filename_from_msg_name(spec.srv_name))__struct.hpp"
+
+#ifndef @(header_guard_variable)
+#define @(header_guard_variable)
 
 namespace rosidl_generator_traits
 {
@@ -24,16 +32,18 @@ namespace rosidl_generator_traits
 template<typename T>
 struct has_fixed_size : std::false_type {};
 
-#endif  /* __ROSIDL_GENERATOR_CPP_TRAITS */
+#endif  // __ROSIDL_GENERATOR_CPP_TRAITS
 
-#ifndef __@(spec.pkg_name)__srv__@(get_header_filename_from_msg_name(spec.srv_name))__traits__hpp__
-#define __@(spec.pkg_name)__srv__@(get_header_filename_from_msg_name(spec.srv_name))__traits__hpp__
-template <>
-struct has_fixed_size<@(cpp_namespace)@(spec.srv_name)> :
-std::integral_constant<
-  bool,
-  has_fixed_size<@(cpp_namespace)@(spec.srv_name)_Request>::value &&
-  has_fixed_size<@(cpp_namespace)@(spec.srv_name)_Response>::value> {};
+template<>
+struct has_fixed_size<@(cpp_namespace)@(spec.srv_name)>
+  : std::integral_constant<
+    bool,
+    has_fixed_size<@(cpp_namespace)@(spec.srv_name)_Request>::value &&
+    has_fixed_size<@(cpp_namespace)@(spec.srv_name)_Response>::value
+  >
+{
+};
 
-#endif  // __@(spec.pkg_name)__srv__@(get_header_filename_from_msg_name(spec.srv_name))__traits__hpp__
-}  /* rosidl_generator_traits */
+}  // namespace rosidl_generator_traits
+
+#endif  // @(header_guard_variable)

--- a/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
@@ -255,3 +255,50 @@ foreach(_typesupport_impl ${_typesupport_impls})
       DESTINATION "${PYTHON_INSTALL_DIR}/${PROJECT_NAME}")
   endif()
 endforeach()
+
+if(NOT "${_generated_msg_py_files}${_generated_msg_c_files}${_generated_msg_c_common_files} " STREQUAL " ")
+  find_package(ament_cmake_cppcheck)
+  if(ament_cmake_cppcheck_FOUND)
+    ament_cppcheck(
+      TESTNAME "cppcheck_rosidl_generated_py"
+      "${_output_path}")
+  endif()
+  find_package(ament_cmake_cpplint)
+  if(ament_cmake_cpplint_FOUND)
+    get_filename_component(_cpplint_root "${_output_path}" DIRECTORY)
+    ament_cpplint(
+      TESTNAME "cpplint_rosidl_generated_py"
+      # the generated code might contain longer lines for templated types
+      MAX_LINE_LENGTH 999
+      ROOT "${_cpplint_root}"
+      "${_output_path}")
+  endif()
+  find_package(ament_cmake_pep8)
+  if(ament_cmake_pep8_FOUND)
+    ament_pep8(
+      TESTNAME "pep8_rosidl_generated_py"
+      # the generated code might contain longer lines for templated types
+      MAX_LINE_LENGTH 999
+      "${_output_path}")
+  endif()
+  find_package(ament_cmake_pep257)
+  if(ament_cmake_pep257_FOUND)
+    ament_pep257(
+      TESTNAME "pep257_rosidl_generated_py"
+      "${_output_path}")
+  endif()
+  find_package(ament_cmake_pyflakes)
+  if(ament_cmake_pyflakes_FOUND)
+    ament_pyflakes(
+      TESTNAME "pyflakes_rosidl_generated_py"
+    "${_output_path}")
+  endif()
+  find_package(ament_cmake_uncrustify)
+  if(ament_cmake_uncrustify_FOUND)
+    ament_uncrustify(
+      TESTNAME "uncrustify_rosidl_generated_py"
+      # the generated code might contain longer lines for templated types
+      MAX_LINE_LENGTH 999
+      "${_output_path}")
+  endif()
+endif()

--- a/rosidl_generator_py/resource/_msg.py.template
+++ b/rosidl_generator_py/resource/_msg.py.template
@@ -18,7 +18,8 @@ except ImportError:
 
 if __type_support_importable:
     rclpy_implementation = rclpy._rclpy.rclpy_get_rmw_implementation_identifier()
-    module = import_type_support('@(package_name)', '@(subfolder)', '@(module_name)', rclpy_implementation)
+    module = import_type_support(
+        '@(package_name)', '@(subfolder)', '@(module_name)', rclpy_implementation)
     _convert_from_py = module.convert_from_py_@(module_name)
     _convert_to_py = module.convert_to_py_@(module_name)
     _type_support = module.type_support_@(module_name)
@@ -58,7 +59,7 @@ class Metaclass(type):
     @@property
     def @(constant.name)(self):
         """Message constant '@(constant.name)'."""
-        return Constants.__constants['@(constant.name)']
+        return Metaclass.__constants['@(constant.name)']
 @[end for]@
 @[for field in spec.fields]@
 @[  if field.default_value]@
@@ -72,24 +73,27 @@ class Metaclass(type):
 
 
 class @(spec.base_type.type)(metaclass=Metaclass):
+@[if not spec.constants]@
+    """Message class '@(spec.base_type.type)'."""
+@[else]@
     """
     Message class '@(spec.base_type.type)'.
-@[if spec.constants]@
 
     Constants:
 @[  for constant in spec.constants]@
       @(constant.name)
 @[  end for]@
-@[end if]@
     """
+@[end if]@
 
     __slots__ = [
 @[for field in spec.fields]@
         '_@(field.name)',
 @[end for]@
     ]
-
+@
 @[if len(spec.fields) > 0]@
+
     def __init__(self, **kwargs):
         assert all(['_' + key in self.__slots__ for key in kwargs.keys()]), \
             "Invalid arguments passed to constructor: %r" % kwargs.keys()
@@ -98,7 +102,7 @@ class @(spec.base_type.type)(metaclass=Metaclass):
         self.@(field.name) = kwargs.get(
             '@(field.name)', @(spec.base_type.type).@(field.name.upper())__DEFAULT)
 @[    else]@
-@[      if not field.type.is_primitive_type()]@
+@[      if not field.type.is_primitive_type() and (not field.type.is_array or field.type.array_size)]@
         from @(field.type.pkg_name).msg import @(field.type.type)
 @[      end if]@
 @[      if field.type.type == 'byte']@
@@ -127,7 +131,7 @@ class @(spec.base_type.type)(metaclass=Metaclass):
 
     @@@(field.name).setter
     def @(field.name)(self, value):
-@[  if not field.type.is_primitive_type()]@
+@[  if not field.type.is_primitive_type() and ((field.type.is_array and not field.type.array_size) or (not field.type.is_array and not field.type.string_upper_bound))]@
         from @(field.type.pkg_name).msg import @(field.type.type)
 @[  end if]@
 @[  if field.type.is_array]@
@@ -145,30 +149,31 @@ class @(spec.base_type.type)(metaclass=Metaclass):
 @[  end if]@
         assert isinstance(value, type(None)) or \
 @[  if field.type.is_array]@
-            ((isinstance(value, Sequence) or isinstance(value, Set) \
-            or isinstance(value, UserList)) \
-            and not isinstance(value, str) and not isinstance(value, UserString) \
+            ((isinstance(value, Sequence) or
+              isinstance(value, Set) or
+              isinstance(value, UserList)) and
+             not isinstance(value, str) and
+             not isinstance(value, UserString) and
 @[    if field.type.array_size]@
 @[      if field.type.is_upper_bound]@
-            and len(value) <= @(field.type.array_size) \
+             len(value) <= @(field.type.array_size))
 @[      else]@
-            and len(value) == @(field.type.array_size) \
+             len(value) == @(field.type.array_size))
 @[      end if]@
-            and all([isinstance(v, @(get_python_type(field.type))) for v in value]))
 @[    else]@
-            )
+             all([isinstance(v, @(get_python_type(field.type))) for v in value]))
 @[    end if]@
 @[  elif field.type.string_upper_bound]@
-            ((isinstance(value, str) or isinstance(value, UserString)) \
-            and len(value) <= @(field.type.string_upper_bound))
+            ((isinstance(value, str) or isinstance(value, UserString)) and
+             len(value) <= @(field.type.string_upper_bound))
 @[  elif not field.type.is_primitive_type()]@
             isinstance(value, @(field.type.type))
 @[  elif field.type.type == 'byte']@
-            ((isinstance(value, bytes) or isinstance(value, ByteString)) \
-                and len(value) == 1)
+            ((isinstance(value, bytes) or isinstance(value, ByteString)) and
+             len(value) == 1)
 @[  elif field.type.type == 'char']@
-            ((isinstance(value, str) or isinstance(value, UserString)) \
-            and len(value) == 1)
+            ((isinstance(value, str) or isinstance(value, UserString)) and
+             len(value) == 1)
 @[  elif field.type.type in [
         'bool',
         'float32', 'float64',

--- a/rosidl_generator_py/resource/_msg.py.template
+++ b/rosidl_generator_py/resource/_msg.py.template
@@ -131,7 +131,7 @@ class @(spec.base_type.type)(metaclass=Metaclass):
 
     @@@(field.name).setter
     def @(field.name)(self, value):
-@[  if not field.type.is_primitive_type() and ((field.type.is_array and not field.type.array_size) or (not field.type.is_array and not field.type.string_upper_bound))]@
+@[  if not field.type.is_primitive_type()]@
         from @(field.type.pkg_name).msg import @(field.type.type)
 @[  end if]@
 @[  if field.type.is_array]@
@@ -156,13 +156,12 @@ class @(spec.base_type.type)(metaclass=Metaclass):
              not isinstance(value, UserString) and
 @[    if field.type.array_size]@
 @[      if field.type.is_upper_bound]@
-             len(value) <= @(field.type.array_size))
+             len(value) <= @(field.type.array_size) and
 @[      else]@
-             len(value) == @(field.type.array_size))
+             len(value) == @(field.type.array_size) and
 @[      end if]@
-@[    else]@
-             all([isinstance(v, @(get_python_type(field.type))) for v in value]))
 @[    end if]@
+             all([isinstance(v, @(get_python_type(field.type))) for v in value]))
 @[  elif field.type.string_upper_bound]@
             ((isinstance(value, str) or isinstance(value, UserString)) and
              len(value) <= @(field.type.string_upper_bound))

--- a/rosidl_generator_py/resource/_msg_support.c.template
+++ b/rosidl_generator_py/resource/_msg_support.c.template
@@ -1,3 +1,6 @@
+// generated from rosidl_generator_py/resource/_msg_support.c.template
+// generated code does not contain a copyright notice
+
 #include <Python.h>
 
 #include <@(spec.base_type.pkg_name)/@(subfolder)/@(module_name)__struct.h>
@@ -52,8 +55,9 @@ full_classname = "@(spec.base_type.pkg_name).@(subfolder)._@(module_name).@(spec
   char * module_name = (char *)PyUnicode_1BYTE_DATA(
     PyObject_GetAttrString(PyObject_GetAttrString(_pymsg, "__class__"), "__module__"));
 
-  snprintf(full_classname_dest, @(len(full_classname) + 1), "%s.%s", class_name, module_name);
+  snprintf(full_classname_dest, sizeof(full_classname_dest), "%s.%s", class_name, module_name);
 
+  // TODO(dirk-thomas) The check seems to be wrong, asserting that the strings are not equal?
   assert(strncmp(
       "@(spec.base_type.pkg_name).@(subfolder)._@(module_name).@(spec.base_type.type)",
       full_classname_dest, @(len(full_classname))));
@@ -144,7 +148,7 @@ nested_type = '%s__%s__%s' % (field.type.pkg_name, 'msg', field.type.type)
     tmparray@(field.name)[idx@(field.name)] = PyLong_AsUnsignedLong(item@(field.name));
 @[      else]@
     tmparray@(field.name)[idx@(field.name)] = (@(primitive_msg_type_to_c(field.type.type)))PyLong_AsUnsignedLong(item@(field.name));
-@[      end if]
+@[      end if]@
 @[    elif field.type.type == 'int64']@
     assert(PyLong_Check(item@(field.name)));
     tmparray@(field.name)[idx@(field.name)] = PyLong_AsLongLong(item@(field.name));
@@ -202,7 +206,7 @@ nested_type = '%s__%s__%s' % (field.type.pkg_name, 'msg', field.type.type)
   ros_message->@(field.name) = PyLong_AsUnsignedLong(py@(field.name));
 @[    else]@
   ros_message->@(field.name) = (@(primitive_msg_type_to_c(field.type.type)))PyLong_AsUnsignedLong(py@(field.name));
-@[    end if]
+@[    end if]@
 @[  elif field.type.type == 'int64']@
   assert(PyLong_Check(py@(field.name)));
   ros_message->@(field.name) = PyLong_AsLongLong(py@(field.name));
@@ -275,14 +279,14 @@ nested_type = '%s__%s__%s' % (field.type.pkg_name, 'msg', field.type.type)
   size_t idx@(field.name);
   for (idx@(field.name) = 0; idx@(field.name) < size@(field.name); idx@(field.name)++) {
 @[    if field.type.type in ['char', 'byte']]@
-  {
-    char tmp[1] = {tmpmessagedata@(field.name)[idx@(field.name)]};
-    PyList_SetItem(py@(field.name), idx@(field.name), PyUnicode_FromString(tmp));
-  }
+    {
+      char tmp[1] = {tmpmessagedata@(field.name)[idx@(field.name)]};
+      PyList_SetItem(py@(field.name), idx@(field.name), PyUnicode_FromString(tmp));
+    }
 @[    elif field.type.type in ['string']]@
     PyList_SetItem(py@(field.name), idx@(field.name), PyUnicode_FromString(tmpmessagedata@(field.name)[idx@(field.name)].data));
 @[    elif field.type.type =='bool']@
-     PyList_SetItem(py@(field.name), idx@(field.name), tmpmessagedata@(field.name)[idx@(field.name)] ? Py_True : Py_False);
+    PyList_SetItem(py@(field.name), idx@(field.name), tmpmessagedata@(field.name)[idx@(field.name)] ? Py_True : Py_False);
 @[    elif field.type.type in ['float32', 'float64']]@
     PyList_SetItem(py@(field.name), idx@(field.name), PyFloat_FromDouble(tmpmessagedata@(field.name)[idx@(field.name)]));
 @[    elif field.type.type in [

--- a/rosidl_generator_py/resource/_msg_support.entry_point.c.template
+++ b/rosidl_generator_py/resource/_msg_support.entry_point.c.template
@@ -1,3 +1,6 @@
+// generated from rosidl_generator_py/resource/_msg_support.entry_point.c.template
+// generated code does not contain a copyright notice
+
 #include <Python.h>
 #include <stdint.h>
 

--- a/rosidl_generator_py/resource/_srv.py.template
+++ b/rosidl_generator_py/resource/_srv.py.template
@@ -3,3 +3,5 @@
 
 from @(package_name).msg._@(spec.srv_name)__request import @(spec.srv_name)_Request
 from @(package_name).msg._@(spec.srv_name)__response import @(spec.srv_name)_Response
+@(spec.srv_name)_Request  # unused
+@(spec.srv_name)_Response  # unused

--- a/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
+++ b/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
@@ -98,6 +98,8 @@ def generate_py(generator_arguments_file, typesupport_impls):
         with open(os.path.join(args['output_dir'], module, '__init__.py'), 'w') as f:
             for module_, type_ in modules[module]:
                 f.write('from %s.msg._%s import %s\n' % (args['package_name'], module_, type_))
+            for module_, type_ in modules[module]:
+                f.write('%s  # unused\n' % type_)
 
     for template_file, generated_filenames in mapping_extension_msgs.items():
         for generated_filename in generated_filenames:


### PR DESCRIPTION
This enables linting the generated code and fixes almost all failing tests.

@mikaelarguedas Can you please look into the memory leak reported by cppcheck: http://ci.ros2.org/job/ci_linux/1267/

I will look into the few remaining style related test failures.