### PR TITLE
Fix destroy segfault

### DIFF
--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -10,7 +10,6 @@ class Metaclass(type):
 
     _CONVERT_FROM_PY = None
     _CONVERT_TO_PY = None
-    _DESTROY_ROS_MESSAGE = None
     _TYPE_SUPPORT = None
 
     __constants = {
@@ -32,7 +31,6 @@ class Metaclass(type):
             cls._CONVERT_FROM_PY = module.convert_from_py_msg_@(module_name)
             cls._CONVERT_TO_PY = module.convert_to_py_msg_@(module_name)
             cls._TYPE_SUPPORT = module.type_support_msg_@(module_name)
-            cls._DESTROY_ROS_MESSAGE = module.destroy_ros_message_msg_@(module_name)
 @{
 importable_typesupports = {}
 for field in spec.fields:

--- a/rosidl_generator_py/resource/_msg_support.c.em
+++ b/rosidl_generator_py/resource/_msg_support.c.em
@@ -225,14 +225,6 @@ nested_type = '%s__%s__%s' % (field.type.pkg_name, 'msg', field.type.type)
   return ros_message;
 }
 
-void @(spec.base_type.pkg_name)_@(module_name)__destroy_ros_message(void * raw_ros_message)
-{
-  @(msg_typename) * ros_message = (@(msg_typename) *)raw_ros_message;
-  (void)ros_message;
-
-  @(msg_typename)__destroy(ros_message);
-}
-
 PyObject * @(spec.base_type.pkg_name)_@(module_name)__convert_to_py(void * raw_ros_message)
 {
   @(msg_typename) * ros_message = (@(msg_typename) *)raw_ros_message;

--- a/rosidl_generator_py/resource/_msg_support.entry_point.c.em
+++ b/rosidl_generator_py/resource/_msg_support.entry_point.c.em
@@ -42,7 +42,6 @@ type_name = spec.base_type.type
 module_name = convert_camel_case_to_lower_case_underscore(type_name)
 }@
 void * @(spec.base_type.pkg_name)_@(module_name)__convert_from_py(PyObject * _pymsg);
-void @(spec.base_type.pkg_name)_@(module_name)__destroy_ros_message(void * raw_ros_message);
 PyObject * @(spec.base_type.pkg_name)_@(module_name)__convert_to_py(void * raw_ros_message);
 @[end for]@
 
@@ -65,7 +64,7 @@ static struct PyModuleDef @(package_name)__module = {
 @[for spec, subfolder in message_specs]@
 @{
 type_name = convert_camel_case_to_lower_case_underscore(spec.base_type.type)
-function_names = ['convert_from_py', 'destroy_ros_message', 'convert_to_py', 'type_support']
+function_names = ['convert_from_py', 'convert_to_py', 'type_support']
 }@
 
 ROSIDL_GENERATOR_C_IMPORT


### PR DESCRIPTION
this is a follow up of https://github.com/ros2/rclpy/pull/87. It reverts #215 (by not clearing the allocated memory properly) makes the subscriber crash on message destruction for arrays of nested arrays. Leaving this in progress the time I add a regression test for it

connects to ros2/rclpy#87