### PR TITLE
Add rosidl_runtime_cpp.

### DIFF
--- a/rosidl_generator_cpp/CMakeLists.txt
+++ b/rosidl_generator_cpp/CMakeLists.txt
@@ -14,6 +14,9 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
+  find_package(rosidl_runtime_cpp REQUIRED)
+  include_directories(${rosidl_runtime_cpp_INCLUDE_DIRS})
+
   set(message_files
     "msg/BoundedArrayBounded.msg"
     "msg/BoundedArrayStatic.msg"

--- a/rosidl_generator_cpp/package.xml
+++ b/rosidl_generator_cpp/package.xml
@@ -22,6 +22,7 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>rosidl_cmake</test_depend>
   <test_depend>rosidl_generator_c</test_depend>
+  <test_depend>rosidl_runtime_cpp</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rosidl_generator_py/CMakeLists.txt
+++ b/rosidl_generator_py/CMakeLists.txt
@@ -12,6 +12,9 @@ ament_python_install_package(${PROJECT_NAME})
 if(BUILD_TESTING)
   find_package(ament_cmake_nose REQUIRED)
 
+  find_package(rosidl_runtime_cpp REQUIRED)
+  include_directories(${rosidl_runtime_cpp_INCLUDE_DIRS})
+
   find_package(rosidl_cmake REQUIRED)
   find_package(rosidl_generator_c REQUIRED)
 

--- a/rosidl_generator_py/package.xml
+++ b/rosidl_generator_py/package.xml
@@ -31,6 +31,7 @@
   <test_depend>rosidl_cmake</test_depend>
   <test_depend>rosidl_generator_c</test_depend>
   <test_depend>rosidl_parser</test_depend>
+  <test_depend>rosidl_runtime_cpp</test_depend>
   <test_depend>rosidl_typesupport_c</test_depend>
 
   <export>

--- a/rosidl_runtime_c/CMakeLists.txt
+++ b/rosidl_runtime_c/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 
-project(rosidl_runtime_cpp)
+project(rosidl_runtime_c)
 
 find_package(ament_cmake_ros REQUIRED)
 
@@ -14,7 +14,5 @@ ament_export_include_directories(include)
 install(DIRECTORY include/
   DESTINATION include
 )
-
-ament_export_dependencies(rosidl_runtime_c)
 
 ament_package()

--- a/rosidl_runtime_c/include/rosidl_runtime_c/message_initialization.h
+++ b/rosidl_runtime_c/include/rosidl_runtime_c/message_initialization.h
@@ -12,22 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef ROSIDL_RUNTIME_CPP__MESSAGE_INITIALIZATION_HPP_
-#define ROSIDL_RUNTIME_CPP__MESSAGE_INITIALIZATION_HPP_
+#ifndef ROSIDL_RUNTIME_C__MESSAGE_INITIALIZATION_H_
+#define ROSIDL_RUNTIME_C__MESSAGE_INITIALIZATION_H_
 
-#include <rosidl_runtime_c/message_initialization.h>
-
-namespace rosidl_runtime_cpp
+enum rosidl_runtime_c_message_initialization
 {
-
-enum class MessageInitialization
-{
-  ALL = ROSIDL_RUNTIME_C_MSG_INIT_ALL,
-  SKIP = ROSIDL_RUNTIME_C_MSG_INIT_SKIP,
-  ZERO = ROSIDL_RUNTIME_C_MSG_INIT_ZERO,
-  DEFAULTS_ONLY = ROSIDL_RUNTIME_C_MSG_INIT_DEFAULTS_ONLY,
+  ROSIDL_RUNTIME_C_MSG_INIT_ALL,
+  ROSIDL_RUNTIME_C_MSG_INIT_SKIP,
+  ROSIDL_RUNTIME_C_MSG_INIT_ZERO,
+  ROSIDL_RUNTIME_C_MSG_INIT_DEFAULTS_ONLY,
 };
 
-}  // namespace rosidl_runtime_cpp
-
-#endif  // ROSIDL_RUNTIME_CPP__MESSAGE_INITIALIZATION_HPP_
+#endif  // ROSIDL_RUNTIME_C__MESSAGE_INITIALIZATION_H_

--- a/rosidl_runtime_c/package.xml
+++ b/rosidl_runtime_c/package.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
-  <name>rosidl_runtime_cpp</name>
+  <name>rosidl_runtime_c</name>
   <version>0.0.2</version>
-  <description>Contains shared C++ dependencies for ROS msg and srv generated classes.</description>
+  <description>Contains C shared dependencies for ROS msg and srv generated classes.</description>
   <maintainer email="clalancette@openrobotics.org">Chris Lalancette</maintainer>
   <license>Apache License 2.0</license>
   <author email="clalancette@openrobotics.org">Chris Lalancette</author>
@@ -12,7 +12,6 @@
 
   <build_depend>ament_cmake</build_depend>
   <exec_depend>ament_cmake</exec_depend>
-  <exec_depend>rosidl_runtime_c</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rosidl_runtime_cpp/CMakeLists.txt
+++ b/rosidl_runtime_cpp/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(rosidl_runtime_cpp)
+
+find_package(ament_cmake_ros REQUIRED)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_export_include_directories(include)
+
+install(DIRECTORY include/
+  DESTINATION include
+)
+
+ament_package()

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/message_initialization.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/message_initialization.hpp
@@ -1,0 +1,31 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_RUNTIME_CPP__MESSAGE_INITIALIZATION_HPP_
+#define ROSIDL_RUNTIME_CPP__MESSAGE_INITIALIZATION_HPP_
+
+namespace rosidl_runtime_cpp
+{
+
+enum class MessageInitialization
+{
+  ALL,
+  SKIP,
+  ZERO,
+  DEFAULTS_ONLY,
+};
+
+}  // namespace rosidl_runtime_cpp
+
+#endif  // ROSIDL_RUNTIME_CPP__MESSAGE_INITIALIZATION_HPP_

--- a/rosidl_runtime_cpp/package.xml
+++ b/rosidl_runtime_cpp/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>rosidl_runtime_cpp</name>
+  <version>0.0.2</version>
+  <description>Contains shared dependencies for ROS msg and srv generated classes.</description>
+  <maintainer email="clalancette@openrobotics.org">Chris Lalancette</maintainer>
+  <license>Apache License 2.0</license>
+  <author email="clalancette@openrobotics.org">Chris Lalancette</author>
+
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+
+  <build_depend>ament_cmake</build_depend>
+  <exec_depend>ament_cmake</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
These are build-time dependencies for the generated code
that rosidl_generator_cpp produces.  Currently it just
contains an enum for the MessageInitialization control.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

connects to ros2/ros2#393

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3092)](http://ci.ros2.org/job/ci_linux/3092/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=474)](http://ci.ros2.org/job/ci_linux-aarch64/474/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2480)](http://ci.ros2.org/job/ci_osx/2480/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3166)](http://ci.ros2.org/job/ci_windows/3166/)