### PR TITLE
[rosidl_generator_py] Fixes srv only generation

### DIFF
--- a/rosidl_generator_py/cmake/custom_command.cmake
+++ b/rosidl_generator_py/cmake/custom_command.cmake
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 add_custom_command(
-  OUTPUT ${_generated_msg_py_files} ${_generated_msg_c_files} ${_generated_srv_py_files} ${_generated_srv_c_files}
+  OUTPUT ${_generated_extension_files} ${_generated_msg_py_files} ${_generated_msg_c_files} ${_generated_srv_py_files} ${_generated_srv_c_files}
   COMMAND ${PYTHON_EXECUTABLE} ${rosidl_generator_py_BIN}
   --generator-arguments-file "${generator_arguments_file}"
   --typesupport-impls "${_typesupport_impls}"
@@ -28,6 +28,7 @@ else()
   add_custom_target(
     ${rosidl_generate_interfaces_TARGET}${_target_suffix}
     DEPENDS
+    ${_generated_extension_files}
     ${_generated_msg_py_files}
     ${_generated_msg_c_files}
     ${_generated_srv_py_files}

--- a/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
@@ -269,7 +269,7 @@ endforeach()
 if(BUILD_TESTING AND rosidl_generate_interfaces_ADD_LINTER_TESTS)
   if(
     NOT _generated_msg_py_files STREQUAL "" OR
-    NOT _generated_msg_extension_files STREQUAL "" OR
+    NOT _generated_extension_files STREQUAL "" OR
     NOT _generated_msg_c_files STREQUAL "" OR
     NOT _generated_srv_py_files STREQUAL "" OR
     NOT _generated_srv_c_files STREQUAL ""

--- a/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
@@ -56,15 +56,7 @@ foreach(_idl_file ${rosidl_generate_interfaces_IDL_FILES})
     list(APPEND _generated_msg_c_files
       "${_output_path}/${_parent_folder}/_${_module_name}_s.c"
     )
-    foreach(_typesupport_impl ${_typesupport_impls})
-      list_append_unique(_generated_extension_files "${_output_path}/_${PROJECT_NAME}_s.ep.${_typesupport_impl}.c")
-      list_append_unique(_generated_extension_${_typesupport_impl}_files "${_output_path}/_${PROJECT_NAME}_s.ep.${_typesupport_impl}.c")
-    endforeach()
   elseif(_parent_folder STREQUAL "srv")
-    foreach(_typesupport_impl ${_typesupport_impls})
-      list_append_unique(_generated_extension_files "${_output_path}/_${PROJECT_NAME}_s.ep.${_typesupport_impl}.c")
-      list_append_unique(_generated_extension_${_typesupport_impl}_files "${_output_path}/_${PROJECT_NAME}_s.ep.${_typesupport_impl}.c")
-    endforeach()
     if("_${_module_name}_s.c" MATCHES "(.*)__response(.*)" OR "_${_module_name}_s.c" MATCHES "(.*)__request(.*)")
       list(APPEND _generated_srv_c_files
         "${_output_path}/${_parent_folder}/_${_module_name}_s.c"
@@ -97,6 +89,12 @@ if(NOT _generated_srv_py_files STREQUAL "")
   )
 endif()
 
+if(NOT _generated_msg_c_files STREQUAL "" OR NOT _generated_srv_c_files STREQUAL "")
+    foreach(_typesupport_impl ${_typesupport_impls})
+      list(APPEND _generated_extension_${_typesupport_impl}_files "${_output_path}/_${PROJECT_NAME}_s.ep.${_typesupport_impl}.c")
+      list(APPEND _generated_extension_files "${_generated_extension_${_typesupport_impl}_files}")
+    endforeach()
+endif()
 set(_dependency_files "")
 set(_dependencies "")
 foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})

--- a/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
@@ -33,9 +33,9 @@ endif()
 
 set(_output_path
   "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_py/${PROJECT_NAME}")
+set(_generated_extension_files "")
 set(_generated_msg_py_files "")
 set(_generated_msg_c_files "")
-set(_generated_msg_c_common_files "")
 set(_generated_srv_py_files "")
 set(_generated_srv_c_files "")
 
@@ -56,16 +56,13 @@ foreach(_idl_file ${rosidl_generate_interfaces_IDL_FILES})
     list(APPEND _generated_msg_c_files
       "${_output_path}/${_parent_folder}/_${_module_name}_s.c"
     )
-    list(APPEND _generated_msg_c_common_files
-      "${_output_path}/${_parent_folder}/_${_module_name}_s.c"
-    )
     foreach(_typesupport_impl ${_typesupport_impls})
-      list_append_unique(_generated_msg_c_files "${_output_path}/_${PROJECT_NAME}_s.ep.${_typesupport_impl}.c")
+      list_append_unique(_generated_extension_files "${_output_path}/_${PROJECT_NAME}_s.ep.${_typesupport_impl}.c")
       list_append_unique(_generated_extension_${_typesupport_impl}_files "${_output_path}/_${PROJECT_NAME}_s.ep.${_typesupport_impl}.c")
     endforeach()
   elseif(_parent_folder STREQUAL "srv")
     foreach(_typesupport_impl ${_typesupport_impls})
-      list_append_unique(_generated_msg_c_files "${_output_path}/_${PROJECT_NAME}_s.ep.${_typesupport_impl}.c")
+      list_append_unique(_generated_extension_files "${_output_path}/_${PROJECT_NAME}_s.ep.${_typesupport_impl}.c")
       list_append_unique(_generated_extension_${_typesupport_impl}_files "${_output_path}/_${PROJECT_NAME}_s.ep.${_typesupport_impl}.c")
     endforeach()
     if("_${_module_name}_s.c" MATCHES "(.*)__response(.*)" OR "_${_module_name}_s.c" MATCHES "(.*)__request(.*)")
@@ -184,7 +181,7 @@ file(WRITE "${_subdir}/CMakeLists.txt" "${_custom_command}")
 add_subdirectory("${_subdir}" ${rosidl_generate_interfaces_TARGET}${_target_suffix})
 set_property(
   SOURCE
-  ${_generated_msg_py_files} ${_generated_msg_c_files} ${_generated_srv_py_files} ${_generated_srv_c_files}
+  ${_generated_extension_files} ${_generated_msg_py_files} ${_generated_msg_c_files} ${_generated_srv_py_files} ${_generated_srv_c_files}
   PROPERTY GENERATED 1)
 
 macro(set_properties _build_type)
@@ -205,7 +202,7 @@ foreach(_typesupport_impl ${_typesupport_impls})
 
   add_library(${_target_name} SHARED
     ${_generated_extension_${_typesupport_impl}_files}
-    ${_generated_msg_c_common_files}
+    ${_generated_msg_c_files}
     ${_generated_srv_c_files}
   )
 
@@ -274,8 +271,8 @@ endforeach()
 if(BUILD_TESTING AND rosidl_generate_interfaces_ADD_LINTER_TESTS)
   if(
     NOT _generated_msg_py_files STREQUAL "" OR
+    NOT _generated_msg_extension_files STREQUAL "" OR
     NOT _generated_msg_c_files STREQUAL "" OR
-    NOT _generated_msg_c_common_files STREQUAL "" OR
     NOT _generated_srv_py_files STREQUAL "" OR
     NOT _generated_srv_c_files STREQUAL ""
   )

--- a/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
@@ -40,7 +40,7 @@ set(_generated_srv_py_files "")
 set(_generated_srv_c_files "")
 
 foreach(_typesupport_impl ${_typesupport_impls})
-  set(_generated_msg_c_ts_${_typesupport_impl}_files "")
+  set(_generated_extension_${_typesupport_impl}_files "")
 endforeach()
 
 foreach(_idl_file ${rosidl_generate_interfaces_IDL_FILES})
@@ -60,10 +60,14 @@ foreach(_idl_file ${rosidl_generate_interfaces_IDL_FILES})
       "${_output_path}/${_parent_folder}/_${_module_name}_s.c"
     )
     foreach(_typesupport_impl ${_typesupport_impls})
-      list_append_unique(_generated_msg_c_files "${_output_path}/${_parent_folder}/_${PROJECT_NAME}_s.ep.${_typesupport_impl}.c")
-      list_append_unique(_generated_msg_c_ts_${_typesupport_impl}_files "${_output_path}/${_parent_folder}/_${PROJECT_NAME}_s.ep.${_typesupport_impl}.c")
+      list_append_unique(_generated_msg_c_files "${_output_path}/_${PROJECT_NAME}_s.ep.${_typesupport_impl}.c")
+      list_append_unique(_generated_extension_${_typesupport_impl}_files "${_output_path}/_${PROJECT_NAME}_s.ep.${_typesupport_impl}.c")
     endforeach()
   elseif(_parent_folder STREQUAL "srv")
+    foreach(_typesupport_impl ${_typesupport_impls})
+      list_append_unique(_generated_msg_c_files "${_output_path}/_${PROJECT_NAME}_s.ep.${_typesupport_impl}.c")
+      list_append_unique(_generated_extension_${_typesupport_impl}_files "${_output_path}/_${PROJECT_NAME}_s.ep.${_typesupport_impl}.c")
+    endforeach()
     if("_${_module_name}_s.c" MATCHES "(.*)__response(.*)" OR "_${_module_name}_s.c" MATCHES "(.*)__request(.*)")
       list(APPEND _generated_srv_c_files
         "${_output_path}/${_parent_folder}/_${_module_name}_s.c"
@@ -200,7 +204,7 @@ foreach(_typesupport_impl ${_typesupport_impls})
   set(_target_name "${PROJECT_NAME}__${_typesupport_impl}${_pyext_suffix}")
 
   add_library(${_target_name} SHARED
-    ${_generated_msg_c_ts_${_typesupport_impl}_files}
+    ${_generated_extension_${_typesupport_impl}_files}
     ${_generated_msg_c_common_files}
     ${_generated_srv_c_files}
   )

--- a/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
+++ b/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
@@ -121,7 +121,8 @@ def generate_py(generator_arguments_file, typesupport_impls):
             }
             data.update(functions)
             generated_file = os.path.join(
-                args['output_dir'], 'msg', generated_filename % args['package_name'])
+                args['output_dir'], generated_filename % args['package_name'])
+            print('***generated file: %s' % generated_file)
             expand_template(
                 template_file, data, generated_file,
                 minimum_timestamp=latest_target_timestamp)

--- a/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
+++ b/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
@@ -122,7 +122,6 @@ def generate_py(generator_arguments_file, typesupport_impls):
             data.update(functions)
             generated_file = os.path.join(
                 args['output_dir'], generated_filename % args['package_name'])
-            print('***generated file: %s' % generated_file)
             expand_template(
                 template_file, data, generated_file,
                 minimum_timestamp=latest_target_timestamp)


### PR DESCRIPTION
fixes https://github.com/ros2/rosidl/issues/193
Connects to https://github.com/ros2/rosidl/issues/193
Reason of the failure: the generated file with all python extension symbols was not added to the library when no `.msg` files were present
What this PR does:
 * generated the extension files in the package folder rather than the `msg` subfolder
 * store extension files' paths in a msg agnostic cmake variable and use it for custom command and shared library

CI:
Linux: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2173)](http://ci.ros2.org/job/ci_linux/2173/)
OSX: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1655)](http://ci.ros2.org/job/ci_osx/1655/)
Windows: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2175)](http://ci.ros2.org/job/ci_windows/2175/)