### PR TITLE
removed unused import_typesupport parameters

### DIFF
--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -32,7 +32,7 @@ class Metaclass(type):
         if __type_support_importable:
             rclpy_implementation = rclpy._rclpy.rclpy_get_rmw_implementation_identifier()
             module = import_type_support(
-                '@(package_name)', '@(subfolder)', '@(module_name)', rclpy_implementation)
+                '@(package_name)', rclpy_implementation)
             cls._CONVERT_FROM_PY = module.convert_from_py_@(module_name)
             cls._CONVERT_TO_PY = module.convert_to_py_@(module_name)
             cls._TYPE_SUPPORT = module.type_support_@(module_name)

--- a/rosidl_generator_py/rosidl_generator_py/import_type_support_impl.py
+++ b/rosidl_generator_py/rosidl_generator_py/import_type_support_impl.py
@@ -25,7 +25,7 @@ class UnsupportedTypeSupport(Exception):
         self.rmw_implementation = rmw_implementation
 
 
-def import_type_support(pkg_name, subfolder, rosidl_name, rmw_implementation):
+def import_type_support(pkg_name, rmw_implementation):
     """Import the appropriate type support module for a given rosidl and rmw implementation.
 
     This function will determine the correct type support package to import
@@ -35,8 +35,6 @@ def import_type_support(pkg_name, subfolder, rosidl_name, rmw_implementation):
     used when importing.
 
     :param pkg_name str: name of the package which contains the rosidl
-    :param subfolder str: name of the rosidl containing folder, e.g. `msg`, `srv`, etc.
-    :param rosidl_name str: name of the rosidl
     :param rmw_implementation str: name of the rmw implementation
     :returns: the type support Python module for this specific rosidl and rmw implementation pair
     """


### PR DESCRIPTION
Based on offline discussion with @dirk-thomas we're going to keep a single python extension containing both msg and srv module typesupport functions.
This cleans up the API before starting the work on service generation