### PR TITLE
add missing macro ROSIDL_GET_SRV_TYPE_SUPPORT to introspection type support

### DIFF
--- a/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/impl/rosidl_generator_c/message_type_support.h
+++ b/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/impl/rosidl_generator_c/message_type_support.h
@@ -32,6 +32,9 @@
 #define ROSIDL_GET_MSG_TYPE_SUPPORT(PkgName, MsgName) \
   ROSIDL_GET_TYPE_SUPPORT(PkgName, msg, MsgName)
 
+#define ROSIDL_GET_SRV_TYPE_SUPPORT(PkgName, MsgName) \
+  ROSIDL_GET_TYPE_SUPPORT(PkgName, srv, MsgName)
+
 #define ROSIDL_GET_TYPE_SUPPORT(PkgName, MsgSubfolder, MsgName) \
   ROSIDL_GET_TYPE_SUPPORT_FUNCTION(PkgName, MsgSubfolder, MsgName)()
 


### PR DESCRIPTION
Connects to ros2/ros2#215

However, it can be, and should be, merged as soon as possible in my opinion.