### PR TITLE
Fix bug with fastrtps/connext building redundant library

### DIFF
--- a/rosidl_generator_py/CMakeLists.txt
+++ b/rosidl_generator_py/CMakeLists.txt
@@ -4,6 +4,7 @@ project(rosidl_generator_py)
 
 find_package(ament_cmake REQUIRED)
 
+ament_export_dependencies(ament_cmake)
 ament_export_dependencies(rosidl_cmake)
 
 ament_python_install_package(${PROJECT_NAME})

--- a/rosidl_generator_py/cmake/rosidl_generator_py_get_typesupports.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_get_typesupports.cmake
@@ -15,7 +15,7 @@
 macro(accumulate_typesupports)
   set(_typesupport_impl "")
   get_rmw_typesupport(_typesupport_impl ${rmw_implementation} LANGUAGE "C")
-  list(APPEND _typesupport_impls ${_typesupport_impl})
+  list_append_unique(_typesupport_impls ${_typesupport_impl})
 endmacro()
 
 macro(rosidl_generator_py_get_typesupports TYPESUPPORT_IMPLS)


### PR DESCRIPTION
Should fix a bug introduced by FastRTPS C typesupport pointed out by @dirk-thomas in https://github.com/eProsima/ROS-RMW-Fast-RTPS-cpp/pull/27#issuecomment-227798359.

@mikaelarguedas you also might want to take a look.