### PR TITLE
prevent user to set None to msg fields

### DIFF
--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -177,7 +177,7 @@ class @(spec.base_type.type)(metaclass=Metaclass):
 @[  elif field.type.type in ['char']]@
         from collections import UserString
 @[  end if]@
-        assert isinstance(value, type(None)) or \
+        assert \
 @[  if field.type.is_array]@
             ((isinstance(value, Sequence) or
               isinstance(value, Set) or


### PR DESCRIPTION
Enforce correct type at Python level rather than in the c wrapper.

Before:
```
python3: /media/mikatchou/ROS/work/ros2/ros2_ws/build_debug_isolated/std_msgs/rosidl_generator_py/std_msgs/msg/_string_s.c:31: std_msgs_string__convert_from_py: Assertion `PyUnicode_Check(pydata)' failed.
Aborted (core dumped)
```
after
```
  File "/media/mikatchou/ROS/work/ros2/ros2_ws/build_debug_isolated/rclpy_examples/talker_py.py", line 45, in main
    msg.data = None
  File "/media/mikatchou/ROS/work/ros2/ros2_ws/install_debug_isolated/std_msgs/lib/python3.5/site-packages/std_msgs/msg/_string.py", line 74, in data
    isinstance(value, str)
AssertionError

```