### PR TITLE
Control shared/static linking via BUILD_SHARED_LIBS

### DIFF
--- a/rosidl_generator_c/CMakeLists.txt
+++ b/rosidl_generator_c/CMakeLists.txt
@@ -11,12 +11,12 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 find_package(rosidl_typesupport_interface REQUIRED)
 
 include_directories(include)
-add_library(${PROJECT_NAME} SHARED
+add_library(${PROJECT_NAME}
   "src/message_type_support.c"
   "src/primitives_array_functions.c"
   "src/service_type_support.c"

--- a/rosidl_generator_c/cmake/rosidl_generator_c_generate_interfaces.cmake
+++ b/rosidl_generator_c/cmake/rosidl_generator_c_generate_interfaces.cmake
@@ -122,7 +122,7 @@ list(APPEND _generated_msg_headers "${_visibility_control_file}")
 
 set(_target_suffix "__rosidl_generator_c")
 
-add_library(${rosidl_generate_interfaces_TARGET}${_target_suffix} SHARED
+add_library(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   ${_generated_msg_headers} ${_generated_msg_sources} ${_generated_srv_headers} ${_generated_srv_sources})
 if(rosidl_generate_interfaces_LIBRARY_NAME)
   set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix}

--- a/rosidl_generator_c/package.xml
+++ b/rosidl_generator_c/package.xml
@@ -7,11 +7,11 @@
   <maintainer email="william@osrfoundation.org">William Woodall</maintainer>
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <build_depend>rosidl_typesupport_interface</build_depend>
 
-  <buildtool_export_depend>ament_cmake</buildtool_export_depend>
+  <buildtool_export_depend>ament_cmake_ros</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
 
   <build_export_depend>rosidl_typesupport_interface</build_export_depend>

--- a/rosidl_generator_c/package.xml
+++ b/rosidl_generator_c/package.xml
@@ -11,7 +11,7 @@
 
   <build_depend>rosidl_typesupport_interface</build_depend>
 
-  <buildtool_export_depend>ament_cmake_ros</buildtool_export_depend>
+  <buildtool_export_depend>ament_cmake</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
 
   <build_export_depend>rosidl_typesupport_interface</build_export_depend>

--- a/rosidl_typesupport_introspection_c/CMakeLists.txt
+++ b/rosidl_typesupport_introspection_c/CMakeLists.txt
@@ -11,8 +11,8 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 
 ament_export_dependencies(rosidl_cmake)
 ament_export_dependencies(rosidl_generator_c)
@@ -24,7 +24,7 @@ ament_export_include_directories(include)
 
 ament_python_install_package(${PROJECT_NAME})
 
-add_library(${PROJECT_NAME} SHARED src/identifier.c)
+add_library(${PROJECT_NAME} src/identifier.c)
 if(WIN32)
   target_compile_definitions(${PROJECT_NAME}
     PRIVATE "ROSIDL_TYPESUPPORT_INTROSPECTION_C_BUILDING_DLL")

--- a/rosidl_typesupport_introspection_c/cmake/rosidl_typesupport_introspection_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_introspection_c/cmake/rosidl_typesupport_introspection_c_generate_interfaces.cmake
@@ -114,7 +114,7 @@ list(APPEND _generated_msg_header_files "${_visibility_control_file}")
 
 set(_target_suffix "__rosidl_typesupport_introspection_c")
 
-add_library(${rosidl_generate_interfaces_TARGET}${_target_suffix} SHARED
+add_library(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   ${_generated_msg_header_files} ${_generated_msg_source_files}
   ${_generated_srv_header_files} ${_generated_srv_source_files})
 if(rosidl_generate_interfaces_LIBRARY_NAME)

--- a/rosidl_typesupport_introspection_c/package.xml
+++ b/rosidl_typesupport_introspection_c/package.xml
@@ -9,9 +9,9 @@
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
-  <buildtool_export_depend>ament_cmake</buildtool_export_depend>
+  <buildtool_export_depend>ament_cmake_ros</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
 
   <exec_depend>rosidl_cmake</exec_depend>

--- a/rosidl_typesupport_introspection_c/package.xml
+++ b/rosidl_typesupport_introspection_c/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
-  <buildtool_export_depend>ament_cmake_ros</buildtool_export_depend>
+  <buildtool_export_depend>ament_cmake</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
 
   <exec_depend>rosidl_cmake</exec_depend>

--- a/rosidl_typesupport_introspection_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_introspection_cpp/CMakeLists.txt
@@ -11,8 +11,8 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 find_package(rosidl_typesupport_introspection_c REQUIRED)
 
 ament_export_dependencies(rosidl_cmake)
@@ -25,7 +25,7 @@ ament_export_include_directories(include)
 
 ament_python_install_package(${PROJECT_NAME})
 
-add_library(${PROJECT_NAME} SHARED src/identifier.cpp)
+add_library(${PROJECT_NAME} src/identifier.cpp)
 if(WIN32)
   target_compile_definitions(${PROJECT_NAME}
     PRIVATE "ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_BUILDING_DLL")

--- a/rosidl_typesupport_introspection_cpp/cmake/rosidl_typesupport_introspection_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_introspection_cpp/cmake/rosidl_typesupport_introspection_cpp_generate_interfaces.cmake
@@ -94,7 +94,7 @@ add_custom_command(
 
 set(_target_suffix "__rosidl_typesupport_introspection_cpp")
 
-add_library(${rosidl_generate_interfaces_TARGET}${_target_suffix} SHARED
+add_library(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   ${_generated_msg_header_files} ${_generated_msg_source_files}
   ${_generated_srv_header_files} ${_generated_srv_source_files})
 if(rosidl_generate_interfaces_LIBRARY_NAME)

--- a/rosidl_typesupport_introspection_cpp/package.xml
+++ b/rosidl_typesupport_introspection_cpp/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
-  <buildtool_export_depend>ament_cmake_ros</buildtool_export_depend>
+  <buildtool_export_depend>ament_cmake</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
 
   <build_depend>rosidl_typesupport_introspection_c</build_depend>

--- a/rosidl_typesupport_introspection_cpp/package.xml
+++ b/rosidl_typesupport_introspection_cpp/package.xml
@@ -9,9 +9,9 @@
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
-  <buildtool_export_depend>ament_cmake</buildtool_export_depend>
+  <buildtool_export_depend>ament_cmake_ros</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
 
   <build_depend>rosidl_typesupport_introspection_c</build_depend>


### PR DESCRIPTION
This PR delegates the decision to build a shared or a static library to CMake's BUILD_SHARED_LIBS

Update:

Connects to https://github.com/ros2/ros2/issues/306