### PR TITLE
enforce string length in byte rather than characters

### DIFF
--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -211,7 +211,7 @@ bound = 2**nbits
 @[      end if]@
 @[  elif field.type.string_upper_bound]@
             ((isinstance(value, str) or isinstance(value, UserString)) and
-             len(value) <= @(field.type.string_upper_bound))
+             len(value.encode('utf-8')) <= @(field.type.string_upper_bound))
 @[  elif not field.type.is_primitive_type()]@
             isinstance(value, @(field.type.type))
 @[  elif field.type.type == 'byte']@

--- a/rosidl_generator_py/test/test_interfaces.py
+++ b/rosidl_generator_py/test/test_interfaces.py
@@ -134,6 +134,8 @@ def test_check_constraints():
     a.ub_string = 'a' * 22
     assert 'a' * 22 == a.ub_string
     assert_raises(AssertionError, setattr, a, 'ub_string', 'a' * 23)
+    assert len('こ' * 22) == 22
+    assert_raises(AssertionError, setattr, a, 'ub_string', 'こ' * 22)
 
     b = Nested()
     primitives = Primitives()


### PR DESCRIPTION
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2567)](http://ci.ros2.org/job/ci_linux/2567/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=164)](http://ci.ros2.org/job/ci_linux-aarch64/164/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2037)](http://ci.ros2.org/job/ci_osx/2037/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2676)](http://ci.ros2.org/job/ci_windows/2676/)

related to ros2/ros2#384