### PR TITLE
Fix string delimiter

### DIFF
--- a/rosidl_generator_py/msg/Strings.msg
+++ b/rosidl_generator_py/msg/Strings.msg
@@ -2,8 +2,6 @@ string empty_string
 string def_string "Hello world!"
 string def_string_delimiter 'Hello"world!'
 string def_string_delimiter2 "Hello'world!"
-string def_string_delimiter3 'Hello'world!'
-string def_string_delimiter4 "Hello"world!"
 string<=22 ub_string
 string<=22 ub_def_string "Upper bounded string."
 string<=5[3] ub_string_static_array_value

--- a/rosidl_generator_py/msg/Strings.msg
+++ b/rosidl_generator_py/msg/Strings.msg
@@ -1,5 +1,9 @@
 string empty_string
 string def_string "Hello world!"
+string def_string_delimiter 'Hello"world!'
+string def_string_delimiter2 "Hello'world!"
+string def_string_delimiter3 'Hello'world!'
+string def_string_delimiter4 "Hello"world!"
 string<=22 ub_string
 string<=22 ub_def_string "Upper bounded string."
 string<=5[3] ub_string_static_array_value

--- a/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
+++ b/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
@@ -207,7 +207,7 @@ def constant_value_to_py(type_, value):
 
 def escape_string(s):
     s = s.replace('\\', '\\\\')
-    s = s.replace("'", "\\'")
+    s = s.replace('"', '\\"')
     return s
 
 

--- a/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
+++ b/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
@@ -208,6 +208,7 @@ def constant_value_to_py(type_, value):
 def escape_string(s):
     s = s.replace('\\', '\\\\')
     s = s.replace('"', '\\"')
+    s = s.replace("'", "\\'")
     return s
 
 

--- a/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
+++ b/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
@@ -171,7 +171,7 @@ def primitive_value_to_py(type_, value):
         return '%s' % value
 
     if type_.type == 'string':
-        return '"%s"' % escape_string(value)
+        return "'%s'" % escape_string(value)
 
     assert False, "unknown primitive type '%s'" % type_.type
 
@@ -207,7 +207,6 @@ def constant_value_to_py(type_, value):
 
 def escape_string(s):
     s = s.replace('\\', '\\\\')
-    s = s.replace('"', '\\"')
     s = s.replace("'", "\\'")
     return s
 

--- a/rosidl_generator_py/test/test_interfaces.py
+++ b/rosidl_generator_py/test/test_interfaces.py
@@ -111,6 +111,10 @@ def test_default_values():
     assert 'Bye world' == a.def_string
     assert 'Hello world!' == Strings.DEF_STRING__DEFAULT
     assert 'Hello world!' == a.DEF_STRING__DEFAULT
+    assert 'Hello\"world!' == a.DEF_STRING_DELIMITER__DEFAULT
+    assert "Hello'world!" == a.DEF_STRING_DELIMITER2__DEFAULT
+    assert "Hello'world!" == a.DEF_STRING_DELIMITER3__DEFAULT
+    assert 'Hello\"world!' == a.DEF_STRING_DELIMITER4__DEFAULT
     assert_raises(AttributeError, setattr, Strings, 'DEF_STRING__DEFAULT', 'bar')
 
     b = Various()

--- a/rosidl_generator_py/test/test_interfaces.py
+++ b/rosidl_generator_py/test/test_interfaces.py
@@ -111,8 +111,8 @@ def test_default_values():
     assert 'Bye world' == a.def_string
     assert 'Hello world!' == Strings.DEF_STRING__DEFAULT
     assert 'Hello world!' == a.DEF_STRING__DEFAULT
-    assert "Hello\"world!" == a.DEF_STRING_DELIMITER__DEFAULT
-    assert 'Hello\'world!' == a.DEF_STRING_DELIMITER2__DEFAULT
+    assert 'Hello"world!' == a.DEF_STRING_DELIMITER__DEFAULT
+    assert "Hello'world!" == a.DEF_STRING_DELIMITER2__DEFAULT
     assert_raises(AttributeError, setattr, Strings, 'DEF_STRING__DEFAULT', 'bar')
 
     b = Various()

--- a/rosidl_generator_py/test/test_interfaces.py
+++ b/rosidl_generator_py/test/test_interfaces.py
@@ -111,10 +111,8 @@ def test_default_values():
     assert 'Bye world' == a.def_string
     assert 'Hello world!' == Strings.DEF_STRING__DEFAULT
     assert 'Hello world!' == a.DEF_STRING__DEFAULT
-    assert 'Hello\"world!' == a.DEF_STRING_DELIMITER__DEFAULT
-    assert "Hello'world!" == a.DEF_STRING_DELIMITER2__DEFAULT
-    assert "Hello'world!" == a.DEF_STRING_DELIMITER3__DEFAULT
-    assert 'Hello\"world!' == a.DEF_STRING_DELIMITER4__DEFAULT
+    assert "Hello\"world!" == a.DEF_STRING_DELIMITER__DEFAULT
+    assert 'Hello\'world!' == a.DEF_STRING_DELIMITER2__DEFAULT
     assert_raises(AttributeError, setattr, Strings, 'DEF_STRING__DEFAULT', 'bar')
 
     b = Various()


### PR DESCRIPTION
rosidl_parser uses double quote as string delimiter. So we should escape double quotes instead of single quotes.
Addresses https://github.com/ros2/rosidl/pull/197#discussion_r94443669

Before:
```python
            'DEF_STRING_DELIMITER__DEFAULT': "Hello"world!",
            'DEF_STRING_DELIMITER2__DEFAULT': "Hello\'world!",
            'DEF_STRING_DELIMITER3__DEFAULT': "Hello\'world!",
            'DEF_STRING_DELIMITER4__DEFAULT': "Hello"world!",
```
After
```python
            'DEF_STRING_DELIMITER__DEFAULT': "Hello\"world!",
            'DEF_STRING_DELIMITER2__DEFAULT': "Hello'world!",
            'DEF_STRING_DELIMITER3__DEFAULT': "Hello'world!",
            'DEF_STRING_DELIMITER4__DEFAULT': "Hello\"world!",
```