### PR TITLE
rosidl_generator_cpp: fixed size check in BoundedVector<T>::assign(first, last)

### DIFF
--- a/rosidl_generator_cpp/include/rosidl_generator_cpp/bounded_vector.hpp
+++ b/rosidl_generator_cpp/include/rosidl_generator_cpp/bounded_vector.hpp
@@ -276,7 +276,7 @@ public:
   void
   assign(_InputIterator __first, _InputIterator __last)
   {
-    if (size() + std::distance(__first, __last) > _UpperBound) {
+    if (std::distance(__first, __last) > _UpperBound) {
       throw std::length_error("Exceeded upper bound");
     }
     _Base::assign(__first, __last);


### PR DESCRIPTION
Example:
```cpp
using namespace rosidl_generator_cpp;

int main(int argc, char **argv) {
  BoundedVector<int, 3> bounded_vector{1, 2, 3};
  int assigned_values[3] = { 4, 5, 6 };

  // unexpectedly throws length_error:
  // size() + std::distance(assigned_values, assigned_values + 3) == 6 > 3 == _UpperBound
  bounded_vector.assign(assigned_values, assigned_values + 3);

  return 0;
}
```