### PR TITLE
move repr to avoid multiple declarations

### DIFF
--- a/rosidl_generator_py/resource/_msg.py.template
+++ b/rosidl_generator_py/resource/_msg.py.template
@@ -122,14 +122,15 @@ class @(spec.base_type.type)(metaclass=Metaclass):
 @[    end if]@
 @[  end for]@
 @[end if]@
-@[for field in spec.fields]@
-
+@
     def __repr__(self):
         typename = self.__class__.__module__.split('.')
         typename.pop()
         typename.append(self.__class__.__name__)
         args = [s[1:] + '=' + repr(getattr(self, s, None)) for s in self.__slots__]
         return '%s(%s)' % ('.'.join(typename), ', '.join(args))
+
+@[for field in spec.fields]@
 
     @@property
     def @(field.name)(self):


### PR DESCRIPTION
This declare the repr function once per messages. I didn't catch it when reviewing #134 .
Should solve new pyflakes complaints cf. http://ci.ros2.org/job/ci_linux/1299/