### PR TITLE
python extras is required to build c extensions

### DIFF
--- a/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
@@ -21,7 +21,7 @@ find_package(rosidl_typesupport_interface REQUIRED)
 find_package(PythonInterp 3.5 REQUIRED)
 
 find_package(python_cmake_module REQUIRED)
-find_package(PythonExtra MODULE)
+find_package(PythonExtra MODULE REQUIRED)
 
 # Get a list of typesupport implementations from valid rmw implementations.
 rosidl_generator_py_get_typesupports(_typesupport_impls)


### PR DESCRIPTION
We noticed that when browsing the code with @wjwwood yesterday

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3287)](http://ci.ros2.org/job/ci_linux/3287/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=562)](http://ci.ros2.org/job/ci_linux-aarch64/562/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2621)](http://ci.ros2.org/job/ci_osx/2621/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3328)](http://ci.ros2.org/job/ci_windows/3328/) (known flaky test unrelated to this change)