### PR TITLE
Cleanup generator py templates

### DIFF
--- a/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
@@ -110,7 +110,7 @@ set(target_dependencies
   "${rosidl_generator_py_BIN}"
   ${rosidl_generator_py_GENERATOR_FILES}
   "${rosidl_generator_py_TEMPLATE_DIR}/_msg_support.c.em"
-  "${rosidl_generator_py_TEMPLATE_DIR}/_msg_support.entry_point.c.em"
+  "${rosidl_generator_py_TEMPLATE_DIR}/_msg_pkg_typesupport_entry_point.c.em"
   "${rosidl_generator_py_TEMPLATE_DIR}/_msg.py.em"
   "${rosidl_generator_py_TEMPLATE_DIR}/_srv.py.em"
   ${rosidl_generate_interfaces_IDL_FILES}

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -1,6 +1,20 @@
 # generated from rosidl_generator_py/resource/_msg.py.em
 # generated code does not contain a copyright notice
 
+@#######################################################################
+@# EmPy template for generating
+@# _<msg>.py files
+@#
+@# Context:
+@#  - module_name
+@#  - package_name
+@#  - spec (rosidl_parser.MessageSpecification)
+@#    Parsed specification of the .msg file
+@#  - constant_value_to_py (function)
+@#  - get_python_type (function)
+@#  - value_to_py (function)
+@#######################################################################
+@
 import logging
 import traceback
 

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -2,8 +2,7 @@
 # generated code does not contain a copyright notice
 
 @#######################################################################
-@# EmPy template for generating
-@# _<msg>.py files
+@# EmPy template for generating _<msg>.py files
 @#
 @# Context:
 @#  - module_name

--- a/rosidl_generator_py/resource/_msg_pkg_typesupport_entry_point.c.em
+++ b/rosidl_generator_py/resource/_msg_pkg_typesupport_entry_point.c.em
@@ -1,6 +1,17 @@
-// generated from rosidl_generator_py/resource/_msg_support.entry_point.c.em
+// generated from rosidl_generator_py/resource/_msg_pkg_typesupport_entry_point.c.em
 // generated code does not contain a copyright notice
 
+@#######################################################################
+@# EmPy template for generating
+@# _<msg_pkg>_s.ep.<typesupport_impl>_c.c files
+@#
+@# Context:
+@#  - module_name
+@#  - spec (rosidl_parser.ServiceSpecification)
+@#    Parsed specification of the .srv file
+@#  - get_header_filename_from_msg_name (function)
+@#######################################################################
+@
 #include <Python.h>
 #include <stdint.h>
 
@@ -33,6 +44,7 @@ for spec, subfolder in service_specs:
   key = '%s/%s/%s' % (spec.pkg_name, subfolder, module_name)
   includes[key] = '#include <%s.h>' % key
 }@
+
 @[for v in sorted(includes.values())]@
 @(v)
 @[end for]@
@@ -41,6 +53,7 @@ for spec, subfolder in service_specs:
 type_name = spec.base_type.type
 module_name = convert_camel_case_to_lower_case_underscore(type_name)
 }@
+// TEST TEST3 @(module_name)
 void * @(spec.base_type.pkg_name)_@(module_name)__convert_from_py(PyObject * _pymsg);
 void @(spec.base_type.pkg_name)_@(module_name)__destroy_ros_message(void * raw_ros_message);
 PyObject * @(spec.base_type.pkg_name)_@(module_name)__convert_to_py(void * raw_ros_message);

--- a/rosidl_generator_py/resource/_msg_pkg_typesupport_entry_point.c.em
+++ b/rosidl_generator_py/resource/_msg_pkg_typesupport_entry_point.c.em
@@ -47,7 +47,6 @@ for spec, subfolder in service_specs:
   key = '%s/%s/%s' % (spec.pkg_name, subfolder, module_name)
   includes[key] = '#include <%s.h>' % key
 }@
-
 @[for v in sorted(includes.values())]@
 @(v)
 @[end for]@
@@ -56,7 +55,6 @@ for spec, subfolder in service_specs:
 type_name = spec.base_type.type
 module_name = convert_camel_case_to_lower_case_underscore(type_name)
 }@
-// TEST TEST3 @(module_name)
 void * @(spec.base_type.pkg_name)_@(module_name)__convert_from_py(PyObject * _pymsg);
 void @(spec.base_type.pkg_name)_@(module_name)__destroy_ros_message(void * raw_ros_message);
 PyObject * @(spec.base_type.pkg_name)_@(module_name)__convert_to_py(void * raw_ros_message);

--- a/rosidl_generator_py/resource/_msg_pkg_typesupport_entry_point.c.em
+++ b/rosidl_generator_py/resource/_msg_pkg_typesupport_entry_point.c.em
@@ -6,10 +6,13 @@
 @# _<msg_pkg>_s.ep.<typesupport_impl>_c.c files
 @#
 @# Context:
-@#  - module_name
-@#  - spec (rosidl_parser.ServiceSpecification)
-@#    Parsed specification of the .srv file
-@#  - get_header_filename_from_msg_name (function)
+@#  - package_name
+@#  - message_specs (list of rosidl_parser.MessageSpecification)
+@#    Parsed specification of the .msg files
+@#  - service_specs (list of rosidl_parser.ServiceSpecification)
+@#    Parsed specification of the .srv files
+@#  - typesupport_impl (string identifying the typesupport used)
+@#  - convert_camel_case_to_lower_case_underscore (function)
 @#######################################################################
 @
 #include <Python.h>

--- a/rosidl_generator_py/resource/_msg_pkg_typesupport_entry_point.c.em
+++ b/rosidl_generator_py/resource/_msg_pkg_typesupport_entry_point.c.em
@@ -2,8 +2,7 @@
 // generated code does not contain a copyright notice
 
 @#######################################################################
-@# EmPy template for generating
-@# _<msg_pkg>_s.ep.<typesupport_impl>_c.c files
+@# EmPy template for generating _<msg_pkg>_s.ep.<typesupport_impl>_c.c files
 @#
 @# Context:
 @#  - package_name

--- a/rosidl_generator_py/resource/_msg_support.c.em
+++ b/rosidl_generator_py/resource/_msg_support.c.em
@@ -1,6 +1,18 @@
 // generated from rosidl_generator_py/resource/_msg_support.c.em
 // generated code does not contain a copyright notice
 
+@#######################################################################
+@# EmPy template for generating
+@# _<msg>_s.c files
+@#
+@# Context:
+@#  - module_name
+@#  - spec (rosidl_parser.MessageSpecification)
+@#    Parsed specification of the .msg file
+@#  - convert_camel_case_to_lower_case_underscore (function)
+@#  - primitive_msg_type_to_c (function)
+@#######################################################################
+@
 #include <Python.h>
 
 #include <@(spec.base_type.pkg_name)/@(subfolder)/@(module_name)__struct.h>

--- a/rosidl_generator_py/resource/_msg_support.c.em
+++ b/rosidl_generator_py/resource/_msg_support.c.em
@@ -2,8 +2,7 @@
 // generated code does not contain a copyright notice
 
 @#######################################################################
-@# EmPy template for generating
-@# _<msg>_s.c files
+@# EmPy template for generating _<msg>_s.c files
 @#
 @# Context:
 @#  - module_name

--- a/rosidl_generator_py/resource/_srv.py.em
+++ b/rosidl_generator_py/resource/_srv.py.em
@@ -1,6 +1,18 @@
 # generated from rosidl_generator_py/resource/_srv.py.em
 # generated code does not contain a copyright notice
 
+@#######################################################################
+@# EmPy template for generating
+@# _<msg>.py files
+@#
+@# Context:
+@#  - module_name
+@#  - package_name
+@#  - spec (rosidl_parser.ServiceSpecification)
+@#    Parsed specification of the .msg file
+@#  - convert_camel_case_to_lower_case_underscore (function)
+@#######################################################################
+@
 import logging
 import traceback
 

--- a/rosidl_generator_py/resource/_srv.py.em
+++ b/rosidl_generator_py/resource/_srv.py.em
@@ -2,13 +2,13 @@
 # generated code does not contain a copyright notice
 
 @#######################################################################
-@# EmPy template for generating _<msg>.py files
+@# EmPy template for generating _<srv>.py files
 @#
 @# Context:
 @#  - module_name
 @#  - package_name
 @#  - spec (rosidl_parser.ServiceSpecification)
-@#    Parsed specification of the .msg file
+@#    Parsed specification of the .srv file
 @#  - convert_camel_case_to_lower_case_underscore (function)
 @#######################################################################
 @

--- a/rosidl_generator_py/resource/_srv.py.em
+++ b/rosidl_generator_py/resource/_srv.py.em
@@ -2,8 +2,7 @@
 # generated code does not contain a copyright notice
 
 @#######################################################################
-@# EmPy template for generating
-@# _<msg>.py files
+@# EmPy template for generating _<msg>.py files
 @#
 @# Context:
 @#  - module_name

--- a/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
+++ b/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
@@ -36,7 +36,7 @@ def generate_py(generator_arguments_file, typesupport_impls):
         os.path.join(template_dir, '_msg_support.c.em'): ['_%s_s.c'],
     }
     mapping_extension_msgs = {
-        os.path.join(template_dir, '_msg_support.entry_point.c.em'):
+        os.path.join(template_dir, '_msg_pkg_typesupport_entry_point.c.em'):
         type_support_impl_by_filename.keys(),
     }
 

--- a/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
+++ b/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
@@ -87,7 +87,6 @@ def generate_py(generator_arguments_file, typesupport_impls):
                     'module_name': module_name,
                     'package_name': args['package_name'],
                     'spec': spec, 'subfolder': subfolder,
-                    'typesupport_impl': type_support_impl_by_filename.get(generated_filename, ''),
                 }
                 data.update(functions)
                 generated_file = os.path.join(

--- a/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
+++ b/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
@@ -35,7 +35,7 @@ def generate_py(generator_arguments_file, typesupport_impls):
         os.path.join(template_dir, '_msg.py.em'): ['_%s.py'],
         os.path.join(template_dir, '_msg_support.c.em'): ['_%s_s.c'],
     }
-    mapping_extension_msgs = {
+    mapping_msg_pkg_extension = {
         os.path.join(template_dir, '_msg_pkg_typesupport_entry_point.c.em'):
         type_support_impl_by_filename.keys(),
     }
@@ -46,7 +46,7 @@ def generate_py(generator_arguments_file, typesupport_impls):
 
     for template_file in mapping_msgs.keys():
         assert os.path.exists(template_file), 'Could not find template: ' + template_file
-    for template_file in mapping_extension_msgs.keys():
+    for template_file in mapping_msg_pkg_extension.keys():
         assert os.path.exists(template_file), 'Could not find template: ' + template_file
     for template_file in mapping_srvs.keys():
         assert os.path.exists(template_file), 'Could not find template: ' + template_file
@@ -110,7 +110,7 @@ def generate_py(generator_arguments_file, typesupport_impls):
             for noqa_line in sorted(import_list.keys()):
                         f.write(noqa_line)
 
-    for template_file, generated_filenames in mapping_extension_msgs.items():
+    for template_file, generated_filenames in mapping_msg_pkg_extension.items():
         for generated_filename in generated_filenames:
             data = {
                 'package_name': args['package_name'],

--- a/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
+++ b/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
@@ -113,7 +113,6 @@ def generate_py(generator_arguments_file, typesupport_impls):
     for template_file, generated_filenames in mapping_extension_msgs.items():
         for generated_filename in generated_filenames:
             data = {
-                'module_name': module_name,
                 'package_name': args['package_name'],
                 'message_specs': message_specs,
                 'service_specs': service_specs,


### PR DESCRIPTION
Makes template names more accurate, remove unused variables passed to templates and add "docblocks". This is a first step before tackling https://github.com/ros2/rosidl/issues/225

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3050)](http://ci.ros2.org/job/ci_linux/3050/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=447)](http://ci.ros2.org/job/ci_linux-aarch64/447/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2453)](http://ci.ros2.org/job/ci_osx/2453/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3124)](http://ci.ros2.org/job/ci_windows/3124/)