### PR TITLE
expose template declaration publically and unify naming

### DIFF
--- a/rosidl_typesupport_introspection_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_introspection_cpp/CMakeLists.txt
@@ -33,6 +33,8 @@ target_include_directories(${PROJECT_NAME}
 )
 ament_export_libraries(${PROJECT_NAME})
 
+ament_index_register_resource("rosidl_typesupport_cpp")
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/identifier.hpp
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/identifier.hpp
@@ -21,7 +21,7 @@ namespace rosidl_typesupport_introspection_cpp
 {
 
 ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_IMPORT
-extern const char * typesupport_introspection_identifier;
+extern const char * typesupport_identifier;
 
 }  // namespace rosidl_typesupport_introspection_cpp
 

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/impl/rosidl_generator_cpp/message_type_support.hpp
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/impl/rosidl_generator_cpp/message_type_support.hpp
@@ -23,18 +23,10 @@
 // Provides the declaration of the function
 // rosidl_generator_cpp::get_message_type_support_handle.
 #include "rosidl_generator_cpp/message_type_support_decl.hpp"
+// Provides the declaration of the function template
+#include "rosidl_typesupport_introspection_cpp/message_type_support_decl.hpp"
 // Provides visibility macros like ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC.
 #include "rosidl_typesupport_introspection_cpp/visibility_control.h"
-
-namespace rosidl_typesupport_introspection_cpp
-{
-
-// This is implemented in the shared library provided by this package.
-template<typename T>
-ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC
-const rosidl_message_type_support_t * get_message_type_support_handle_introspection();
-
-}  // namespace rosidl_typesupport_introspection_cpp
 
 namespace rosidl_generator_cpp
 {
@@ -49,7 +41,7 @@ const rosidl_message_type_support_t * get_message_type_support_handle()
   // message library. This is intentional to allow the linker to pick the
   // correct implementation specific message library when being over linked
   // with multiple implementation options.
-  return rosidl_typesupport_introspection_cpp::get_message_type_support_handle_introspection<T>();
+  return ::rosidl_typesupport_introspection_cpp::get_message_type_support_handle<T>();
 }
 
 }  // namespace rosidl_generator_cpp

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/impl/rosidl_generator_cpp/service_type_support.hpp
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/impl/rosidl_generator_cpp/service_type_support.hpp
@@ -23,18 +23,10 @@
 // Provides the declaration of the function
 // rosidl_generator_cpp::get_service_type_support_handle.
 #include "rosidl_generator_cpp/service_type_support_decl.hpp"
+// Provides the declaration of the function template
+#include "rosidl_typesupport_introspection_cpp/service_type_support_decl.hpp"
 // Provides visibility macros like ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC.
 #include "rosidl_typesupport_introspection_cpp/visibility_control.h"
-
-namespace rosidl_typesupport_introspection_cpp
-{
-
-// This is implemented in the shared library provided by this package.
-template<typename T>
-ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC
-const rosidl_service_type_support_t * get_service_type_support_handle_introspection();
-
-}  // namespace rosidl_typesupport_introspection_cpp
 
 namespace rosidl_generator_cpp
 {
@@ -49,7 +41,7 @@ const rosidl_service_type_support_t * get_service_type_support_handle()
   // service library. This is intentional to allow the linker to pick the
   // correct implementation specific service library when being over linked
   // with multiple implementation options.
-  return rosidl_typesupport_introspection_cpp::get_service_type_support_handle_introspection<T>();
+  return ::rosidl_typesupport_introspection_cpp::get_service_type_support_handle<T>();
 }
 
 }  // namespace rosidl_generator_cpp

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/message_type_support_decl.hpp
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/message_type_support_decl.hpp
@@ -12,12 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef ROSIDL_TYPESUPPORT_INTROSPECTION_CPP__MESSAGE_TYPE_SUPPORT_DECL_HPP_
+#define ROSIDL_TYPESUPPORT_INTROSPECTION_CPP__MESSAGE_TYPE_SUPPORT_DECL_HPP_
+
+// Provides the definition of the rosidl_message_type_support_t struct.
+#include "rosidl_generator_c/message_type_support_struct.h"
+// Provides visibility macros like ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC.
 #include "rosidl_typesupport_introspection_cpp/visibility_control.h"
 
 namespace rosidl_typesupport_introspection_cpp
 {
 
-ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_EXPORT
-const char * typesupport_identifier = "introspection_cpp";
+// This is implemented in the shared library provided by this package.
+template<typename T>
+ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC
+const rosidl_message_type_support_t * get_message_type_support_handle();
 
 }  // namespace rosidl_typesupport_introspection_cpp
+
+#endif  // ROSIDL_TYPESUPPORT_INTROSPECTION_CPP__MESSAGE_TYPE_SUPPORT_DECL_HPP_

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/service_type_support_decl.hpp
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/service_type_support_decl.hpp
@@ -12,12 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef ROSIDL_TYPESUPPORT_INTROSPECTION_CPP__SERVICE_TYPE_SUPPORT_DECL_HPP_
+#define ROSIDL_TYPESUPPORT_INTROSPECTION_CPP__SERVICE_TYPE_SUPPORT_DECL_HPP_
+
+// Provides the definition of the rosidl_service_type_support_t struct.
+#include "rosidl_generator_c/service_type_support.h"
+// Provides visibility macros like ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC.
 #include "rosidl_typesupport_introspection_cpp/visibility_control.h"
 
 namespace rosidl_typesupport_introspection_cpp
 {
 
-ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_EXPORT
-const char * typesupport_identifier = "introspection_cpp";
+// This is implemented in the shared library provided by this package.
+template<typename T>
+ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC
+const rosidl_service_type_support_t * get_service_type_support_handle();
 
 }  // namespace rosidl_typesupport_introspection_cpp
+
+#endif  // ROSIDL_TYPESUPPORT_INTROSPECTION_CPP__SERVICE_TYPE_SUPPORT_DECL_HPP_

--- a/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
@@ -110,7 +110,7 @@ for index, field in enumerate(spec.fields):
         # size_t string_upper_bound
         print('    0,  // upper bound of string')
         # const rosidl_message_type_support_t * members_
-        print('    ::rosidl_typesupport_introspection_cpp::get_message_type_support_handle_introspection<%s::msg::%s>(),  // members of sub message' % (field.type.pkg_name, field.type.type))
+        print('    ::rosidl_typesupport_introspection_cpp::get_message_type_support_handle<%s::msg::%s>(),  // members of sub message' % (field.type.pkg_name, field.type.type))
     # bool is_array_
     print('    %s,  // is array' % ('true' if field.type.is_array else 'false'))
     # size_t array_size_
@@ -153,7 +153,7 @@ static const ::rosidl_typesupport_introspection_cpp::MessageMembers @(spec.base_
 };
 
 static const rosidl_message_type_support_t @(spec.base_type.type)_message_type_support_handle = {
-  ::rosidl_typesupport_introspection_cpp::typesupport_introspection_identifier,
+  ::rosidl_typesupport_introspection_cpp::typesupport_identifier,
   &@(spec.base_type.type)_message_members
 };
 
@@ -170,7 +170,7 @@ namespace rosidl_typesupport_introspection_cpp
 template<>
 ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC
 const rosidl_message_type_support_t *
-get_message_type_support_handle_introspection<@(spec.base_type.pkg_name)::@(subfolder)::@(spec.base_type.type)>()
+get_message_type_support_handle<@(spec.base_type.pkg_name)::@(subfolder)::@(spec.base_type.type)>()
 {
   return &::@(spec.base_type.pkg_name)::@(subfolder)::rosidl_typesupport_introspection_cpp::@(spec.base_type.type)_message_type_support_handle;
 }

--- a/rosidl_typesupport_introspection_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_introspection_cpp/resource/srv__type_support.cpp.em
@@ -42,13 +42,13 @@ static ::rosidl_typesupport_introspection_cpp::ServiceMembers @(spec.srv_name)_s
   "@(spec.pkg_name)",  // package name
   "@(spec.srv_name)",  // service name
   // these two fields are initialized below on the first access
-  // see get_service_type_support_handle_introspection<@(spec.pkg_name)::@(spec.srv_name)>()
+  // see get_service_type_support_handle<@(spec.pkg_name)::@(spec.srv_name)>()
   nullptr,  // request message
   nullptr  // response message
 };
 
 static const rosidl_service_type_support_t @(spec.srv_name)_service_type_support_handle = {
-  ::rosidl_typesupport_introspection_cpp::typesupport_introspection_identifier,
+  ::rosidl_typesupport_introspection_cpp::typesupport_identifier,
   &@(spec.srv_name)_service_members
 };
 
@@ -65,7 +65,7 @@ namespace rosidl_typesupport_introspection_cpp
 template<>
 ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC
 const rosidl_service_type_support_t *
-get_service_type_support_handle_introspection<@(spec.pkg_name)::srv::@(spec.srv_name)>()
+get_service_type_support_handle<@(spec.pkg_name)::srv::@(spec.srv_name)>()
 {
   // get a handle to the value to be returned
   auto service_type_support =
@@ -84,7 +84,7 @@ get_service_type_support_handle_introspection<@(spec.pkg_name)::srv::@(spec.srv_
     service_members->request_members_ = static_cast<
       const ::rosidl_typesupport_introspection_cpp::MessageMembers *
       >(
-      ::rosidl_typesupport_introspection_cpp::get_message_type_support_handle_introspection<
+      ::rosidl_typesupport_introspection_cpp::get_message_type_support_handle<
         ::@(spec.pkg_name)::srv::@(spec.request.base_type.type)
       >()->data
       );
@@ -92,7 +92,7 @@ get_service_type_support_handle_introspection<@(spec.pkg_name)::srv::@(spec.srv_
     service_members->response_members_ = static_cast<
       const ::rosidl_typesupport_introspection_cpp::MessageMembers *
       >(
-      ::rosidl_typesupport_introspection_cpp::get_message_type_support_handle_introspection<
+      ::rosidl_typesupport_introspection_cpp::get_message_type_support_handle<
         ::@(spec.pkg_name)::srv::@(spec.response.base_type.type)
       >()->data
       );


### PR DESCRIPTION
This will unify the symbols across the type support packages so that they only differ in the namespace.

Connect to ros2/rosidl_typesupport#1.