### PR TITLE
[rosidl_generator_py] enforce value range

### DIFF
--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -205,7 +205,7 @@ bound = 2**nbits
 }@
              all([val >= 0 and val < @(bound) for val in value]))
 @[      elif field.type.type == 'char']@
-             all([ord(val) >= -128 and val < 128 for val in value]))
+             all([ord(val) >= -128 and ord(val) < 128 for val in value]))
 @[      else]@
              True)
 @[      end if]@

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -202,7 +202,7 @@ class @(spec.base_type.type)(metaclass=Metaclass):
              len(value) == 1)
 @[  elif field.type.type == 'char']@
             ((isinstance(value, str) or isinstance(value, UserString)) and
-             len(value) == 1)
+             len(value) == 1 and ord(value) >= -128 and ord(value) < 128)
 @[  elif field.type.type in [
         'bool',
         'float32', 'float64',
@@ -212,6 +212,19 @@ class @(spec.base_type.type)(metaclass=Metaclass):
         'int64', 'uint64',
         'string',
     ]]@
+@[    if field.type.type.startswith('int')]@
+@{
+nbytes = int(field.type.type[field.type.type.rfind('t') + 1:])
+bound = 2**(nbytes - 1)
+}@
+            (value >= -@(bound) and value < @(bound)) and \
+@[    elif field.type.type.startswith('uint')]@
+@{
+nbytes = int(field.type.type[field.type.type.rfind('t') + 1:])
+bound = 2**nbytes
+}@
+            (value >= 0 and value < @(bound)) and \
+@[    end if]@
             isinstance(value, @(get_python_type(field.type)))
 @[  else]@
             False

--- a/rosidl_generator_py/test/test_interfaces.py
+++ b/rosidl_generator_py/test/test_interfaces.py
@@ -199,3 +199,34 @@ def test_check_constraints():
     assert ['foo', 'bar', 'baz'] == c.up_to_three_string_values
     assert_raises(
         AssertionError, setattr, c, 'up_to_three_string_values', ['foo', 'bar', 'baz', 'hello'])
+
+
+def test_out_of_range():
+    a = Primitives()
+    assert_raises(
+        AssertionError, setattr, a, 'char_value', '\x80')
+    for i in [8, 16, 32, 64]:
+        assert_raises(
+            AssertionError, setattr, a, 'int%d_value' % i, 2**(i - 1))
+        assert_raises(
+            AssertionError, setattr, a, 'int%d_value' % i, -2**(i - 1) - 1)
+        assert_raises(
+            AssertionError, setattr, a, 'uint%d_value' % i, -1)
+        assert_raises(
+            AssertionError, setattr, a, 'int%d_value' % i, 2**i)
+
+    b = Various()
+    assert_raises(
+        AssertionError, setattr, b, 'two_uint16_value', [2**16])
+    assert_raises(
+        AssertionError, setattr, b, 'two_uint16_value', [-1])
+
+    assert_raises(
+        AssertionError, setattr, b, 'up_to_three_int32_values', [2**31])
+    assert_raises(
+        AssertionError, setattr, b, 'up_to_three_int32_values', [-2**31 - 1])
+
+    assert_raises(
+        AssertionError, setattr, b, 'unbounded_uint64_values', [2**64])
+    assert_raises(
+        AssertionError, setattr, b, 'unbounded_uint64_values', [-1])


### PR DESCRIPTION
Currently we never check if the values fit and we cast them at the C level before serialization without even throwing a warning.
This prevents users from setting out of range values. This change applies only to message fields, not default values or constants because the parser already enforce these.