### PR TITLE
Document string behavior and initialize to the empty string

### DIFF
--- a/rosidl_generator_c/include/rosidl_generator_c/string_functions.h
+++ b/rosidl_generator_c/include/rosidl_generator_c/string_functions.h
@@ -25,11 +25,12 @@ extern "C"
 {
 #endif
 
-/* The contents of rosidl_generator_c__String are initialized a single null character '\0'.
- The string initially has size 0 and capacity 1.
- Size represents the size of the contents of the string, while capacity represents the overall
- storage of the string (counting the null terminator).
- All strings must be null-terminated.
+/// Initialize a rosidl_generator_c__String structure.
+/* The contents of rosidl_generator_c__String are initialized to a single null character ('\0').
+ * The string initially has size 0 and capacity 1.
+ * Size represents the size of the contents of the string, while capacity represents the overall
+ * storage of the string (counting the null terminator).
+ * All strings must be null-terminated.
  */
 ROSIDL_GENERATOR_C_PUBLIC
 void

--- a/rosidl_generator_c/include/rosidl_generator_c/string_functions.h
+++ b/rosidl_generator_c/include/rosidl_generator_c/string_functions.h
@@ -33,7 +33,7 @@ extern "C"
  * All strings must be null-terminated.
  */
 ROSIDL_GENERATOR_C_PUBLIC
-void
+bool
 rosidl_generator_c__String__init(rosidl_generator_c__String * str);
 
 ROSIDL_GENERATOR_C_PUBLIC

--- a/rosidl_generator_c/include/rosidl_generator_c/string_functions.h
+++ b/rosidl_generator_c/include/rosidl_generator_c/string_functions.h
@@ -25,6 +25,12 @@ extern "C"
 {
 #endif
 
+/* The contents of rosidl_generator_c__String are initialized a single null character '\0'.
+ The string initially has size 0 and capacity 1.
+ Size represents the size of the contents of the string, while capacity represents the overall
+ storage of the string (counting the null terminator).
+ All strings must be null-terminated.
+ */
 ROSIDL_GENERATOR_C_PUBLIC
 void
 rosidl_generator_c__String__init(rosidl_generator_c__String * str);

--- a/rosidl_generator_c/resource/msg__functions.c.em
+++ b/rosidl_generator_c/resource/msg__functions.c.em
@@ -219,7 +219,7 @@ bool
   }
   @(msg_typename) * data = NULL;
   if (size) {
-    data = (@(msg_typename) *)malloc(sizeof(@(msg_typename)) * size);
+    data = (@(msg_typename) *)calloc(size, sizeof(@(msg_typename)));
     if (!data) {
       return false;
     }

--- a/rosidl_generator_c/src/string_functions.c
+++ b/rosidl_generator_c/src/string_functions.c
@@ -24,9 +24,10 @@ rosidl_generator_c__String__init(rosidl_generator_c__String * str)
   if (!str) {
     return;
   }
-  str->data = NULL;
+  str->data = malloc(1);
+  str->data[0] = '\0';
   str->size = 0;
-  str->capacity = 0;
+  str->capacity = 1;
 }
 
 void
@@ -43,7 +44,7 @@ rosidl_generator_c__String__fini(rosidl_generator_c__String * str)
     str->size = 0;
     str->capacity = 0;
   } else {
-    /* ensure that data, szie and and capacity values are consistent */
+    /* ensure that data, size and and capacity values are consistent */
     assert(0 == str->size);
     assert(0 == str->capacity);
   }

--- a/rosidl_generator_c/src/string_functions.c
+++ b/rosidl_generator_c/src/string_functions.c
@@ -17,6 +17,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 
 bool
 rosidl_generator_c__String__init(rosidl_generator_c__String * str)
@@ -42,7 +43,11 @@ rosidl_generator_c__String__fini(rosidl_generator_c__String * str)
   }
   if (str->data) {
     /* ensure that data and capacity values are consistent */
-    assert(str->capacity > 0);
+    if (str->capacity <= 0) {
+      fprintf(stderr, "Unexpected condition: string capacity was zero for allocated data! "
+        "Exiting.\n");
+      exit(-1);
+    }
     if (str->data) {
       free(str->data);
       str->data = NULL;
@@ -51,8 +56,16 @@ rosidl_generator_c__String__fini(rosidl_generator_c__String * str)
     str->capacity = 0;
   } else {
     /* ensure that data, size, and capacity values are consistent */
-    assert(0 == str->size);
-    assert(0 == str->capacity);
+    if (0 != str->size) {
+      fprintf(stderr, "Unexpected condition: string size was non-zero for deallocated data! "
+        "Exiting.\n");
+      exit(-1);
+    }
+    if (0 != str->capacity) {
+      fprintf(stderr, "Unexpected behavior: srring capacity was non-zero for deallocated data! "
+        "Exiting.\n");
+      exit(-1);
+    }
   }
 }
 

--- a/rosidl_generator_c/src/string_functions.c
+++ b/rosidl_generator_c/src/string_functions.c
@@ -44,7 +44,7 @@ rosidl_generator_c__String__fini(rosidl_generator_c__String * str)
     str->size = 0;
     str->capacity = 0;
   } else {
-    /* ensure that data, size and and capacity values are consistent */
+    /* ensure that data, size, and capacity values are consistent */
     assert(0 == str->size);
     assert(0 == str->capacity);
   }

--- a/rosidl_generator_c/src/string_functions.c
+++ b/rosidl_generator_c/src/string_functions.c
@@ -25,6 +25,9 @@ rosidl_generator_c__String__init(rosidl_generator_c__String * str)
     return;
   }
   str->data = malloc(1);
+  if (!str->data) {
+    return;
+  }
   str->data[0] = '\0';
   str->size = 0;
   str->capacity = 1;

--- a/rosidl_generator_c/src/string_functions.c
+++ b/rosidl_generator_c/src/string_functions.c
@@ -18,19 +18,20 @@
 #include <stdlib.h>
 #include <string.h>
 
-void
+bool
 rosidl_generator_c__String__init(rosidl_generator_c__String * str)
 {
   if (!str) {
-    return;
+    return false;
   }
   str->data = malloc(1);
   if (!str->data) {
-    return;
+    return false;
   }
   str->data[0] = '\0';
   str->size = 0;
   str->capacity = 1;
+  return true;
 }
 
 void
@@ -42,8 +43,10 @@ rosidl_generator_c__String__fini(rosidl_generator_c__String * str)
   if (str->data) {
     /* ensure that data and capacity values are consistent */
     assert(str->capacity > 0);
-    free(str->data);
-    str->data = NULL;
+    if (str->data) {
+      free(str->data);
+      str->data = NULL;
+    }
     str->size = 0;
     str->capacity = 0;
   } else {
@@ -73,7 +76,7 @@ rosidl_generator_c__String__assignn(
     return false;
   }
   rosidl_generator_c__String__fini(str);
-  memcpy(data, value, n);
+  data = memcpy(data, value, n);
   data[n] = '\0';
   str->data = data;
   str->size = n;


### PR DESCRIPTION
Attempting to document the behavior of rosidl_generator_c strings that the typesupport libraries expect, and initialize rosidl_generator_c__String to the empty string state as it is understood in the typesupport libraries.

@mikaelarguedas and @wjwwood in particular, does this make sense?