### PR TITLE
add bounded_vector

### DIFF
--- a/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
@@ -125,20 +125,17 @@ macro(rosidl_generate_interfaces target)
     ament_index_register_resource("rosidl_interfaces" CONTENT "${_idl_files_lines}")
   endif()
 
-  # collect package names of recursive dependencies
+  # collect package names of recursive dependencies which contain interface files
   set(_recursive_dependencies)
   foreach(_dep ${_ARG_DEPENDENCIES})
-    list_append_unique(_recursive_dependencies "${_dep}")
-    foreach(_dep2 ${${_dep}_RECURSIVE_DEPENDENCIES})
-      list_append_unique(_recursive_dependencies "${_dep2}")
-    endforeach()
-  endforeach()
-
-  # check that all dependencies are actually valid message packages
-  foreach(_dep ${_recursive_dependencies})
-    if(NOT DEFINED ${_dep}_INTERFACE_FILES)
-      message(FATAL_ERROR "The message package '${_dep}' does not declare the interface files")
+    if(DEFINED ${_dep}_INTERFACE_FILES)
+      list_append_unique(_recursive_dependencies "${_dep}")
     endif()
+    foreach(_dep2 ${${_dep}_RECURSIVE_DEPENDENCIES})
+      if(DEFINED ${_dep2}_INTERFACE_FILES)
+        list_append_unique(_recursive_dependencies "${_dep2}")
+      endif()
+    endforeach()
   endforeach()
 
   # generators must be executed in topological order

--- a/rosidl_default_runtime/CMakeLists.txt
+++ b/rosidl_default_runtime/CMakeLists.txt
@@ -5,6 +5,8 @@ project(rosidl_default_runtime NONE)
 find_package(ament_cmake REQUIRED)
 
 ament_export_dependencies(rosidl_generator_cpp)
+ament_export_dependencies(rosidl_typesupport_introspection_c)
+ament_export_dependencies(rosidl_typesupport_introspection_cpp)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/rosidl_default_runtime/CMakeLists.txt
+++ b/rosidl_default_runtime/CMakeLists.txt
@@ -4,8 +4,7 @@ project(rosidl_default_runtime NONE)
 
 find_package(ament_cmake REQUIRED)
 
-ament_export_dependencies(rosidl_typesupport_introspection_c)
-ament_export_dependencies(rosidl_typesupport_introspection_cpp)
+ament_export_dependencies(rosidl_generator_cpp)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/rosidl_default_runtime/package.xml
+++ b/rosidl_default_runtime/package.xml
@@ -9,6 +9,16 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_export_depend>rosidl_generator_cpp</build_export_depend>
+  <build_export_depend>rosidl_typesupport_introspection_c</build_export_depend>
+  <build_export_depend>rosidl_typesupport_introspection_cpp</build_export_depend>
+
+  <!-- These two dependencies cannot stay here. -->
+  <!-- This is a workaround for: https://github.com/ros2/ros2/issues/174 -->
+  <!-- Once that issue is properly resolved this needs to be removed. -->
+  <build_export_depend>rosidl_typesupport_connext_c</build_export_depend>
+  <build_export_depend>rosidl_typesupport_connext_cpp</build_export_depend>
+  <build_export_depend>rosidl_typesupport_opensplice_c</build_export_depend>
+  <build_export_depend>rosidl_typesupport_opensplice_cpp</build_export_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rosidl_default_runtime/package.xml
+++ b/rosidl_default_runtime/package.xml
@@ -8,17 +8,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_export_depend>rosidl_typesupport_introspection_c</build_export_depend>
-  <build_export_depend>rosidl_typesupport_introspection_cpp</build_export_depend>
-
-  <!-- These two dependencies cannot stay here. -->
-  <!-- This is a workaround for: https://github.com/ros2/ros2/issues/174 -->
-  <!-- Once that issue is properly resolved this needs to be removed. -->
-  <build_export_depend>rosidl_typesupport_connext_c</build_export_depend>
-  <build_export_depend>rosidl_typesupport_connext_cpp</build_export_depend>
-  <build_export_depend>rosidl_typesupport_opensplice_c</build_export_depend>
-  <build_export_depend>rosidl_typesupport_opensplice_cpp</build_export_depend>
-  <!--  -->
+  <build_export_depend>rosidl_generator_cpp</build_export_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rosidl_generator_cpp/CMakeLists.txt
+++ b/rosidl_generator_cpp/CMakeLists.txt
@@ -53,6 +53,10 @@ if(BUILD_TESTING)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
   endif()
 
+  include_directories(include)
+
+  ament_add_gtest(test_bounded_vector test/test_bounded_vector.cpp)
+
   ament_add_gtest(test_interfaces_cpp test/test_interfaces.cpp)
   if(TARGET test_interfaces_cpp)
     add_dependencies(test_interfaces_cpp ${PROJECT_NAME})

--- a/rosidl_generator_cpp/include/rosidl_generator_cpp/bounded_vector.hpp
+++ b/rosidl_generator_cpp/include/rosidl_generator_cpp/bounded_vector.hpp
@@ -1,0 +1,712 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_GENERATOR_CPP__BOUNDED_VECTOR_HPP_
+#define ROSIDL_GENERATOR_CPP__BOUNDED_VECTOR_HPP_
+
+#include <algorithm>
+#include <memory>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace rosidl_generator_cpp
+{
+
+/**
+ *  @brief  A container based on std::vector but with an upper bound.
+ *
+ *  @tparam  _Tp  Type of element.
+ *  @tparam  _UpperBound  The upper bound for the number of elements.
+ *  @tparam  _Alloc  Allocator type, defaults to allocator<_Tp>.
+ *
+ *  Meets the same requirements as std::vector.
+*/
+template<typename _Tp, std::size_t _UpperBound, typename _Alloc = std::allocator<_Tp>>
+class BoundedVector
+  : protected std::vector<_Tp, _Alloc>
+{
+  using _Base = std::vector<_Tp, _Alloc>;
+
+public:
+  using typename _Base::value_type;
+  using typename _Base::pointer;
+  using typename _Base::const_pointer;
+  using typename _Base::reference;
+  using typename _Base::const_reference;
+  using typename _Base::iterator;
+  using typename _Base::const_iterator;
+  using typename _Base::const_reverse_iterator;
+  using typename _Base::reverse_iterator;
+  using typename _Base::size_type;
+  using typename _Base::difference_type;
+  using typename _Base::allocator_type;
+
+  /**
+   *  @brief  Creates a %BoundedVector with no elements.
+   */
+  BoundedVector()
+  noexcept(std::is_nothrow_default_constructible<_Alloc>::value)
+  : _Base()
+  {}
+
+  /**
+   *  @brief  Creates a %BoundedVector with no elements.
+   *  @param  __a  An allocator object.
+   */
+  explicit
+  BoundedVector(
+    const typename _Base::allocator_type & __a)
+  noexcept
+  : _Base(__a)
+  {}
+
+  /**
+   *  @brief  Creates a %BoundedVector with default constructed elements.
+   *  @param  __n  The number of elements to initially create.
+   *  @param  __a  An allocator.
+   *
+   *  This constructor fills the %BoundedVector with @a __n default
+   *  constructed elements.
+   */
+  explicit
+  BoundedVector(
+    typename _Base::size_type __n,
+    const typename _Base::allocator_type & __a = allocator_type())
+  : _Base(__n, __a)
+  {
+    if (__n > _UpperBound) {
+      throw std::length_error("Exceeded upper bound");
+    }
+  }
+
+  /**
+   *  @brief  Creates a %BoundedVector with copies of an exemplar element.
+   *  @param  __n  The number of elements to initially create.
+   *  @param  __value  An element to copy.
+   *  @param  __a  An allocator.
+   *
+   *  This constructor fills the %BoundedVector with @a __n copies of @a __value.
+   */
+  BoundedVector(
+    typename _Base::size_type __n,
+    const typename _Base::value_type & __value,
+    const typename _Base::allocator_type & __a = allocator_type())
+  : _Base(__n, __value, __a)
+  {
+    if (__n > _UpperBound) {
+      throw std::length_error("Exceeded upper bound");
+    }
+  }
+
+  /**
+   *  @brief  %BoundedVector copy constructor.
+   *  @param  __x  A %BoundedVector of identical element and allocator types.
+   *
+   *  The newly-created %BoundedVector uses a copy of the allocation
+   *  object used by @a __x.  All the elements of @a __x are copied,
+   *  but any extra memory in
+   *  @a __x (for fast expansion) will not be copied.
+   */
+  BoundedVector(
+    const BoundedVector & __x)
+  : _Base(__x)
+  {}
+
+  /**
+   *  @brief  %BoundedVector move constructor.
+   *  @param  __x  A %BoundedVector of identical element and allocator types.
+   *
+   *  The newly-created %BoundedVector contains the exact contents of @a __x.
+   *  The contents of @a __x are a valid, but unspecified %BoundedVector.
+   */
+  BoundedVector(BoundedVector && __x) noexcept
+  : _Base(std::move(__x))
+  {}
+
+  /// Copy constructor with alternative allocator
+  BoundedVector(const BoundedVector & __x, const typename _Base::allocator_type & __a)
+  : _Base(__x, __a)
+  {}
+
+  /**
+   *  @brief  Builds a %BoundedVector from an initializer list.
+   *  @param  __l  An initializer_list.
+   *  @param  __a  An allocator.
+   *
+   *  Create a %BoundedVector consisting of copies of the elements in the
+   *  initializer_list @a __l.
+   *
+   *  This will call the element type's copy constructor N times
+   *  (where N is @a __l.size()) and do no memory reallocation.
+   */
+  BoundedVector(
+    std::initializer_list<typename _Base::value_type> __l,
+    const typename _Base::allocator_type & __a = typename _Base::allocator_type())
+  : _Base(__l, __a)
+  {
+    if (__l.size() > _UpperBound) {
+      throw std::length_error("Exceeded upper bound");
+    }
+  }
+
+  /**
+   *  @brief  Builds a %BoundedVector from a range.
+   *  @param  __first  An input iterator.
+   *  @param  __last  An input iterator.
+   *  @param  __a  An allocator.
+   *
+   *  Create a %BoundedVector consisting of copies of the elements from
+   *  [first,last).
+   *
+   *  If the iterators are forward, bidirectional, or
+   *  random-access, then this will call the elements' copy
+   *  constructor N times (where N is distance(first,last)) and do
+   *  no memory reallocation.  But if only input iterators are
+   *  used, then this will do at most 2N calls to the copy
+   *  constructor, and logN memory reallocations.
+   */
+  template<
+    typename _InputIterator
+  >
+  BoundedVector(
+    _InputIterator __first,
+    _InputIterator __last,
+    const typename _Base::allocator_type & __a = allocator_type())
+  : _Base(__first, __last, __a)
+  {
+    if (size() > _UpperBound) {
+      throw std::length_error("Exceeded upper bound");
+    }
+  }
+
+  /**
+   *  The dtor only erases the elements, and note that if the
+   *  elements themselves are pointers, the pointed-to memory is
+   *  not touched in any way.  Managing the pointer is the user's
+   *  responsibility.
+   */
+  ~BoundedVector() noexcept
+  {}
+
+  /**
+   *  @brief  %BoundedVector assignment operator.
+   *  @param  __x  A %BoundedVector of identical element and allocator types.
+   *
+   *  All the elements of @a __x are copied, but any extra memory in
+   *  @a __x (for fast expansion) will not be copied.  Unlike the
+   *  copy constructor, the allocator object is not copied.
+   */
+  BoundedVector &
+  operator=(const BoundedVector & __x)
+  {
+    reinterpret_cast<std::vector<_Tp, _Alloc> *>(this)->operator=(
+      *reinterpret_cast<const std::vector<_Tp, _Alloc> *>(&__x));
+    return *this;
+  }
+
+  /**
+   *  @brief  %BoundedVector list assignment operator.
+   *  @param  __l  An initializer_list.
+   *
+   *  This function fills a %BoundedVector with copies of the elements in the
+   *  initializer list @a __l.
+   *
+   *  Note that the assignment completely changes the %BoundedVector and
+   *  that the resulting %BoundedVector's size is the same as the number
+   *  of elements assigned.  Old data may be lost.
+   */
+  BoundedVector &
+  operator=(std::initializer_list<typename _Base::value_type> __l)
+  {
+    if (__l.size() > _UpperBound) {
+      throw std::length_error("Exceeded upper bound");
+    }
+    _Base::operator=(__l);
+    return *this;
+  }
+
+  /**
+   *  @brief  Assigns a given value to a %BoundedVector.
+   *  @param  __n  Number of elements to be assigned.
+   *  @param  __val  Value to be assigned.
+   *
+   *  This function fills a %BoundedVector with @a __n copies of the given
+   *  value.  Note that the assignment completely changes the
+   *  %BoundedVector and that the resulting %BoundedVector's size is the same as
+   *  the number of elements assigned.  Old data may be lost.
+   */
+  void
+  assign(
+    typename _Base::size_type __n,
+    const typename _Base::value_type & __val)
+  {
+    if (__n > _UpperBound) {
+      throw std::length_error("Exceeded upper bound");
+    }
+    _Base::assign(__n, __val);
+  }
+
+  /**
+   *  @brief  Assigns a range to a %BoundedVector.
+   *  @param  __first  An input iterator.
+   *  @param  __last   An input iterator.
+   *
+   *  This function fills a %BoundedVector with copies of the elements in the
+   *  range [__first,__last).
+   *
+   *  Note that the assignment completely changes the %BoundedVector and
+   *  that the resulting %BoundedVector's size is the same as the number
+   *  of elements assigned.  Old data may be lost.
+   */
+  template<
+    typename _InputIterator
+  >
+  void
+  assign(_InputIterator __first, _InputIterator __last)
+  {
+    if (size() + std::distance(__first, __last) > _UpperBound) {
+      throw std::length_error("Exceeded upper bound");
+    }
+    _Base::assign(__first, __last);
+  }
+
+  /**
+   *  @brief  Assigns an initializer list to a %BoundedVector.
+   *  @param  __l  An initializer_list.
+   *
+   *  This function fills a %BoundedVector with copies of the elements in the
+   *  initializer list @a __l.
+   *
+   *  Note that the assignment completely changes the %BoundedVector and
+   *  that the resulting %BoundedVector's size is the same as the number
+   *  of elements assigned.  Old data may be lost.
+   */
+  void
+  assign(std::initializer_list<typename _Base::value_type> __l)
+  {
+    if (__l.size() > _UpperBound) {
+      throw std::length_error("Exceeded upper bound");
+    }
+    _Base::assign(__l);
+  }
+
+  using _Base::begin;
+  using _Base::end;
+  using _Base::rbegin;
+  using _Base::rend;
+  using _Base::cbegin;
+  using _Base::cend;
+  using _Base::crbegin;
+  using _Base::crend;
+  using _Base::size;
+
+  /**  Returns the size() of the largest possible %BoundedVector.  */
+  typename _Base::size_type
+  max_size() const noexcept
+  {
+    return std::min(_UpperBound, _Base::max_size());
+  }
+
+  /**
+   *  @brief  Resizes the %BoundedVector to the specified number of elements.
+   *  @param  __new_size  Number of elements the %BoundedVector should contain.
+   *
+   *  This function will %resize the %BoundedVector to the specified
+   *  number of elements.  If the number is smaller than the
+   *  %BoundedVector's current size the %BoundedVector is truncated, otherwise
+   *  default constructed elements are appended.
+   */
+  void
+  resize(typename _Base::size_type __new_size)
+  {
+    if (__new_size > _UpperBound) {
+      throw std::length_error("Exceeded upper bound");
+    }
+    _Base::resize(__new_size);
+  }
+
+  /**
+   *  @brief  Resizes the %BoundedVector to the specified number of elements.
+   *  @param  __new_size  Number of elements the %BoundedVector should contain.
+   *  @param  __x  Data with which new elements should be populated.
+   *
+   *  This function will %resize the %BoundedVector to the specified
+   *  number of elements.  If the number is smaller than the
+   *  %BoundedVector's current size the %BoundedVector is truncated, otherwise
+   *  the %BoundedVector is extended and new elements are populated with
+   *  given data.
+   */
+  void
+  resize(
+    typename _Base::size_type __new_size,
+    const typename _Base::value_type & __x)
+  {
+    if (__new_size > _UpperBound) {
+      throw std::length_error("Exceeded upper bound");
+    }
+    _Base::resize(__new_size, __x);
+  }
+
+  using _Base::shrink_to_fit;
+  using _Base::capacity;
+  using _Base::empty;
+
+  /**
+   *  @brief  Attempt to preallocate enough memory for specified number of
+   *          elements.
+   *  @param  __n  Number of elements required.
+   *  @throw  std::length_error  If @a n exceeds @c max_size().
+   *
+   *  This function attempts to reserve enough memory for the
+   *  %BoundedVector to hold the specified number of elements.  If the
+   *  number requested is more than max_size(), length_error is
+   *  thrown.
+   *
+   *  The advantage of this function is that if optimal code is a
+   *  necessity and the user can determine the number of elements
+   *  that will be required, the user can reserve the memory in
+   *  %advance, and thus prevent a possible reallocation of memory
+   *  and copying of %BoundedVector data.
+   */
+  void
+  reserve(typename _Base::size_type __n)
+  {
+    if (__n > _UpperBound) {
+      throw std::length_error("Exceeded upper bound");
+    }
+    _Base::reserve(__n);
+  }
+
+  using _Base::operator[];
+  using _Base::at;
+  using _Base::front;
+  using _Base::back;
+
+  // DR 464. Suggestion for new member functions in standard containers.
+  // data access
+  /**
+   *  Returns a pointer such that [data(), data() + size()) is a valid
+   *  range.  For a non-empty %BoundedVector, data() == &front().
+   */
+  template<
+    typename T,
+    typename std::enable_if<
+      !std::is_same<T, _Tp>::value &&
+      !std::is_same<T, bool>::value
+    >::type * = nullptr
+  >
+  T *
+  data() noexcept
+  {
+    return _Base::data();
+  }
+
+  template<
+    typename T,
+    typename std::enable_if<
+      !std::is_same<T, _Tp>::value &&
+      !std::is_same<T, bool>::value
+    >::type * = nullptr
+  >
+  const T *
+  data() const noexcept
+  {
+    return _Base::data();
+  }
+
+  // [23.2.4.3] modifiers
+  /**
+   *  @brief  Add data to the end of the %BoundedVector.
+   *  @param  __x  Data to be added.
+   *
+   *  This is a typical stack operation.  The function creates an
+   *  element at the end of the %BoundedVector and assigns the given data
+   *  to it.  Due to the nature of a %BoundedVector this operation can be
+   *  done in constant time if the %BoundedVector has preallocated space
+   *  available.
+   */
+  void
+  push_back(const typename _Base::value_type & __x)
+  {
+    if (size() >= _UpperBound) {
+      throw std::length_error("Exceeded upper bound");
+    }
+    _Base::push_back(__x);
+  }
+
+  void
+  push_back(typename _Base::value_type && __x)
+  {
+    if (size() >= _UpperBound) {
+      throw std::length_error("Exceeded upper bound");
+    }
+    _Base::push_back(__x);
+  }
+
+  /**
+   *  @brief  Inserts an object in %BoundedVector before specified iterator.
+   *  @param  __position  A const_iterator into the %BoundedVector.
+   *  @param  __args  Arguments.
+   *  @return  An iterator that points to the inserted data.
+   *
+   *  This function will insert an object of type T constructed
+   *  with T(std::forward<Args>(args)...) before the specified location.
+   *  Note that this kind of operation could be expensive for a %BoundedVector
+   *  and if it is frequently used the user should consider using
+   *  std::list.
+   */
+  template<typename ... _Args>
+  typename _Base::iterator
+  emplace(
+    typename _Base::const_iterator __position,
+    _Args && ... __args)
+  {
+    if (size() >= _UpperBound) {
+      throw std::length_error("Exceeded upper bound");
+    }
+    _Base::emplace(__position, std::forward<_Args>(__args) ...);
+  }
+
+  /**
+   *  @brief  Inserts given value into %BoundedVector before specified iterator.
+   *  @param  __position  A const_iterator into the %BoundedVector.
+   *  @param  __x  Data to be inserted.
+   *  @return  An iterator that points to the inserted data.
+   *
+   *  This function will insert a copy of the given value before
+   *  the specified location.  Note that this kind of operation
+   *  could be expensive for a %BoundedVector and if it is frequently
+   *  used the user should consider using std::list.
+   */
+  typename _Base::iterator
+  insert(
+    typename _Base::const_iterator __position,
+    const typename _Base::value_type & __x)
+  {
+    if (size() >= _UpperBound) {
+      throw std::length_error("Exceeded upper bound");
+    }
+    return _Base::insert(__position, __x);
+  }
+
+  /**
+   *  @brief  Inserts given rvalue into %BoundedVector before specified iterator.
+   *  @param  __position  A const_iterator into the %BoundedVector.
+   *  @param  __x  Data to be inserted.
+   *  @return  An iterator that points to the inserted data.
+   *
+   *  This function will insert a copy of the given rvalue before
+   *  the specified location.  Note that this kind of operation
+   *  could be expensive for a %BoundedVector and if it is frequently
+   *  used the user should consider using std::list.
+   */
+  typename _Base::iterator
+  insert(
+    typename _Base::const_iterator __position,
+    typename _Base::value_type && __x)
+  {
+    if (size() >= _UpperBound) {
+      throw std::length_error("Exceeded upper bound");
+    }
+    return _Base::insert(__position, __x);
+  }
+
+  /**
+   *  @brief  Inserts an initializer_list into the %BoundedVector.
+   *  @param  __position  An iterator into the %BoundedVector.
+   *  @param  __l  An initializer_list.
+   *
+   *  This function will insert copies of the data in the
+   *  initializer_list @a l into the %BoundedVector before the location
+   *  specified by @a position.
+   *
+   *  Note that this kind of operation could be expensive for a
+   *  %BoundedVector and if it is frequently used the user should
+   *  consider using std::list.
+   */
+  typename _Base::iterator
+  insert(
+    typename _Base::const_iterator __position,
+    std::initializer_list<typename _Base::value_type> __l)
+  {
+    if (size() + __l.size() > _UpperBound) {
+      throw std::length_error("Exceeded upper bound");
+    }
+    return _Base::insert(__position, __l);
+  }
+
+  /**
+   *  @brief  Inserts a number of copies of given data into the %BoundedVector.
+   *  @param  __position  A const_iterator into the %BoundedVector.
+   *  @param  __n  Number of elements to be inserted.
+   *  @param  __x  Data to be inserted.
+   *  @return  An iterator that points to the inserted data.
+   *
+   *  This function will insert a specified number of copies of
+   *  the given data before the location specified by @a position.
+   *
+   *  Note that this kind of operation could be expensive for a
+   *  %BoundedVector and if it is frequently used the user should
+   *  consider using std::list.
+   */
+  typename _Base::iterator
+  insert(
+    typename _Base::const_iterator __position,
+    typename _Base::size_type __n,
+    const typename _Base::value_type & __x)
+  {
+    if (size() + __n > _UpperBound) {
+      throw std::length_error("Exceeded upper bound");
+    }
+    return _Base::insert(__position, __n, __x);
+  }
+
+  /**
+   *  @brief  Inserts a range into the %BoundedVector.
+   *  @param  __position  A const_iterator into the %BoundedVector.
+   *  @param  __first  An input iterator.
+   *  @param  __last   An input iterator.
+   *  @return  An iterator that points to the inserted data.
+   *
+   *  This function will insert copies of the data in the range
+   *  [__first,__last) into the %BoundedVector before the location specified
+   *  by @a pos.
+   *
+   *  Note that this kind of operation could be expensive for a
+   *  %BoundedVector and if it is frequently used the user should
+   *  consider using std::list.
+   */
+  template<
+    typename _InputIterator
+  >
+  typename _Base::iterator
+  insert(
+    typename _Base::const_iterator __position,
+    _InputIterator __first,
+    _InputIterator __last)
+  {
+    if (size() + std::distance(__first, __last) > _UpperBound) {
+      throw std::length_error("Exceeded upper bound");
+    }
+    return _Base::insert(__position, __first, __last);
+  }
+
+  using _Base::erase;
+  using _Base::pop_back;
+  using _Base::clear;
+};
+
+/**
+ *  @brief  Vector equality comparison.
+ *  @param  __x  A %BoundedVector.
+ *  @param  __y  A %BoundedVector of the same type as @a __x.
+ *  @return  True if the size and elements of the vectors are equal.
+ *
+ *  This is an equivalence relation.  It is linear in the size of the
+ *  vectors.  Vectors are considered equivalent if their sizes are equal,
+ *  and if corresponding elements compare equal.
+*/
+template<typename _Tp, std::size_t _UpperBound, typename _Alloc>
+inline bool
+operator==(
+  const BoundedVector<_Tp, _UpperBound, _Alloc> & __x,
+  const BoundedVector<_Tp, _UpperBound, _Alloc> & __y)
+{
+  return operator==(
+    *reinterpret_cast<const std::vector<_Tp, _Alloc> *>(&__x),
+    *reinterpret_cast<const std::vector<_Tp, _Alloc> *>(&__y));
+}
+
+/**
+ *  @brief  Vector ordering relation.
+ *  @param  __x  A %BoundedVector.
+ *  @param  __y  A %BoundedVector of the same type as @a __x.
+ *  @return  True if @a __x is lexicographically less than @a __y.
+ *
+ *  This is a total ordering relation.  It is linear in the size of the
+ *  vectors.  The elements must be comparable with @c <.
+ *
+ *  See std::lexicographical_compare() for how the determination is made.
+*/
+template<typename _Tp, std::size_t _UpperBound, typename _Alloc>
+inline bool
+operator<(
+  const BoundedVector<_Tp, _UpperBound, _Alloc> & __x,
+  const BoundedVector<_Tp, _UpperBound, _Alloc> & __y)
+{
+  return operator<(
+    *reinterpret_cast<const std::vector<_Tp, _Alloc> *>(&__x),
+    *reinterpret_cast<const std::vector<_Tp, _Alloc> *>(&__y));
+}
+
+/// Based on operator==
+template<typename _Tp, std::size_t _UpperBound, typename _Alloc>
+inline bool
+operator!=(
+  const BoundedVector<_Tp, _UpperBound, _Alloc> & __x,
+  const BoundedVector<_Tp, _UpperBound, _Alloc> & __y)
+{
+  return operator!=(
+    *reinterpret_cast<const std::vector<_Tp, _Alloc> *>(&__x),
+    *reinterpret_cast<const std::vector<_Tp, _Alloc> *>(&__y));
+}
+
+/// Based on operator<
+template<typename _Tp, std::size_t _UpperBound, typename _Alloc>
+inline bool
+operator>(
+  const BoundedVector<_Tp, _UpperBound, _Alloc> & __x,
+  const BoundedVector<_Tp, _UpperBound, _Alloc> & __y)
+{
+  return operator>(
+    *reinterpret_cast<const std::vector<_Tp, _Alloc> *>(&__x),
+    *reinterpret_cast<const std::vector<_Tp, _Alloc> *>(&__y));
+}
+
+/// Based on operator<
+template<typename _Tp, std::size_t _UpperBound, typename _Alloc>
+inline bool
+operator<=(
+  const BoundedVector<_Tp, _UpperBound, _Alloc> & __x,
+  const BoundedVector<_Tp, _UpperBound, _Alloc> & __y)
+{
+  return operator<=(
+    *reinterpret_cast<const std::vector<_Tp, _Alloc> *>(&__x),
+    *reinterpret_cast<const std::vector<_Tp, _Alloc> *>(&__y));
+}
+
+/// Based on operator<
+template<typename _Tp, std::size_t _UpperBound, typename _Alloc>
+inline bool
+operator>=(
+  const BoundedVector<_Tp, _UpperBound, _Alloc> & __x,
+  const BoundedVector<_Tp, _UpperBound, _Alloc> & __y)
+{
+  return operator>=(
+    *reinterpret_cast<const std::vector<_Tp, _Alloc> *>(&__x),
+    *reinterpret_cast<const std::vector<_Tp, _Alloc> *>(&__y));
+}
+
+/// See rosidl_generator_cpp::BoundedVector::swap().
+template<typename _Tp, std::size_t _UpperBound, typename _Alloc>
+inline void
+swap(BoundedVector<_Tp, _UpperBound, _Alloc> & __x, BoundedVector<_Tp, _UpperBound, _Alloc> & __y)
+{
+  __x.swap(__y);
+}
+
+}  // namespace rosidl_generator_cpp
+
+#endif  // ROSIDL_GENERATOR_CPP__BOUNDED_VECTOR_HPP_

--- a/rosidl_generator_cpp/include/rosidl_generator_cpp/bounded_vector.hpp
+++ b/rosidl_generator_cpp/include/rosidl_generator_cpp/bounded_vector.hpp
@@ -24,15 +24,14 @@
 namespace rosidl_generator_cpp
 {
 
+/// A container based on std::vector but with an upper bound.
 /**
- *  @brief  A container based on std::vector but with an upper bound.
+ * Meets the same requirements as std::vector.
  *
- *  @tparam  _Tp  Type of element.
- *  @tparam  _UpperBound  The upper bound for the number of elements.
- *  @tparam  _Alloc  Allocator type, defaults to allocator<_Tp>.
- *
- *  Meets the same requirements as std::vector.
-*/
+ * \param _Tp Type of element
+ * \param _UpperBound The upper bound for the number of elements
+ * \param _Alloc Allocator type, defaults to std::allocator<_Tp>
+ */
 template<typename _Tp, std::size_t _UpperBound, typename _Alloc = std::allocator<_Tp>>
 class BoundedVector
   : protected std::vector<_Tp, _Alloc>
@@ -53,17 +52,15 @@ public:
   using typename _Base::difference_type;
   using typename _Base::allocator_type;
 
-  /**
-   *  @brief  Creates a %BoundedVector with no elements.
-   */
+  /// Create a %BoundedVector with no elements.
   BoundedVector()
   noexcept(std::is_nothrow_default_constructible<_Alloc>::value)
   : _Base()
   {}
 
+  /// Creates a %BoundedVector with no elements.
   /**
-   *  @brief  Creates a %BoundedVector with no elements.
-   *  @param  __a  An allocator object.
+   * \param __a An allocator object
    */
   explicit
   BoundedVector(
@@ -72,13 +69,13 @@ public:
   : _Base(__a)
   {}
 
+  /// Create a %BoundedVector with default constructed elements.
   /**
-   *  @brief  Creates a %BoundedVector with default constructed elements.
-   *  @param  __n  The number of elements to initially create.
-   *  @param  __a  An allocator.
+   * This constructor fills the %BoundedVector with @a __n default
+   * constructed elements.
    *
-   *  This constructor fills the %BoundedVector with @a __n default
-   *  constructed elements.
+   * \param __n The number of elements to initially create
+   * \param __a An allocator
    */
   explicit
   BoundedVector(
@@ -91,13 +88,13 @@ public:
     }
   }
 
+  /// Create a %BoundedVector with copies of an exemplar element.
   /**
-   *  @brief  Creates a %BoundedVector with copies of an exemplar element.
-   *  @param  __n  The number of elements to initially create.
-   *  @param  __value  An element to copy.
-   *  @param  __a  An allocator.
+   * This constructor fills the %BoundedVector with @a __n copies of @a __value.
    *
-   *  This constructor fills the %BoundedVector with @a __n copies of @a __value.
+   * \param __n The number of elements to initially create
+   * \param __value An element to copy
+   * \param __a An allocator
    */
   BoundedVector(
     typename _Base::size_type __n,
@@ -110,14 +107,14 @@ public:
     }
   }
 
+  ///\returnedVector copy constructor.
   /**
-   *  @brief  %BoundedVector copy constructor.
-   *  @param  __x  A %BoundedVector of identical element and allocator types.
+   * The newly-created %BoundedVector uses a copy of the allocation
+   * object used by @a __x.
+   * All the elements of @a __x are copied, but any extra memory in
+   * @a __x (for fast expansion) will not be copied.
    *
-   *  The newly-created %BoundedVector uses a copy of the allocation
-   *  object used by @a __x.  All the elements of @a __x are copied,
-   *  but any extra memory in
-   *  @a __x (for fast expansion) will not be copied.
+   * \param __x A %BoundedVector of identical element and allocator types
    */
   BoundedVector(
     const BoundedVector & __x)
@@ -125,11 +122,11 @@ public:
   {}
 
   /**
-   *  @brief  %BoundedVector move constructor.
-   *  @param  __x  A %BoundedVector of identical element and allocator types.
+   * %BoundedVector move constructor.
+   * \param __x A %BoundedVector of identical element and allocator types.
    *
-   *  The newly-created %BoundedVector contains the exact contents of @a __x.
-   *  The contents of @a __x are a valid, but unspecified %BoundedVector.
+   * The newly-created %BoundedVector contains the exact contents of @a __x.
+   * The contents of @a __x are a valid, but unspecified %BoundedVector.
    */
   BoundedVector(BoundedVector && __x) noexcept
   : _Base(std::move(__x))
@@ -140,16 +137,16 @@ public:
   : _Base(__x, __a)
   {}
 
+  /// Build a %BoundedVector from an initializer list.
   /**
-   *  @brief  Builds a %BoundedVector from an initializer list.
-   *  @param  __l  An initializer_list.
-   *  @param  __a  An allocator.
+   * Create a %BoundedVector consisting of copies of the elements in the
+   * initializer_list @a __l.
    *
-   *  Create a %BoundedVector consisting of copies of the elements in the
-   *  initializer_list @a __l.
+   * This will call the element type's copy constructor N times
+   * (where N is @a __l.size()) and do no memory reallocation.
    *
-   *  This will call the element type's copy constructor N times
-   *  (where N is @a __l.size()) and do no memory reallocation.
+   * \param __l An initializer_list
+   * \param __a An allocator
    */
   BoundedVector(
     std::initializer_list<typename _Base::value_type> __l,
@@ -161,21 +158,20 @@ public:
     }
   }
 
+  /// Build a %BoundedVector from a range.
   /**
-   *  @brief  Builds a %BoundedVector from a range.
-   *  @param  __first  An input iterator.
-   *  @param  __last  An input iterator.
-   *  @param  __a  An allocator.
+   * Create a %BoundedVector consisting of copies of the elements from
+   * [first,last).
    *
-   *  Create a %BoundedVector consisting of copies of the elements from
-   *  [first,last).
+   * If the iterators are forward, bidirectional, or random-access, then
+   * this will call the elements' copy constructor N times (where N is
+   * distance(first,last)) and do no memory reallocation.
+   * But if only input iterators are used, then this will do at most 2N
+   * calls to the copy constructor, and logN memory reallocations.
    *
-   *  If the iterators are forward, bidirectional, or
-   *  random-access, then this will call the elements' copy
-   *  constructor N times (where N is distance(first,last)) and do
-   *  no memory reallocation.  But if only input iterators are
-   *  used, then this will do at most 2N calls to the copy
-   *  constructor, and logN memory reallocations.
+   * \param __first An input iterator
+   * \param __last An input iterator
+   * \param __a An allocator
    */
   template<
     typename _InputIterator
@@ -191,22 +187,22 @@ public:
     }
   }
 
+  /// The dtor only erases the elements.
   /**
-   *  The dtor only erases the elements, and note that if the
-   *  elements themselves are pointers, the pointed-to memory is
-   *  not touched in any way.  Managing the pointer is the user's
-   *  responsibility.
+   * Note that if the elements themselves are pointers, the pointed-to
+   * memory is not touched in any way.
+   * Managing the pointer is the user's responsibility.
    */
   ~BoundedVector() noexcept
   {}
 
+  /// %BoundedVector assignment operator.
   /**
-   *  @brief  %BoundedVector assignment operator.
-   *  @param  __x  A %BoundedVector of identical element and allocator types.
+   * All the elements of @a __x are copied, but any extra memory in
+   * @a __x (for fast expansion) will not be copied.
+   * Unlike the copy constructor, the allocator object is not copied.
    *
-   *  All the elements of @a __x are copied, but any extra memory in
-   *  @a __x (for fast expansion) will not be copied.  Unlike the
-   *  copy constructor, the allocator object is not copied.
+   * \param __x A %BoundedVector of identical element and allocator types
    */
   BoundedVector &
   operator=(const BoundedVector & __x)
@@ -216,16 +212,17 @@ public:
     return *this;
   }
 
+  /// %BoundedVector list assignment operator.
   /**
-   *  @brief  %BoundedVector list assignment operator.
-   *  @param  __l  An initializer_list.
+   * This function fills a %BoundedVector with copies of the elements in
+   * the initializer list @a __l.
    *
-   *  This function fills a %BoundedVector with copies of the elements in the
-   *  initializer list @a __l.
+   * Note that the assignment completely changes the %BoundedVector and
+   * that the resulting %BoundedVector's size is the same as the number
+   * of elements assigned.
+   * Old data may be lost.
    *
-   *  Note that the assignment completely changes the %BoundedVector and
-   *  that the resulting %BoundedVector's size is the same as the number
-   *  of elements assigned.  Old data may be lost.
+   * \param __l An initializer_list
    */
   BoundedVector &
   operator=(std::initializer_list<typename _Base::value_type> __l)
@@ -237,15 +234,17 @@ public:
     return *this;
   }
 
+  /// Assign a given value to a %BoundedVector.
   /**
-   *  @brief  Assigns a given value to a %BoundedVector.
-   *  @param  __n  Number of elements to be assigned.
-   *  @param  __val  Value to be assigned.
+   * This function fills a %BoundedVector with @a __n copies of the
+   * given value.
+   * Note that the assignment completely changes the %BoundedVector and
+   * that the resulting %BoundedVector's size is the same as the number
+   * of elements assigned.
+   * Old data may be lost.
    *
-   *  This function fills a %BoundedVector with @a __n copies of the given
-   *  value.  Note that the assignment completely changes the
-   *  %BoundedVector and that the resulting %BoundedVector's size is the same as
-   *  the number of elements assigned.  Old data may be lost.
+   * \param __n Number of elements to be assigned
+   * \param __val Value to be assigned
    */
   void
   assign(
@@ -258,17 +257,18 @@ public:
     _Base::assign(__n, __val);
   }
 
+  /// Assign a range to a %BoundedVector.
   /**
-   *  @brief  Assigns a range to a %BoundedVector.
-   *  @param  __first  An input iterator.
-   *  @param  __last   An input iterator.
+   * This function fills a %BoundedVector with copies of the elements in
+   * the range [__first,__last).
    *
-   *  This function fills a %BoundedVector with copies of the elements in the
-   *  range [__first,__last).
+   * Note that the assignment completely changes the %BoundedVector and
+   * that the resulting %BoundedVector's size is the same as the number
+   * of elements assigned.
+   * Old data may be lost.
    *
-   *  Note that the assignment completely changes the %BoundedVector and
-   *  that the resulting %BoundedVector's size is the same as the number
-   *  of elements assigned.  Old data may be lost.
+   * \param __first An input iterator
+   * \param __last   An input iterator
    */
   template<
     typename _InputIterator
@@ -282,16 +282,17 @@ public:
     _Base::assign(__first, __last);
   }
 
+  /// Assign an initializer list to a %BoundedVector.
   /**
-   *  @brief  Assigns an initializer list to a %BoundedVector.
-   *  @param  __l  An initializer_list.
+   * This function fills a %BoundedVector with copies of the elements in
+   * the initializer list @a __l.
    *
-   *  This function fills a %BoundedVector with copies of the elements in the
-   *  initializer list @a __l.
+   * Note that the assignment completely changes the %BoundedVector and
+   * that the resulting %BoundedVector's size is the same as the number
+   * of elements assigned.
+   * Old data may be lost.
    *
-   *  Note that the assignment completely changes the %BoundedVector and
-   *  that the resulting %BoundedVector's size is the same as the number
-   *  of elements assigned.  Old data may be lost.
+   * \param __l An initializer_list
    */
   void
   assign(std::initializer_list<typename _Base::value_type> __l)
@@ -312,21 +313,22 @@ public:
   using _Base::crend;
   using _Base::size;
 
-  /**  Returns the size() of the largest possible %BoundedVector.  */
+  /** Returns the size() of the largest possible %BoundedVector.  */
   typename _Base::size_type
   max_size() const noexcept
   {
     return std::min(_UpperBound, _Base::max_size());
   }
 
+  /// Resize the %BoundedVector to the specified number of elements.
   /**
-   *  @brief  Resizes the %BoundedVector to the specified number of elements.
-   *  @param  __new_size  Number of elements the %BoundedVector should contain.
+   * This function will %resize the %BoundedVector to the specified
+   * number of elements.
+   * If the number is smaller than the %BoundedVector's current size the
+   * %BoundedVector is truncated, otherwise default constructed elements
+   * are appended.
    *
-   *  This function will %resize the %BoundedVector to the specified
-   *  number of elements.  If the number is smaller than the
-   *  %BoundedVector's current size the %BoundedVector is truncated, otherwise
-   *  default constructed elements are appended.
+   * \param __new_size Number of elements the %BoundedVector should contain
    */
   void
   resize(typename _Base::size_type __new_size)
@@ -337,16 +339,16 @@ public:
     _Base::resize(__new_size);
   }
 
+  /// Resize the %BoundedVector to the specified number of elements.
   /**
-   *  @brief  Resizes the %BoundedVector to the specified number of elements.
-   *  @param  __new_size  Number of elements the %BoundedVector should contain.
-   *  @param  __x  Data with which new elements should be populated.
+   * This function will %resize the %BoundedVector to the specified
+   * number of elements.
+   * If the number is smaller than the %BoundedVector's current size the
+   * %BoundedVector is truncated, otherwise the %BoundedVector is
+   * extended and new elements are populated with given data.
    *
-   *  This function will %resize the %BoundedVector to the specified
-   *  number of elements.  If the number is smaller than the
-   *  %BoundedVector's current size the %BoundedVector is truncated, otherwise
-   *  the %BoundedVector is extended and new elements are populated with
-   *  given data.
+   * \param __new_size Number of elements the %BoundedVector should contain
+   * \param __x Data with which new elements should be populated
    */
   void
   resize(
@@ -363,22 +365,21 @@ public:
   using _Base::capacity;
   using _Base::empty;
 
+  /// Attempt to preallocate enough memory for specified number of elements.
   /**
-   *  @brief  Attempt to preallocate enough memory for specified number of
-   *          elements.
-   *  @param  __n  Number of elements required.
-   *  @throw  std::length_error  If @a n exceeds @c max_size().
+   * This function attempts to reserve enough memory for the
+   * %BoundedVector to hold the specified number of elements.
+   * If the number requested is more than max_size(), length_error is
+   * thrown.
    *
-   *  This function attempts to reserve enough memory for the
-   *  %BoundedVector to hold the specified number of elements.  If the
-   *  number requested is more than max_size(), length_error is
-   *  thrown.
+   * The advantage of this function is that if optimal code is a
+   * necessity and the user can determine the number of elements that
+   * will be required, the user can reserve the memory in %advance, and
+   * thus prevent a possible reallocation of memory and copying of
+   * %BoundedVector data.
    *
-   *  The advantage of this function is that if optimal code is a
-   *  necessity and the user can determine the number of elements
-   *  that will be required, the user can reserve the memory in
-   *  %advance, and thus prevent a possible reallocation of memory
-   *  and copying of %BoundedVector data.
+   * \param __n Number of elements required
+   * @throw std::length_error If @a n exceeds @c max_size()
    */
   void
   reserve(typename _Base::size_type __n)
@@ -394,11 +395,9 @@ public:
   using _Base::front;
   using _Base::back;
 
-  // DR 464. Suggestion for new member functions in standard containers.
-  // data access
+  /// Return a pointer such that [data(), data() + size()) is a valid range.
   /**
-   *  Returns a pointer such that [data(), data() + size()) is a valid
-   *  range.  For a non-empty %BoundedVector, data() == &front().
+   * For a non-empty %BoundedVector, data() == &front().
    */
   template<
     typename T,
@@ -426,16 +425,16 @@ public:
     return _Base::data();
   }
 
-  // [23.2.4.3] modifiers
+  /// Add data to the end of the %BoundedVector.
   /**
-   *  @brief  Add data to the end of the %BoundedVector.
-   *  @param  __x  Data to be added.
+   * This is a typical stack operation.
+   * The function creates an element at the end of the %BoundedVector
+   * and assigns the given data to it.
+   * Due to the nature of a %BoundedVector this operation can be done in
+   * constant time if the %BoundedVector has preallocated space
+   * available.
    *
-   *  This is a typical stack operation.  The function creates an
-   *  element at the end of the %BoundedVector and assigns the given data
-   *  to it.  Due to the nature of a %BoundedVector this operation can be
-   *  done in constant time if the %BoundedVector has preallocated space
-   *  available.
+   * \param __x Data to be added
    */
   void
   push_back(const typename _Base::value_type & __x)
@@ -455,17 +454,17 @@ public:
     _Base::push_back(__x);
   }
 
+  /// Insert an object in %BoundedVector before specified iterator.
   /**
-   *  @brief  Inserts an object in %BoundedVector before specified iterator.
-   *  @param  __position  A const_iterator into the %BoundedVector.
-   *  @param  __args  Arguments.
-   *  @return  An iterator that points to the inserted data.
+   * This function will insert an object of type T constructed with
+   * T(std::forward<Args>(args)...) before the specified location.
+   * Note that this kind of operation could be expensive for a
+   * %BoundedVector and if it is frequently used the user should
+   * consider using std::list.
    *
-   *  This function will insert an object of type T constructed
-   *  with T(std::forward<Args>(args)...) before the specified location.
-   *  Note that this kind of operation could be expensive for a %BoundedVector
-   *  and if it is frequently used the user should consider using
-   *  std::list.
+   * \param __position A const_iterator into the %BoundedVector
+   * \param __args Arguments
+   * \return An iterator that points to the inserted data
    */
   template<typename ... _Args>
   typename _Base::iterator
@@ -479,16 +478,17 @@ public:
     _Base::emplace(__position, std::forward<_Args>(__args) ...);
   }
 
+  /// Insert given value into %BoundedVector before specified iterator.
   /**
-   *  @brief  Inserts given value into %BoundedVector before specified iterator.
-   *  @param  __position  A const_iterator into the %BoundedVector.
-   *  @param  __x  Data to be inserted.
-   *  @return  An iterator that points to the inserted data.
+   * This function will insert a copy of the given value before the
+   * specified location.
+   * Note that this kind of operation could be expensive for a
+   * %BoundedVector and if it is frequently used the user should
+   * consider using std::list.
    *
-   *  This function will insert a copy of the given value before
-   *  the specified location.  Note that this kind of operation
-   *  could be expensive for a %BoundedVector and if it is frequently
-   *  used the user should consider using std::list.
+   * \param __position A const_iterator into the %BoundedVector
+   * \param __x Data to be inserted
+   * \return An iterator that points to the inserted data
    */
   typename _Base::iterator
   insert(
@@ -501,16 +501,17 @@ public:
     return _Base::insert(__position, __x);
   }
 
+  /// Insert given rvalue into %BoundedVector before specified iterator.
   /**
-   *  @brief  Inserts given rvalue into %BoundedVector before specified iterator.
-   *  @param  __position  A const_iterator into the %BoundedVector.
-   *  @param  __x  Data to be inserted.
-   *  @return  An iterator that points to the inserted data.
+   * This function will insert a copy of the given rvalue before the
+   * specified location.
+   * Note that this kind of operation could be expensive for a
+   * %BoundedVector and if it is frequently used the user should
+   * consider using std::list.
    *
-   *  This function will insert a copy of the given rvalue before
-   *  the specified location.  Note that this kind of operation
-   *  could be expensive for a %BoundedVector and if it is frequently
-   *  used the user should consider using std::list.
+   * \param __position A const_iterator into the %BoundedVector
+   * \param __x Data to be inserted
+   * \return An iterator that points to the inserted data
    */
   typename _Base::iterator
   insert(
@@ -523,18 +524,18 @@ public:
     return _Base::insert(__position, __x);
   }
 
+  /// Insert an initializer_list into the %BoundedVector.
   /**
-   *  @brief  Inserts an initializer_list into the %BoundedVector.
-   *  @param  __position  An iterator into the %BoundedVector.
-   *  @param  __l  An initializer_list.
+   * This function will insert copies of the data in the
+   * initializer_list @a l into the %BoundedVector before the location
+   * specified by @a position.
    *
-   *  This function will insert copies of the data in the
-   *  initializer_list @a l into the %BoundedVector before the location
-   *  specified by @a position.
+   * Note that this kind of operation could be expensive for a
+   * %BoundedVector and if it is frequently used the user should
+   * consider using std::list.
    *
-   *  Note that this kind of operation could be expensive for a
-   *  %BoundedVector and if it is frequently used the user should
-   *  consider using std::list.
+   * \param __position An iterator into the %BoundedVector
+   * \param __l An initializer_list
    */
   typename _Base::iterator
   insert(
@@ -547,19 +548,19 @@ public:
     return _Base::insert(__position, __l);
   }
 
+  /// Insert a number of copies of given data into the %BoundedVector.
   /**
-   *  @brief  Inserts a number of copies of given data into the %BoundedVector.
-   *  @param  __position  A const_iterator into the %BoundedVector.
-   *  @param  __n  Number of elements to be inserted.
-   *  @param  __x  Data to be inserted.
-   *  @return  An iterator that points to the inserted data.
+   * This function will insert a specified number of copies of the given
+   * data before the location specified by @a position.
    *
-   *  This function will insert a specified number of copies of
-   *  the given data before the location specified by @a position.
+   * Note that this kind of operation could be expensive for a
+   * %BoundedVector and if it is frequently used the user should
+   * consider using std::list.
    *
-   *  Note that this kind of operation could be expensive for a
-   *  %BoundedVector and if it is frequently used the user should
-   *  consider using std::list.
+   * \param __position A const_iterator into the %BoundedVector
+   * \param __n Number of elements to be inserted
+   * \param __x Data to be inserted
+   * \return An iterator that points to the inserted data
    */
   typename _Base::iterator
   insert(
@@ -573,20 +574,20 @@ public:
     return _Base::insert(__position, __n, __x);
   }
 
+  /// Insert a range into the %BoundedVector.
   /**
-   *  @brief  Inserts a range into the %BoundedVector.
-   *  @param  __position  A const_iterator into the %BoundedVector.
-   *  @param  __first  An input iterator.
-   *  @param  __last   An input iterator.
-   *  @return  An iterator that points to the inserted data.
+   * This function will insert copies of the data in the range
+   * [__first,__last) into the %BoundedVector before the location
+   * specified by @a pos.
    *
-   *  This function will insert copies of the data in the range
-   *  [__first,__last) into the %BoundedVector before the location specified
-   *  by @a pos.
+   * Note that this kind of operation could be expensive for a
+   * %BoundedVector and if it is frequently used the user should
+   * consider using std::list.
    *
-   *  Note that this kind of operation could be expensive for a
-   *  %BoundedVector and if it is frequently used the user should
-   *  consider using std::list.
+   * \param __position A const_iterator into the %BoundedVector
+   * \param __first An input iterator
+   * \param __last   An input iterator
+   * \return An iterator that points to the inserted data
    */
   template<
     typename _InputIterator
@@ -608,15 +609,16 @@ public:
   using _Base::clear;
 };
 
+/// Vector equality comparison.
 /**
- *  @brief  Vector equality comparison.
- *  @param  __x  A %BoundedVector.
- *  @param  __y  A %BoundedVector of the same type as @a __x.
- *  @return  True if the size and elements of the vectors are equal.
+ * This is an equivalence relation.
+ * It is linear in the size of the vectors.
+ * Vectors are considered equivalent if their sizes are equal, and if
+ * corresponding elements compare equal.
  *
- *  This is an equivalence relation.  It is linear in the size of the
- *  vectors.  Vectors are considered equivalent if their sizes are equal,
- *  and if corresponding elements compare equal.
+ * \param __x A %BoundedVector
+ * \param __y A %BoundedVector of the same type as @a __x
+ * \return True if the size and elements of the vectors are equal
 */
 template<typename _Tp, std::size_t _UpperBound, typename _Alloc>
 inline bool
@@ -629,16 +631,17 @@ operator==(
     *reinterpret_cast<const std::vector<_Tp, _Alloc> *>(&__y));
 }
 
+/// Vector ordering relation.
 /**
- *  @brief  Vector ordering relation.
- *  @param  __x  A %BoundedVector.
- *  @param  __y  A %BoundedVector of the same type as @a __x.
- *  @return  True if @a __x is lexicographically less than @a __y.
+ * This is a total ordering relation.
+ * It is linear in the size of the vectors.
+ * The elements must be comparable with @c <.
  *
- *  This is a total ordering relation.  It is linear in the size of the
- *  vectors.  The elements must be comparable with @c <.
+ * See std::lexicographical_compare() for how the determination is made.
  *
- *  See std::lexicographical_compare() for how the determination is made.
+ * \param __x A %BoundedVector
+ * \param __y A %BoundedVector of the same type as @a __x
+ * @return True if @a __x is lexicographically less than @a __y
 */
 template<typename _Tp, std::size_t _UpperBound, typename _Alloc>
 inline bool

--- a/rosidl_generator_cpp/resource/msg__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.em
@@ -43,6 +43,7 @@ cpp_full_name_with_alloc = '%s<ContainerAllocator>' % (cpp_full_name)
 #include <memory>
 #include <string>
 #include <vector>
+#include <rosidl_generator_cpp/bounded_vector.hpp>
 
 // include message dependencies
 @{

--- a/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
+++ b/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
@@ -114,10 +114,14 @@ def msg_type_to_cpp(type_):
             (type_.pkg_name, type_.type)
 
     if type_.is_array:
-        if type_.array_size is None:
+        if not type_.array_size:
             return \
                 ('std::vector<%s, typename ContainerAllocator::template ' +
                  'rebind<%s>::other>') % (cpp_type, cpp_type)
+        elif type_.is_upper_bound:
+            return \
+                ('rosidl_generator_cpp::BoundedVector<%s, %u, typename ContainerAllocator::' +
+                 'template rebind<%s>::other>') % (cpp_type, type_.array_size, cpp_type)
         else:
             return 'std::array<%s, %u>' % (cpp_type, type_.array_size)
     else:

--- a/rosidl_generator_cpp/test/test_bounded_vector.cpp
+++ b/rosidl_generator_cpp/test/test_bounded_vector.cpp
@@ -1,0 +1,32 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "rosidl_generator_cpp/bounded_vector.hpp"
+
+
+TEST(rosidl_generator_cpp, bounded_vector) {
+  rosidl_generator_cpp::BoundedVector<int, 2> v;
+  ASSERT_EQ(v.size(), 0u);
+  ASSERT_EQ(v.max_size(), 2u);
+  v.push_back(1);
+  v.push_back(2);
+  ASSERT_THROW(v.push_back(3), std::length_error);
+  ASSERT_THROW(v.resize(3), std::length_error);
+  v.resize(1);
+  ASSERT_EQ(v.size(), 1u);
+  v = {1, 2};
+  ASSERT_EQ(v.size(), 2u);
+}

--- a/rosidl_generator_cpp/test/test_bounded_vector.cpp
+++ b/rosidl_generator_cpp/test/test_bounded_vector.cpp
@@ -29,4 +29,6 @@ TEST(rosidl_generator_cpp, bounded_vector) {
   ASSERT_EQ(v.size(), 1u);
   v = {1, 2};
   ASSERT_EQ(v.size(), 2u);
+  auto l = {1, 2, 3};
+  ASSERT_THROW(v = l, std::length_error);
 }

--- a/rosidl_generator_cpp/test/test_interfaces.cpp
+++ b/rosidl_generator_cpp/test/test_interfaces.cpp
@@ -142,10 +142,12 @@ void test_message_primitives_static(rosidl_generator_cpp::msg::PrimitivesStatic 
 
 #define TEST_BOUNDED_ARRAY_PRIMITIVE( \
     Message, FieldName, PrimitiveType, ArraySize, MinVal, MaxVal) \
-  std::array<PrimitiveType, ArraySize> pattern_ ## FieldName; \
+  rosidl_generator_cpp::BoundedVector<PrimitiveType, ArraySize> pattern_ ## FieldName; \
+  Message.FieldName.resize(ArraySize); \
+  pattern_ ## FieldName.resize(ArraySize); \
   test_vector_fill<decltype(pattern_ ## FieldName)>( \
     &pattern_ ## FieldName, ArraySize, MinVal, MaxVal); \
-  std::copy_n(pattern_ ## FieldName.begin(), ArraySize, Message.FieldName.begin()); \
+  std::copy_n(pattern_ ## FieldName.begin(), Message.FieldName.size(), Message.FieldName.begin()); \
   ASSERT_EQ(pattern_ ## FieldName, Message.FieldName); \
 
 void test_message_primitives_bounded(rosidl_generator_cpp::msg::PrimitivesBounded message)
@@ -183,6 +185,7 @@ void test_message_primitives_bounded(rosidl_generator_cpp::msg::PrimitivesBounde
 #define TEST_UNBOUNDED_ARRAY_PRIMITIVE( \
     Message, FieldName, PrimitiveType, ArraySize, MinVal, MaxVal) \
   std::vector<PrimitiveType> pattern_ ## FieldName(ArraySize); \
+  pattern_ ## FieldName.resize(ArraySize); \
   test_vector_fill<decltype(pattern_ ## FieldName)>( \
     &pattern_ ## FieldName, ArraySize, MinVal, MaxVal); \
   Message.FieldName.resize(ArraySize); \
@@ -266,6 +269,7 @@ TEST(Test_messages, static_array_unbounded) {
 // Bounded array of a submessage of static primitive
 TEST(Test_messages, bounded_array_static) {
   rosidl_generator_cpp::msg::BoundedArrayStatic message;
+  message.primitive_values.resize(SUBMESSAGE_ARRAY_SIZE);
   for (int i = 0; i < SUBMESSAGE_ARRAY_SIZE; i++) {
     test_message_primitives_static(message.primitive_values[i]);
   }
@@ -274,6 +278,7 @@ TEST(Test_messages, bounded_array_static) {
 // Bounded array of a submessage of bounded array of primitives
 TEST(Test_messages, bounded_array_bounded) {
   rosidl_generator_cpp::msg::BoundedArrayBounded message;
+  message.primitive_values.resize(SUBMESSAGE_ARRAY_SIZE);
   for (int i = 0; i < SUBMESSAGE_ARRAY_SIZE; i++) {
     test_message_primitives_bounded(message.primitive_values[i]);
   }
@@ -282,6 +287,7 @@ TEST(Test_messages, bounded_array_bounded) {
 // Bounded array of a submessage of unbounded array of primitives
 TEST(Test_messages, bounded_array_unbounded) {
   rosidl_generator_cpp::msg::BoundedArrayUnbounded message;
+  message.primitive_values.resize(SUBMESSAGE_ARRAY_SIZE);
   for (int i = 0; i < SUBMESSAGE_ARRAY_SIZE; i++) {
     test_message_primitives_unbounded(message.primitive_values[i]);
   }

--- a/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
@@ -213,19 +213,16 @@ foreach(_typesupport_impl ${_typesupport_impls})
     ${PythonExtra_INCLUDE_DIRS}
   )
 
+  ament_target_dependencies(${_target_name}
+    "rosidl_generator_c"
+    "${_typesupport_impl}"
+  )
   foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
     ament_target_dependencies(${_target_name}
       ${_pkg_name}
     )
   endforeach()
-  ament_target_dependencies(${_target_name}
-    "rosidl_generator_c"
-    "${_typesupport_impl}"
-  )
 
-  ament_target_dependencies(${_target_name}
-    ${_typesupport_impl}
-  )
   add_dependencies(${_target_name}
     ${rosidl_generate_interfaces_TARGET}__${_typesupport_impl}
   )

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -110,7 +110,7 @@ class @(spec.base_type.type)(metaclass=Metaclass):
 @[      if not field.type.is_primitive_type() and (not field.type.is_array or field.type.array_size)]@
         from @(field.type.pkg_name).msg import @(field.type.type)
 @[      end if]@
-@[      if field.type.array_size]@
+@[      if field.type.array_size and not field.type.is_upper_bound]@
 @[        if field.type.type == 'byte']@
         self.@(field.name) = kwargs.get(
             '@(field.name)',

--- a/rosidl_generator_py/resource/_msg_support.c.em
+++ b/rosidl_generator_py/resource/_msg_support.c.em
@@ -78,7 +78,7 @@ nested_type = '%s__%s__%s' % (field.type.pkg_name, 'msg', field.type.type)
   assert(PySequence_Check(py@(field.name)));
   PyObject * seq@(field.name) = PySequence_Fast(py@(field.name), "expected a sequence");
   @(nested_type) * item@(field.name);
-@[      if field.type.array_size is None]@
+@[      if field.type.array_size is None or field.type.is_upper_bound]@
   size_t size@(field.name) = PySequence_Size(py@(field.name));
   if (!@(nested_type)__Array__init(&(ros_message->@(field.name)), size@(field.name))) {
     PyErr_SetString(PyExc_RuntimeError, "unable to create @(nested_type)__Array ros_message");
@@ -86,11 +86,7 @@ nested_type = '%s__%s__%s' % (field.type.pkg_name, 'msg', field.type.type)
   @(nested_type) * dest@(field.name) = ros_message->@(field.name).data;
 @[      else]@
   size_t size@(field.name) = @(field.type.array_size);
-@[        if field.type.is_upper_bound]@
-  @(nested_type) * dest@(field.name) = ros_message->@(field.name).data;
-@[        else]@
   @(nested_type) * dest@(field.name) = ros_message->@(field.name);
-@[        end if]@
 @[      end if]@
   size_t idx@(field.name);
   for (idx@(field.name) = 0; idx@(field.name) < size@(field.name); idx@(field.name)++) {
@@ -106,7 +102,7 @@ nested_type = '%s__%s__%s' % (field.type.pkg_name, 'msg', field.type.type)
   assert(PySequence_Check(py@(field.name)));
   PyObject * seq@(field.name) = PySequence_Fast(py@(field.name), "expected a sequence");
   PyObject * item@(field.name);
-@[    if field.type.array_size is None]@
+@[    if field.type.array_size is None or field.type.is_upper_bound]@
   size_t size@(field.name) = PySequence_Size(py@(field.name));
 @[      if field.type.type == 'string']@
   if (!rosidl_generator_c__String__Array__init(&(ros_message->@(field.name)), size@(field.name))) {
@@ -120,11 +116,7 @@ nested_type = '%s__%s__%s' % (field.type.pkg_name, 'msg', field.type.type)
   @primitive_msg_type_to_c(field.type.type) * dest@(field.name) = ros_message->@(field.name).data;
 @[    else]@
   size_t size@(field.name) = @(field.type.array_size);
-@[        if field.type.is_upper_bound]@
-  @primitive_msg_type_to_c(field.type.type) * dest@(field.name) = ros_message->@(field.name).data;
-@[        else]@
   @primitive_msg_type_to_c(field.type.type) * dest@(field.name) = ros_message->@(field.name);
-@[        end if]@
 @[    end if]@
 @[    if field.type.type != 'string']@
   @primitive_msg_type_to_c(field.type.type) tmp@(field.name);
@@ -260,7 +252,7 @@ nested_type = '%s__%s__%s' % (field.type.pkg_name, 'msg', field.type.type)
   typedef PyObject *(* convert_to_py_signature)(void *);
   convert_to_py_signature convert_to_py_@(field.name) = (convert_to_py_signature)PyCapsule_GetPointer(py@(field.name)_convert_to_py, NULL);
 @[    if field.type.is_array]@
-@[      if field.type.array_size is None]@
+@[      if field.type.array_size is None or field.type.is_upper_bound]@
   size_t size@(field.name) = ros_message->@(field.name).size;
 @[      else]@
   size_t size@(field.name) = @(field.type.array_size);
@@ -282,16 +274,12 @@ nested_type = '%s__%s__%s' % (field.type.pkg_name, 'msg', field.type.type)
   py@(field.name) = convert_to_py_@(field.name)(&pytmp@(field.name));
 @[    end if]@
 @[  elif field.type.is_array]@
-@[    if field.type.array_size is None]@
+@[    if field.type.array_size is None or field.type.is_upper_bound]@
   size_t size@(field.name) = ros_message->@(field.name).size;
   @primitive_msg_type_to_c(field.type.type) * tmpmessagedata@(field.name) = ros_message->@(field.name).data;
 @[    else]@
   size_t size@(field.name) = @(field.type.array_size);
-@[      if field.type.is_upper_bound]@
-  @primitive_msg_type_to_c(field.type.type) * tmpmessagedata@(field.name) = ros_message->@(field.name).data;
-@[      else]@
   @primitive_msg_type_to_c(field.type.type) * tmpmessagedata@(field.name) = ros_message->@(field.name);
-@[      end if]@
 @[    end if]@
   py@(field.name) = PyList_New(size@(field.name));
   size_t idx@(field.name);

--- a/rosidl_typesupport_introspection_c/cmake/rosidl_typesupport_introspection_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_introspection_c/cmake/rosidl_typesupport_introspection_c_generate_interfaces.cmake
@@ -127,13 +127,13 @@ target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
 )
 target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   ${rosidl_generate_interfaces_TARGET}__rosidl_generator_c)
+ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+  "rosidl_typesupport_introspection_c")
 foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
   ament_target_dependencies(
     ${rosidl_generate_interfaces_TARGET}${_target_suffix}
     ${_pkg_name})
 endforeach()
-ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}
-  "rosidl_typesupport_introspection_c")
 
 add_dependencies(
   ${rosidl_generate_interfaces_TARGET}

--- a/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
+++ b/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
@@ -154,7 +154,7 @@ for index, field in enumerate(spec.fields):
     # bool is_array_
     print('    %s,  // is array' % ('true' if field.type.is_array else 'false'))
     # size_t array_size_
-    print('    %u,  // array size' % (field.type.array_size if field.type.array_size and not field.type.is_upper_bound else 0))
+    print('    %u,  // array size' % (field.type.array_size if field.type.array_size else 0))
     # bool is_upper_bound_
     print('    %s,  // is upper bound' % ('true' if field.type.is_upper_bound else 'false'))
     # unsigned long offset_

--- a/rosidl_typesupport_introspection_cpp/cmake/rosidl_typesupport_introspection_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_introspection_cpp/cmake/rosidl_typesupport_introspection_cpp_generate_interfaces.cmake
@@ -93,13 +93,13 @@ target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   PUBLIC
   ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp
 )
+ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+  "rosidl_typesupport_introspection_cpp")
 foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
   ament_target_dependencies(
     ${rosidl_generate_interfaces_TARGET}${_target_suffix}
     ${_pkg_name})
 endforeach()
-ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}
-  "rosidl_typesupport_introspection_cpp")
 
 add_dependencies(
   ${rosidl_generate_interfaces_TARGET}

--- a/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
@@ -114,7 +114,7 @@ for index, field in enumerate(spec.fields):
     # bool is_array_
     print('    %s,  // is array' % ('true' if field.type.is_array else 'false'))
     # size_t array_size_
-    print('    %u,  // array size' % (field.type.array_size if field.type.array_size and not field.type.is_upper_bound else 0))
+    print('    %u,  // array size' % (field.type.array_size if field.type.array_size else 0))
     # bool is_upper_bound_
     print('    %s,  // is upper bound' % ('true' if field.type.is_upper_bound else 'false'))
     # unsigned long offset_


### PR DESCRIPTION
The new custom container `BoundedVector` uses a template parameter to specify the upper bound because that enables to internally subclass `std::vector` (which safes us from writing a lot more code). If the upper bound would be passed to the constructor it would need to be stored in a member variable which would make the class not a POD anymore (when still subclassing) and that doesn't work with our type support code for introspection which relies on accessing the message fields using `offsetof`.

* http://ci.ros2.org/job/ci_linux/1516/ (compared to master http://ci.ros2.org/job/ci_linux/1515/)
* http://ci.ros2.org/job/ci_osx/1185/ (compared to master http://ci.ros2.org/job/ci_osx/1183/)
* http://ci.ros2.org/job/ci_windows/1519/ (compared to master http://ci.ros2.org/job/ci_windows/1517/)