### PR TITLE
typesupport reloaded

### DIFF
--- a/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
@@ -31,6 +31,9 @@ include(CMakeParseArguments)
 # :param DEPENDENCIES: the packages from which message types are
 #   being used
 # :type DEPENDENCIES: list of strings
+# :param LIBRARY_NAME: the base name of the library, specific generators might
+#   append their own suffix
+# :type LIBRARY_NAME: string
 # :param SKIP_INSTALL: if set skip installing the interface files
 # :type SKIP_INSTALL: option
 # :param ADD_LINTER_TESTS: if set lint the interface files using
@@ -40,7 +43,7 @@ include(CMakeParseArguments)
 # @public
 #
 macro(rosidl_generate_interfaces target)
-  cmake_parse_arguments(_ARG "ADD_LINTER_TESTS;SKIP_INSTALL" "" "DEPENDENCIES" ${ARGN})
+  cmake_parse_arguments(_ARG "ADD_LINTER_TESTS;SKIP_INSTALL" "LIBRARY_NAME" "DEPENDENCIES" ${ARGN})
   if(NOT _ARG_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "rosidl_generate_interfaces() called without any idl "
       "files")
@@ -144,6 +147,7 @@ macro(rosidl_generate_interfaces target)
   set(rosidl_generate_interfaces_TARGET ${target})
   set(rosidl_generate_interfaces_IDL_FILES ${_idl_files})
   set(rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES ${_recursive_dependencies})
+  set(rosidl_generate_interfaces_LIBRARY_NAME ${_ARG_LIBRARY_NAME})
   set(rosidl_generate_interfaces_SKIP_INSTALL ${_ARG_SKIP_INSTALL})
   set(rosidl_generate_interfaces_ADD_LINTER_TESTS ${_ARG_ADD_LINTER_TESTS})
   ament_execute_extensions("rosidl_generate_interfaces")

--- a/rosidl_generator_c/CMakeLists.txt
+++ b/rosidl_generator_c/CMakeLists.txt
@@ -11,7 +11,9 @@ find_package(ament_cmake_python REQUIRED)
 
 include_directories(include)
 add_library(${PROJECT_NAME} SHARED
+  "src/message_type_support.c"
   "src/primitives_array_functions.c"
+  "src/service_type_support.c"
   "src/string_functions.c"
 )
 if(NOT WIN32)

--- a/rosidl_generator_c/cmake/rosidl_generator_c_generate_interfaces.cmake
+++ b/rosidl_generator_c/cmake/rosidl_generator_c_generate_interfaces.cmake
@@ -124,6 +124,10 @@ set(_target_suffix "__rosidl_generator_c")
 
 add_library(${rosidl_generate_interfaces_TARGET}${_target_suffix} SHARED
   ${_generated_msg_headers} ${_generated_msg_sources} ${_generated_srv_headers} ${_generated_srv_sources})
+if(rosidl_generate_interfaces_LIBRARY_NAME)
+  set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    PROPERTIES OUTPUT_NAME "${rosidl_generate_interfaces_LIBRARY_NAME}${_target_suffix}")
+endif()
 if(NOT WIN32)
   set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix} PROPERTIES
     COMPILE_FLAGS "-std=c11 -Wall -Wextra")

--- a/rosidl_generator_c/include/rosidl_generator_c/message_type_support_struct.h
+++ b/rosidl_generator_c/include/rosidl_generator_c/message_type_support_struct.h
@@ -1,4 +1,4 @@
-// Copyright 2015 Open Source Robotics Foundation, Inc.
+// Copyright 2015-2016 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,11 +22,25 @@ extern "C"
 {
 #endif
 
+typedef struct rosidl_message_type_support_t rosidl_message_type_support_t;
+
+typedef const rosidl_message_type_support_t * (* rosidl_message_typesupport_handle_function)(
+  const rosidl_message_type_support_t *, const char *);
+
 typedef struct ROSIDL_PUBLIC_TYPE rosidl_message_type_support_t
 {
   const char * typesupport_identifier;
   const void * data;
+  rosidl_message_typesupport_handle_function func;
 } rosidl_message_type_support_t;
+
+ROSIDL_GENERATOR_C_PUBLIC
+const rosidl_message_type_support_t * get_message_typesupport_handle(
+  const rosidl_message_type_support_t * handle, const char * identifier);
+
+ROSIDL_GENERATOR_C_PUBLIC
+const rosidl_message_type_support_t * get_message_typesupport_handle_function(
+  const rosidl_message_type_support_t * handle, const char * identifier);
 
 #ifdef __cplusplus
 }

--- a/rosidl_generator_c/include/rosidl_generator_c/service_type_support.h
+++ b/rosidl_generator_c/include/rosidl_generator_c/service_type_support.h
@@ -1,4 +1,4 @@
-// Copyright 2015 Open Source Robotics Foundation, Inc.
+// Copyright 2015-2016 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,11 +22,25 @@ extern "C"
 {
 #endif
 
+typedef struct rosidl_service_type_support_t rosidl_service_type_support_t;
+
+typedef const rosidl_service_type_support_t * (* rosidl_service_typesupport_handle_function)(
+  const rosidl_service_type_support_t *, const char *);
+
 typedef struct ROSIDL_PUBLIC_TYPE rosidl_service_type_support_t
 {
   const char * typesupport_identifier;
   const void * data;
+  rosidl_service_typesupport_handle_function func;
 } rosidl_service_type_support_t;
+
+ROSIDL_GENERATOR_C_PUBLIC
+const rosidl_service_type_support_t * get_service_typesupport_handle(
+  const rosidl_service_type_support_t * handle, const char * identifier);
+
+ROSIDL_GENERATOR_C_PUBLIC
+const rosidl_service_type_support_t * get_service_typesupport_handle_function(
+  const rosidl_service_type_support_t * handle, const char * identifier);
 
 /* This macro is used to create the symbol of the get_service_type_support
  * function for a specific service type. The library of the message package

--- a/rosidl_generator_c/src/message_type_support.c
+++ b/rosidl_generator_c/src/message_type_support.c
@@ -1,0 +1,41 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rosidl_generator_c/message_type_support_struct.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+const rosidl_message_type_support_t * get_message_typesupport_handle(
+  const rosidl_message_type_support_t * handle, const char * identifier)
+{
+  assert(handle);
+  assert(handle->func);
+  rosidl_message_typesupport_handle_function func =
+    (rosidl_message_typesupport_handle_function)(handle->func);
+  return func(handle, identifier);
+}
+
+const rosidl_message_type_support_t * get_message_typesupport_handle_function(
+  const rosidl_message_type_support_t * handle, const char * identifier)
+{
+  assert(handle);
+  assert(handle->typesupport_identifier);
+  assert(identifier);
+  if (strcmp(handle->typesupport_identifier, identifier) == 0) {
+    return handle;
+  }
+  return 0;
+}

--- a/rosidl_generator_c/src/service_type_support.c
+++ b/rosidl_generator_c/src/service_type_support.c
@@ -1,0 +1,40 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rosidl_generator_c/service_type_support.h"
+
+#include <assert.h>
+#include <string.h>
+
+const rosidl_service_type_support_t * get_service_typesupport_handle(
+  const rosidl_service_type_support_t * handle, const char * identifier)
+{
+  assert(handle);
+  assert(handle->func);
+  rosidl_service_typesupport_handle_function func =
+    (rosidl_service_typesupport_handle_function)(handle->func);
+  return func(handle, identifier);
+}
+
+const rosidl_service_type_support_t * get_service_typesupport_handle_function(
+  const rosidl_service_type_support_t * handle, const char * identifier)
+{
+  assert(handle);
+  assert(handle->typesupport_identifier);
+  assert(identifier);
+  if (strcmp(handle->typesupport_identifier, identifier) == 0) {
+    return handle;
+  }
+  return 0;
+}

--- a/rosidl_generator_cpp/include/rosidl_typesupport_cpp/message_type_support.hpp
+++ b/rosidl_generator_cpp/include/rosidl_typesupport_cpp/message_type_support.hpp
@@ -1,0 +1,29 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_TYPESUPPORT_CPP__MESSAGE_TYPE_SUPPORT_HPP_
+#define ROSIDL_TYPESUPPORT_CPP__MESSAGE_TYPE_SUPPORT_HPP_
+
+#include <rosidl_generator_c/message_type_support_struct.h>
+#include <rosidl_generator_c/visibility_control.h>
+
+namespace rosidl_typesupport_cpp
+{
+
+template<typename T>
+const rosidl_message_type_support_t * get_message_type_support_handle();
+
+}  // namespace rosidl_typesupport_cpp
+
+#endif  // ROSIDL_TYPESUPPORT_CPP__MESSAGE_TYPE_SUPPORT_HPP_

--- a/rosidl_generator_cpp/include/rosidl_typesupport_cpp/service_type_support.hpp
+++ b/rosidl_generator_cpp/include/rosidl_typesupport_cpp/service_type_support.hpp
@@ -1,0 +1,29 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_TYPESUPPORT_CPP__SERVICE_TYPE_SUPPORT_HPP_
+#define ROSIDL_TYPESUPPORT_CPP__SERVICE_TYPE_SUPPORT_HPP_
+
+#include <rosidl_generator_c/service_type_support.h>
+#include <rosidl_generator_c/visibility_control.h>
+
+namespace rosidl_typesupport_cpp
+{
+
+template<typename T>
+const rosidl_service_type_support_t * get_service_type_support_handle();
+
+}  // namespace rosidl_typesupport_cpp
+
+#endif  // ROSIDL_TYPESUPPORT_CPP__SERVICE_TYPE_SUPPORT_HPP_

--- a/rosidl_typesupport_interface/CMakeLists.txt
+++ b/rosidl_typesupport_interface/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(rosidl_typesupport_interface NONE)
+
+find_package(ament_cmake REQUIRED)
+
+ament_export_include_directories(include)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()
+
+install(
+  DIRECTORY include/
+  DESTINATION include
+)

--- a/rosidl_typesupport_interface/include/rosidl_typesupport_interface/macros.h
+++ b/rosidl_typesupport_interface/include/rosidl_typesupport_interface/macros.h
@@ -1,0 +1,35 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_TYPESUPPORT_INTERFACE__MACROS_H_
+#define ROSIDL_TYPESUPPORT_INTERFACE__MACROS_H_
+
+#define ROSIDL_TYPESUPPORT_INTERFACE__SYMBOL_NAME( \
+    typesupport_name, function_name, package_name, interface_type, interface_name) \
+  typesupport_name ## __ ## function_name ## __ ## \
+  package_name ## __ ## interface_type ## __ ## interface_name
+
+#define ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME( \
+    typesupport_name, package_name, interface_type, message_name) \
+  ROSIDL_TYPESUPPORT_INTERFACE__SYMBOL_NAME( \
+    typesupport_name, get_message_type_support_handle, \
+    package_name, interface_type, message_name)
+
+#define ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME( \
+    typesupport_name, package_name, service_name) \
+  ROSIDL_TYPESUPPORT_INTERFACE__SYMBOL_NAME( \
+    typesupport_name, get_service_type_support_handle, \
+    package_name, srv, service_name)
+
+#endif  // ROSIDL_TYPESUPPORT_INTERFACE__MACROS_H_

--- a/rosidl_typesupport_interface/package.xml
+++ b/rosidl_typesupport_interface/package.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>rosidl_typesupport_interface</name>
+  <version>0.0.0</version>
+  <description>
+    The interface for rosidl typesupport packages.
+  </description>
+  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/rosidl_typesupport_introspection_c/cmake/rosidl_typesupport_introspection_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_introspection_c/cmake/rosidl_typesupport_introspection_c_generate_interfaces.cmake
@@ -117,6 +117,10 @@ set(_target_suffix "__rosidl_typesupport_introspection_c")
 add_library(${rosidl_generate_interfaces_TARGET}${_target_suffix} SHARED
   ${_generated_msg_header_files} ${_generated_msg_source_files}
   ${_generated_srv_header_files} ${_generated_srv_source_files})
+if(rosidl_generate_interfaces_LIBRARY_NAME)
+  set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    PROPERTIES OUTPUT_NAME "${rosidl_generate_interfaces_LIBRARY_NAME}${_target_suffix}")
+endif()
 if(NOT WIN32)
   set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix} PROPERTIES
     COMPILE_FLAGS "-std=c11 -Wall -Wextra")

--- a/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
+++ b/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
@@ -196,7 +196,8 @@ static const rosidl_typesupport_introspection_c__MessageMembers @(function_prefi
 // since C does not allow non-integral compile-time constants
 static rosidl_message_type_support_t @(function_prefix)__@(spec.base_type.type)_message_type_support_handle = {
   0,
-  &@(function_prefix)__@(spec.base_type.type)_message_members
+  &@(function_prefix)__@(spec.base_type.type)_message_members,
+  get_message_typesupport_handle_function,
 };
 
 ROSIDL_GENERATOR_C_EXPORT_@(spec.base_type.pkg_name)

--- a/rosidl_typesupport_introspection_c/resource/srv__type_support.c.em
+++ b/rosidl_typesupport_introspection_c/resource/srv__type_support.c.em
@@ -44,7 +44,8 @@ static rosidl_typesupport_introspection_c__ServiceMembers @(function_prefix)__@(
 
 static rosidl_service_type_support_t @(function_prefix)__@(spec.srv_name)_service_type_support_handle = {
   0,
-  &@(function_prefix)__@(spec.srv_name)_service_members
+  &@(function_prefix)__@(spec.srv_name)_service_members,
+  get_service_typesupport_handle_function,
 };
 
 // Forward declaration of request/response type support functions

--- a/rosidl_typesupport_introspection_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_introspection_cpp/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(rosidl_typesupport_introspection_c REQUIRED)
 ament_export_dependencies(rosidl_cmake)
 ament_export_dependencies(rosidl_generator_c)
 ament_export_dependencies(rosidl_generator_cpp)
+ament_export_dependencies(rosidl_typesupport_interface)
 ament_export_dependencies(rosidl_typesupport_introspection_c)
 
 ament_export_include_directories(include)

--- a/rosidl_typesupport_introspection_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_introspection_cpp/CMakeLists.txt
@@ -15,10 +15,7 @@ ament_export_dependencies(rosidl_generator_c)
 ament_export_dependencies(rosidl_generator_cpp)
 ament_export_dependencies(rosidl_typesupport_introspection_c)
 
-# The reason the impl folder is exported is that it contains the
-# implementation for the get_*_type_support_handle functions and defines the
-# rosidl_typesupport_introspection_cpp specific version of these functions.
-ament_export_include_directories(include include/${PROJECT_NAME}/impl)
+ament_export_include_directories(include)
 
 ament_python_install_package(${PROJECT_NAME})
 

--- a/rosidl_typesupport_introspection_cpp/cmake/rosidl_typesupport_introspection_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_introspection_cpp/cmake/rosidl_typesupport_introspection_cpp_generate_interfaces.cmake
@@ -94,6 +94,7 @@ target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp
 )
 ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+  "rosidl_typesupport_interface"
   "rosidl_typesupport_introspection_cpp")
 foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
   ament_target_dependencies(

--- a/rosidl_typesupport_introspection_cpp/cmake/rosidl_typesupport_introspection_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_introspection_cpp/cmake/rosidl_typesupport_introspection_cpp_generate_interfaces.cmake
@@ -79,6 +79,10 @@ add_custom_command(
 set(_target_suffix "__rosidl_typesupport_introspection_cpp")
 
 add_library(${rosidl_generate_interfaces_TARGET}${_target_suffix} SHARED ${_generated_files})
+if(rosidl_generate_interfaces_LIBRARY_NAME)
+  set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    PROPERTIES OUTPUT_NAME "${rosidl_generate_interfaces_LIBRARY_NAME}${_target_suffix}")
+endif()
 if(WIN32)
   target_compile_definitions(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     PRIVATE "ROSIDL_BUILDING_DLL")

--- a/rosidl_typesupport_introspection_cpp/package.xml
+++ b/rosidl_typesupport_introspection_cpp/package.xml
@@ -20,6 +20,7 @@
   <exec_depend>rosidl_generator_c</exec_depend>
   <exec_depend>rosidl_generator_cpp</exec_depend>
   <exec_depend>rosidl_parser</exec_depend>
+  <exec_depend>rosidl_typesupport_interface</exec_depend>
   <exec_depend>rosidl_typesupport_introspection_c</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
@@ -22,6 +22,7 @@
 
 #include "rosidl_generator_c/message_type_support_struct.h"
 #include "rosidl_typesupport_cpp/message_type_support.hpp"
+#include "rosidl_typesupport_interface/macros.h"
 
 #include "@(spec.base_type.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.base_type.type))__struct.hpp"
 #include "rosidl_typesupport_introspection_cpp/field_types.hpp"
@@ -153,7 +154,8 @@ static const ::rosidl_typesupport_introspection_cpp::MessageMembers @(spec.base_
 
 static const rosidl_message_type_support_t @(spec.base_type.type)_message_type_support_handle = {
   ::rosidl_typesupport_introspection_cpp::typesupport_identifier,
-  &@(spec.base_type.type)_message_members
+  &@(spec.base_type.type)_message_members,
+  get_message_typesupport_handle_function,
 };
 
 }  // namespace rosidl_typesupport_introspection_cpp
@@ -175,5 +177,20 @@ get_message_type_support_handle<@(spec.base_type.pkg_name)::@(subfolder)::@(spec
 }
 
 }  // namespace rosidl_typesupport_introspection_cpp
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_cpp, @(spec.base_type.pkg_name), @(subfolder), @(spec.base_type.type))() {
+  return &::@(spec.base_type.pkg_name)::@(subfolder)::rosidl_typesupport_introspection_cpp::@(spec.base_type.type)_message_type_support_handle;
+}
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  // __@(spec.base_type.pkg_name)__@(subfolder)__@(get_header_filename_from_msg_name(spec.base_type.type))__type_support__h__

--- a/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
@@ -21,14 +21,13 @@
 #include <vector>
 
 #include "rosidl_generator_c/message_type_support_struct.h"
-// this is defined in the rosidl_typesupport_introspection_cpp package and
-// is in the include/rosidl_typesupport_introspection_cpp/impl folder
-#include "rosidl_generator_cpp/message_type_support.hpp"
+#include "rosidl_typesupport_cpp/message_type_support.hpp"
 
 #include "@(spec.base_type.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.base_type.type))__struct.hpp"
 #include "rosidl_typesupport_introspection_cpp/field_types.hpp"
 #include "rosidl_typesupport_introspection_cpp/identifier.hpp"
 #include "rosidl_typesupport_introspection_cpp/message_introspection.hpp"
+#include "rosidl_typesupport_introspection_cpp/message_type_support_decl.hpp"
 #include "rosidl_typesupport_introspection_cpp/visibility_control.h"
 
 namespace @(spec.base_type.pkg_name)

--- a/rosidl_typesupport_introspection_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_introspection_cpp/resource/srv__type_support.cpp.em
@@ -14,16 +14,16 @@
 #define __@(spec.pkg_name)__@(get_header_filename_from_msg_name(spec.srv_name))__type_support__h__
 
 #include <rosidl_generator_c/service_type_support.h>
-// this is defined in the rosidl_typesupport_introspection_cpp package and
-// is in the include/rosidl_typesupport_introspection_cpp/impl folder
-#include <rosidl_generator_cpp/message_type_support.hpp>
-#include <rosidl_generator_cpp/service_type_support.hpp>
+#include <rosidl_typesupport_cpp/message_type_support.hpp>
+#include <rosidl_typesupport_cpp/service_type_support.hpp>
 
 #include "rosidl_typesupport_introspection_cpp/visibility_control.h"
 
 #include "@(spec.pkg_name)/srv/@(get_header_filename_from_msg_name(spec.srv_name))__struct.hpp"
 #include "rosidl_typesupport_introspection_cpp/identifier.hpp"
+#include "rosidl_typesupport_introspection_cpp/message_type_support_decl.hpp"
 #include "rosidl_typesupport_introspection_cpp/service_introspection.hpp"
+#include "rosidl_typesupport_introspection_cpp/service_type_support_decl.hpp"
 
 #include "@(spec.pkg_name)/srv/@(get_header_filename_from_msg_name(spec.request.base_type.type))__struct.hpp"
 #include "@(spec.pkg_name)/srv/@(get_header_filename_from_msg_name(spec.response.base_type.type))__struct.hpp"

--- a/rosidl_typesupport_introspection_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_introspection_cpp/resource/srv__type_support.cpp.em
@@ -16,6 +16,7 @@
 #include <rosidl_generator_c/service_type_support.h>
 #include <rosidl_typesupport_cpp/message_type_support.hpp>
 #include <rosidl_typesupport_cpp/service_type_support.hpp>
+#include "rosidl_typesupport_interface/macros.h"
 
 #include "rosidl_typesupport_introspection_cpp/visibility_control.h"
 
@@ -49,7 +50,8 @@ static ::rosidl_typesupport_introspection_cpp::ServiceMembers @(spec.srv_name)_s
 
 static const rosidl_service_type_support_t @(spec.srv_name)_service_type_support_handle = {
   ::rosidl_typesupport_introspection_cpp::typesupport_identifier,
-  &@(spec.srv_name)_service_members
+  &@(spec.srv_name)_service_members,
+  get_service_typesupport_handle_function,
 };
 
 }  // namespace rosidl_typesupport_introspection_cpp
@@ -102,5 +104,20 @@ get_service_type_support_handle<@(spec.pkg_name)::srv::@(spec.srv_name)>()
 }
 
 }  // namespace rosidl_typesupport_introspection_cpp
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC
+const rosidl_service_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(rosidl_typesupport_introspection_cpp, @(spec.pkg_name), @(spec.srv_name))() {
+  return ::rosidl_typesupport_introspection_cpp::get_service_type_support_handle<@(spec.pkg_name)::srv::@(spec.srv_name)>();
+}
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  // __@(spec.pkg_name)__@(get_header_filename_from_msg_name(spec.srv_name))__type_support__h__

--- a/rosidl_typesupport_introspection_cpp/src/identifier.cpp
+++ b/rosidl_typesupport_introspection_cpp/src/identifier.cpp
@@ -18,6 +18,6 @@ namespace rosidl_typesupport_introspection_cpp
 {
 
 ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_EXPORT
-const char * typesupport_identifier = "introspection_cpp";
+const char * typesupport_identifier = "rosidl_typesupport_introspection_cpp";
 
 }  // namespace rosidl_typesupport_introspection_cpp


### PR DESCRIPTION
This together with the other linked PRs switches to use the new `rosidl_typesupport_cpp` in C++. It only stores a map of typesupport names to their respective library / symbol name. It will then on-demand load the library using poco.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=1991)](http://ci.ros2.org/job/ci_linux/1991/)
* Mac OS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1532)](http://ci.ros2.org/job/ci_osx/1532/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=1963)](http://ci.ros2.org/job/ci_windows/1963/)

After this has been merged there will be a few follow up rounds:
* Do the same for C typesupport.
* Invert the package order so that  `rosidl_typesupport_cpp` is being built after all rmw implementations. If only a single rmw implementation is available it can then generate a shortcut which avoids poco.
* Do the same indirection / dispatcher for rmw itself.

Ready for review (either comment on all linked PRs individually or just here with a note that it covers all PRs).