### PR TITLE
Disable strict aliasing for the tests.

### DIFF
--- a/rosidl_generator_cpp/CMakeLists.txt
+++ b/rosidl_generator_cpp/CMakeLists.txt
@@ -74,7 +74,9 @@ if(BUILD_TESTING)
   endif()
 
   if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    add_compile_options(-Wall -Wextra -Wpedantic)
+    # Disable strict-aliasing checks because test/test_msg_initialization.cpp
+    # has a test that very specifically needs to do aliasing.
+    add_compile_options(-Wall -Wextra -Wpedantic -Wno-strict-aliasing)
   endif()
 
   include_directories(include

--- a/rosidl_generator_cpp/CMakeLists.txt
+++ b/rosidl_generator_cpp/CMakeLists.txt
@@ -76,7 +76,7 @@ if(BUILD_TESTING)
   if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     # Disable strict-aliasing checks because test/test_msg_initialization.cpp
     # has a test that very specifically needs to do aliasing.
-    add_compile_options(-Wall -Wextra -Wpedantic -Wno-strict-aliasing)
+    add_compile_options(-Wall -Wextra -Wpedantic)
   endif()
 
   include_directories(include

--- a/rosidl_generator_cpp/CMakeLists.txt
+++ b/rosidl_generator_cpp/CMakeLists.txt
@@ -74,8 +74,6 @@ if(BUILD_TESTING)
   endif()
 
   if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    # Disable strict-aliasing checks because test/test_msg_initialization.cpp
-    # has a test that very specifically needs to do aliasing.
     add_compile_options(-Wall -Wextra -Wpedantic)
   endif()
 

--- a/rosidl_generator_cpp/test/test_msg_initialization.cpp
+++ b/rosidl_generator_cpp/test/test_msg_initialization.cpp
@@ -228,8 +228,6 @@ TEST(Test_msg_initialization, skip_constructor) {
   ASSERT_EQ(0xfefefefe, float32_bit_pattern);
   uint64_t float64_bit_pattern = *reinterpret_cast<uint64_t *>(&def->float64_value);
   ASSERT_EQ(0xfefefefefefefefeULL, float64_bit_pattern);
-  ASSERT_EQ(0xfefefefefefefefeULL, def->uint64_value);
-  ASSERT_EQ("", def->string_value);
   ASSERT_TRUE(std::all_of(def->float32_arr.begin(), def->float32_arr.end(), [](float i) {
       uint32_t float32_bit_pattern = *reinterpret_cast<uint32_t *>(&i);
       return 0xfefefefe == float32_bit_pattern;
@@ -241,6 +239,8 @@ TEST(Test_msg_initialization, skip_constructor) {
 #ifndef _WIN32
 #pragma GCC diagnostic pop
 #endif
+  ASSERT_EQ(0xfefefefefefefefeULL, def->uint64_value);
+  ASSERT_EQ("", def->string_value);
   ASSERT_TRUE(std::all_of(def->string_arr.begin(), def->string_arr.end(), [](std::string i) {
       return "" == i;
     }));

--- a/rosidl_generator_cpp/test/test_msg_initialization.cpp
+++ b/rosidl_generator_cpp/test/test_msg_initialization.cpp
@@ -172,10 +172,18 @@ TEST(Test_msg_initialization, defaults_only_constructor) {
   ASSERT_EQ(2.4, def->float64_value);
   ASSERT_EQ(0xfefefefefefefefeULL, def->uint64_value);
   ASSERT_EQ("bar", def->string_value);
+#ifndef _WIN32
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#endif
   ASSERT_TRUE(std::all_of(def->float32_arr.begin(), def->float32_arr.end(), [](float i) {
       uint32_t float32_bit_pattern = *reinterpret_cast<uint32_t *>(&i);
       return 0xfefefefe == float32_bit_pattern;
     }));
+#ifndef _WIN32
+#pragma GCC diagnostic pop
+#endif
+
   ASSERT_EQ(8.5, def->float64_arr[0]);
   ASSERT_EQ(1.2, def->float64_arr[1]);
   ASSERT_EQ(3.4, def->float64_arr[2]);
@@ -212,6 +220,10 @@ TEST(Test_msg_initialization, skip_constructor) {
   // ensures that the memory gets freed even if an ASSERT is raised
   SCOPE_EXIT(def->~Various_(); delete[] memory;);
 
+#ifndef _WIN32
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#endif
   uint32_t float32_bit_pattern = *reinterpret_cast<uint32_t *>(&def->float32_value);
   ASSERT_EQ(0xfefefefe, float32_bit_pattern);
   uint64_t float64_bit_pattern = *reinterpret_cast<uint64_t *>(&def->float64_value);
@@ -226,6 +238,9 @@ TEST(Test_msg_initialization, skip_constructor) {
       uint64_t float64_bit_pattern = *reinterpret_cast<uint64_t *>(&i);
       return 0xfefefefefefefefe == float64_bit_pattern;
     }));
+#ifndef _WIN32
+#pragma GCC diagnostic pop
+#endif
   ASSERT_TRUE(std::all_of(def->string_arr.begin(), def->string_arr.end(), [](std::string i) {
       return "" == i;
     }));


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Fixes warnings seen in nightly release builds, like this: http://ci.ros2.org/view/nightly/job/nightly_linux_release/616/

Full CI (to make sure the pragmas are portable), plus one of the Release jobs that originally caused the problem:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3426)](http://ci.ros2.org/job/ci_linux/3426/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=672)](http://ci.ros2.org/job/ci_linux-aarch64/672/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2753)](http://ci.ros2.org/job/ci_osx/2753/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3468)](http://ci.ros2.org/job/ci_windows/3468/)
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3425)](http://ci.ros2.org/job/ci_linux/3425/)