### PR TITLE
refactor Python convert functions, check all return codes

### DIFF
--- a/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
@@ -284,6 +284,8 @@ if(BUILD_TESTING AND rosidl_generate_interfaces_ADD_LINTER_TESTS)
     get_filename_component(_cpplint_root "${_output_path}" DIRECTORY)
     ament_cpplint(
       TESTNAME "cpplint_rosidl_generated_py"
+      # the generated code might contain functions with more lines
+      FILTERS "-readability/fn_size"
       # the generated code might contain longer lines for templated types
       MAX_LINE_LENGTH 999
       ROOT "${_cpplint_root}"


### PR DESCRIPTION
Fixes ros2/rclpy#69.

This patch simplifies the generated code by removing `@(field.name)` from many variables. It achieves that by using a local scope for all operation related to a specific field.

Additionally it makes sure that all return codes are checked and `NULL` is returned if necessary.

Currently the patch only changes `convert_from_py`. Before applying similar changes to `convert_to_py` I would like to get some feedback on the current patch (in order to avoid unnecessary effort).