### PR TITLE
do not overwrite init files

### DIFF
--- a/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
@@ -68,15 +68,15 @@ foreach(_idl_file ${rosidl_generate_interfaces_IDL_FILES})
   endif()
 endforeach()
 
+file(MAKE_DIRECTORY "${_output_path}")
+file(WRITE "${_output_path}/__init__.py" "")
+
 if(NOT "${_generated_msg_py_files} " STREQUAL " ")
   list(GET _generated_msg_py_files 0 _msg_file)
   get_filename_component(_parent_folder "${_msg_file}" DIRECTORY)
   list(APPEND _generated_msg_py_files
     "${_parent_folder}/__init__.py"
   )
-  # TODO(dirk-thomas) since this are being generated at configure time
-  # it should not be a dependency of the custom command
-  file(WRITE "${_parent_folder}/__init__.py" "")
 endif()
 
 if(NOT "${_generated_srv_files} " STREQUAL " ")
@@ -85,9 +85,6 @@ if(NOT "${_generated_srv_files} " STREQUAL " ")
   list(APPEND _generated_srv_files
     "${_parent_folder}/__init__.py"
   )
-  # TODO(dirk-thomas) since this are being generated at configure time
-  # it should not be a dependency of the custom command
-  file(WRITE "${_parent_folder}/__init__.py" "")
 endif()
 
 set(_dependency_files "")
@@ -127,8 +124,6 @@ rosidl_write_generator_arguments(
   TARGET_DEPENDENCIES ${target_dependencies}
 )
 
-file(MAKE_DIRECTORY "${_output_path}")
-file(WRITE "${_output_path}/__init__.py" "")
 
 if(NOT "${_generated_msg_py_files} " STREQUAL " ")
   list(GET _generated_msg_py_files 0 _msg_file)


### PR DESCRIPTION
This reverts a hack/fix we introduced [here](https://github.com/ros2/rosidl/pull/125) to avoid the python generator to be invoked multiple times. This would prevent cmake to overwrite generated init files if reran.
It should allow windows to find the python modules.
Not really ready for review yet. But seems to work on linux without introducing multiple generator invocations.