### PR TITLE
return NULL in case some Python function fails

### DIFF
--- a/rosidl_generator_py/resource/_msg_support.c.em
+++ b/rosidl_generator_py/resource/_msg_support.c.em
@@ -402,8 +402,13 @@ nested_type = '%s__%s__%s' % (field.type.pkg_name, 'msg', field.type.type)
   assert(false);
 @[  end if]@
   assert(py@(field.name) != NULL);
-  PyObject_SetAttrString(_pymessage, "@(field.name)", py@(field.name));
-  Py_DECREF(py@(field.name));
+  {
+    int rc = PyObject_SetAttrString(_pymessage, "@(field.name)", py@(field.name));
+    Py_DECREF(py@(field.name));
+    if (rc) {
+      return NULL;
+    }
+  }
 @[end for]@
   // ownership of _pymessage is transferred to the caller
   return _pymessage;

--- a/rosidl_generator_py/resource/_msg_support.c.em
+++ b/rosidl_generator_py/resource/_msg_support.c.em
@@ -281,9 +281,11 @@ PyObject * @(spec.base_type.pkg_name)_@(module_name)__convert_to_py(void * raw_r
     PyObject * pymessage_class = PyObject_GetAttrString(pymessage_module, "@(spec.base_type.type)");
     Py_DECREF(pymessage_module);
     _pymessage = PyObject_CallObject(pymessage_class, NULL);
+    if (!_pymessage) {
+      return NULL;
+    }
     Py_DECREF(pymessage_class);
   }
-  assert(_pymessage != NULL);
 
 @[for field in spec.fields]@
   PyObject * py@(field.name) = NULL;
@@ -403,7 +405,6 @@ nested_type = '%s__%s__%s' % (field.type.pkg_name, 'msg', field.type.type)
   PyObject_SetAttrString(_pymessage, "@(field.name)", py@(field.name));
   Py_DECREF(py@(field.name));
 @[end for]@
-  assert(_pymessage != NULL);
   // ownership of _pymessage is transferred to the caller
   return _pymessage;
 }


### PR DESCRIPTION
Follow up of ros2/rclpy#95.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3341)](http://ci.ros2.org/job/ci_linux/3341/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=600)](http://ci.ros2.org/job/ci_linux-aarch64/600/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2671)](http://ci.ros2.org/job/ci_osx/2671/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3397)](http://ci.ros2.org/job/ci_windows/3397/)

Ready for review.