### PR TITLE
aggregate ts in dictionary and import ts only once

### DIFF
--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -38,19 +38,17 @@ class Metaclass(type):
             cls._CONVERT_TO_PY = module.convert_to_py_@(module_name)
             cls._TYPE_SUPPORT = module.type_support_@(module_name)
 @{
-importable_typesupports = dict()
+importable_typesupports = {}
 for field in spec.fields:
     if not field.type.is_primitive_type():
         key = '%s.msg.%s' % (field.type.pkg_name, field.type.type)
         if key not in importable_typesupports:
             importable_typesupports[key] = [field.type.pkg_name, field.type.type]
 for key in sorted(importable_typesupports.keys()):
-    print('            from %s.msg import %s' % (
-        importable_typesupports[key][0], importable_typesupports[key][1]))
-    print('            if %s.__class__.TYPE_SUPPORT is None:' \
-        % importable_typesupports[key][1])
-    print('                %s.__class__.__import_type_support__()' \
-        % importable_typesupports[key][1])
+    (pkg_name, field_name) = importable_typesupports[key]
+    print('%sfrom %s.msg import %s' % (' ' * 4 * 3, pkg_name, field_name))
+    print('%sif %s.__class__.TYPE_SUPPORT is None:' % (' ' * 4 * 3, field_name))
+    print('%s%s.__class__.__import_type_support__()' % (' ' * 4 * 4, field_name))
 }@
 
     @@classmethod

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -36,12 +36,17 @@ class Metaclass(type):
             cls._CONVERT_FROM_PY = module.convert_from_py_@(module_name)
             cls._CONVERT_TO_PY = module.convert_to_py_@(module_name)
             cls._TYPE_SUPPORT = module.type_support_@(module_name)
-@[for field in spec.fields]@
-@[  if not field.type.is_primitive_type()]@
-            from @(field.type.pkg_name).msg import @(field.type.type)
-            if @(field.type.type).__class__._TYPE_SUPPORT is None:
-                @(field.type.type).__class__.__import_type_support__()
-@[  end if]@
+@{
+importable_typesupports = dict()
+for field in spec.fields:
+    if not field.type.is_primitive_type():
+        if not field.type.type in importable_typesupports:
+            importable_typesupports[str(field.type.type)] = field.type.pkg_name
+}@
+@[for type_support in importable_typesupports]@
+            from @(importable_typesupports[type_support]).msg import @(type_support)
+            if @(type_support).__class__._TYPE_SUPPORT is None:
+                @(type_support).__class__.__import_type_support__()
 @[end for]@
 
     @@classmethod

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -42,9 +42,10 @@ for field in spec.fields:
     if not field.type.is_primitive_type():
         if not field.type.type in importable_typesupports:
             importable_typesupports[str(field.type.type)] = field.type.pkg_name
+sorted_typesupports = [(k, importable_typesupports[k]) for k in sorted(importable_typesupports, key=importable_typesupports.get)]
 }@
-@[for type_support in importable_typesupports]@
-            from @(importable_typesupports[type_support]).msg import @(type_support)
+@[for type_support, msg_pkg in sorted_typesupports]@
+            from @(msg_pkg).msg import @(type_support)
             if @(type_support).__class__._TYPE_SUPPORT is None:
                 @(type_support).__class__.__import_type_support__()
 @[end for]@

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -47,7 +47,7 @@ for field in spec.fields:
 for key in sorted(importable_typesupports.keys()):
     (pkg_name, field_name) = importable_typesupports[key]
     print('%sfrom %s.msg import %s' % (' ' * 4 * 3, pkg_name, field_name))
-    print('%sif %s.__class__.TYPE_SUPPORT is None:' % (' ' * 4 * 3, field_name))
+    print('%sif %s.__class__._TYPE_SUPPORT is None:' % (' ' * 4 * 3, field_name))
     print('%s%s.__class__.__import_type_support__()' % (' ' * 4 * 4, field_name))
 }@
 


### PR DESCRIPTION
This avoid duplicating type_support import logic when messages have multiple fields using the same complex type.

Linux: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=1805)](http://ci.ros2.org/job/ci_linux/1805)
OSX: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1357)](http://ci.ros2.org/job/ci_osx/1357/)
Windows: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=1727)](http://ci.ros2.org/job/ci_windows/1727/)

before:
```python
            module = import_type_support(
                'rosidl_generator_py', rclpy_implementation)
            cls._CONVERT_FROM_PY = module.convert_from_py_various
            cls._CONVERT_TO_PY = module.convert_to_py_various
            cls._TYPE_SUPPORT = module.type_support_various
            from rosidl_generator_py.msg import Empty
            if Empty.__class__._TYPE_SUPPORT is None:
                Empty.__class__.__import_type_support__()
            from rosidl_generator_py.msg import Empty
            if Empty.__class__._TYPE_SUPPORT is None:
                Empty.__class__.__import_type_support__()
            from rosidl_generator_py.msg import Empty
            if Empty.__class__._TYPE_SUPPORT is None:
                Empty.__class__.__import_type_support__()
            from rosidl_generator_py.msg import Nested
            if Nested.__class__._TYPE_SUPPORT is None:
                Nested.__class__.__import_type_support__()
            from rosidl_generator_py.msg import Nested
            if Nested.__class__._TYPE_SUPPORT is None:
                Nested.__class__.__import_type_support__()
            from rosidl_generator_py.msg import Nested
            if Nested.__class__._TYPE_SUPPORT is None:
                Nested.__class__.__import_type_support__()
```
after:
```python
            module = import_type_support(
                'rosidl_generator_py', rclpy_implementation)
            cls._CONVERT_FROM_PY = module.convert_from_py_various
            cls._CONVERT_TO_PY = module.convert_to_py_various
            cls._TYPE_SUPPORT = module.type_support_various
            from rosidl_generator_py.msg import Empty
            if Empty.__class__._TYPE_SUPPORT is None:
                Empty.__class__.__import_type_support__()
            from rosidl_generator_py.msg import Nested
            if Nested.__class__._TYPE_SUPPORT is None:
                Nested.__class__.__import_type_support__()

```