### PR TITLE
Fix ambiguous identifier E741 linter error

### DIFF
--- a/rosidl_parser/rosidl_parser/__init__.py
+++ b/rosidl_parser/rosidl_parser/__init__.py
@@ -628,7 +628,7 @@ def parse_service_file(pkg_name, interface_filename):
 def parse_service_string(pkg_name, srv_name, message_string):
     lines = message_string.splitlines()
     separator_indices = [
-        index for index, l in enumerate(lines) if l == SERVICE_REQUEST_RESPONSE_SEPARATOR]
+        index for index, line in enumerate(lines) if line == SERVICE_REQUEST_RESPONSE_SEPARATOR]
     if not separator_indices:
         raise InvalidServiceSpecification(
             "Could not find separator '%s' between request and response" %


### PR DESCRIPTION
E741 was added in flake8 3.5.0 recently
(without this PR: http://ci.ros2.org/job/ci_osx/2712/testReport/junit/rosidl_parser/flake8/E741____rosidl_parser___init___py_631_51_/)
CI OS X: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2713)](http://ci.ros2.org/job/ci_osx/2713/)