### PR TITLE
Cpp fix bool init

### DIFF
--- a/rosidl_generator_cpp/resource/msg__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.em
@@ -30,13 +30,10 @@ header_guard_variable = '__'.join([x.upper() for x in header_guard_parts]) + '_'
 
 @{
 from rosidl_generator_cpp import create_init_alloc_and_member_lists
-from rosidl_generator_cpp import default_cpp_value_from_type
 from rosidl_generator_cpp import escape_string
 from rosidl_generator_cpp import msg_type_only_to_cpp
 from rosidl_generator_cpp import msg_type_to_cpp
 from rosidl_generator_cpp import MSG_TYPE_TO_CPP
-from rosidl_generator_cpp import primitive_value_to_cpp
-from rosidl_generator_cpp import value_to_cpp
 
 cpp_namespace = '%s::%s::' % (spec.base_type.pkg_name, subfolder)
 cpp_class = '%s_' % spec.base_type.type

--- a/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
+++ b/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
@@ -144,6 +144,22 @@ def msg_type_to_cpp(type_):
 
 
 def value_to_cpp(type_, value):
+    """
+    Convert a python value into a string representing that value in C++.
+
+    This is equivalent to primitive_value_to_cpp but can process arrays values as well
+
+    Warning this still processes only primitive types
+    @param type_: a ROS IDL type
+    @type type_: builtin.str
+    @param value: the value to convert
+    @type value: python builtin (bool, int, float, str or list)
+    @returns: a string containing the C++ representation of the value
+    """
+    # :raises: ValueError on if the provided type_ is unknown
+    # """
+    # TODO(mikaelarguedas) this should raise proper exceptions rather than asserting
+    # without error message
     assert type_.is_primitive_type()
     assert value is not None
 
@@ -163,6 +179,20 @@ def value_to_cpp(type_, value):
 
 
 def primitive_value_to_cpp(type_, value):
+    """
+    Convert a python value into a string representing that value in C++.
+
+    Warning: The value has to be a primitive and not a list
+      (aka this function doesn't work for arrays)
+    @param type_: a ROS IDL type
+    @type type_: builtin.str
+    @param value: the value to convert
+    @type value: python builtin (bool, int, float or str)
+    @returns: a string containing the C++ representation of the value
+    """
+    # :raises: ValueError on if the provided type_ is unknown
+    # TODO(mikaelarguedas) this should raise proper exceptions rather than asserting
+    # without error message
     assert type_.is_primitive_type()
     assert value is not None
 
@@ -196,6 +226,7 @@ def primitive_value_to_cpp(type_, value):
     if type_.type == 'string':
         return '"%s"' % escape_string(value)
 
+    # raise ValueError("unknown primitive type '%s'" % type_.type)
     assert False, "unknown primitive type '%s'" % type_.type
 
 

--- a/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
+++ b/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
@@ -191,14 +191,14 @@ def primitive_value_to_cpp(type_, value):
     assert False, "unknown primitive type '%s'" % type_.type
 
 
-def default_cpp_value_from_type(type_):
+def default_value_from_type(type_):
     if type_ == 'string':
         return ''
     elif type_ in ['float32', 'float64']:
-        return '0.0'
+        return 0.0
     elif type_ == 'bool':
         return False
-    return '0'
+    return 0
 
 
 def escape_string(s):
@@ -257,7 +257,7 @@ def create_init_alloc_and_member_lists(spec):
             if field.type.is_fixed_size_array():
                 if field.type.is_primitive_type():
                     alloc_list.append(field.name + '(_alloc)')
-                    default = default_cpp_value_from_type(field.type.type)
+                    default = default_value_from_type(field.type.type)
                     single = primitive_value_to_cpp(field.type, default)
                     member.zero_value = [single] * field.type.array_size
                     if field.default_value is not None:
@@ -273,14 +273,14 @@ def create_init_alloc_and_member_lists(spec):
                     member.default_value = value_to_cpp(field.type, field.default_value)
                     length = len(field.default_value)
                     field_type = field.type.type
-                    defaults = [default_cpp_value_from_type(field_type) for x in range(0, length)]
+                    defaults = [default_value_from_type(field_type) for x in range(0, length)]
                     member.zero_value = value_to_cpp(field.type, defaults)
                     member.num_prealloc = len(field.default_value)
         else:
             if field.type.is_primitive_type():
                 if field.type.type == 'string':
                     alloc_list.append(field.name + '(_alloc)')
-                default = default_cpp_value_from_type(field.type.type)
+                default = default_value_from_type(field.type.type)
                 member.zero_value = primitive_value_to_cpp(field.type, default)
                 if field.default_value is not None:
                     member.default_value = primitive_value_to_cpp(field.type, field.default_value)

--- a/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
+++ b/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
@@ -156,8 +156,6 @@ def value_to_cpp(type_, value):
     @type value: python builtin (bool, int, float, str or list)
     @returns: a string containing the C++ representation of the value
     """
-    # :raises: ValueError on if the provided type_ is unknown
-    # """
     # TODO(mikaelarguedas) this should raise proper exceptions rather than asserting
     # without error message
     assert type_.is_primitive_type()
@@ -190,7 +188,6 @@ def primitive_value_to_cpp(type_, value):
     @type value: python builtin (bool, int, float or str)
     @returns: a string containing the C++ representation of the value
     """
-    # :raises: ValueError on if the provided type_ is unknown
     # TODO(mikaelarguedas) this should raise proper exceptions rather than asserting
     # without error message
     assert type_.is_primitive_type()
@@ -226,7 +223,6 @@ def primitive_value_to_cpp(type_, value):
     if type_.type == 'string':
         return '"%s"' % escape_string(value)
 
-    # raise ValueError("unknown primitive type '%s'" % type_.type)
     assert False, "unknown primitive type '%s'" % type_.type
 
 

--- a/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
+++ b/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
@@ -174,13 +174,23 @@ def primitive_value_to_cpp(type_, value):
         'char',
         'int8', 'uint8',
         'int16', 'uint16',
-        'int32', 'uint32',
-        'int64', 'uint64',
         'float64'
     ]:
         return str(value)
 
-    if type_.type in ['float32']:
+    if type_.type == 'int32':
+        return '%sl' % value
+
+    if type_.type == 'uint32':
+        return '%sul' % value
+
+    if type_.type == 'int64':
+        return '%sll' % value
+
+    if type_.type == 'uint64':
+        return '%sull' % value
+
+    if type_.type == 'float32':
         return '%sf' % value
 
     if type_.type == 'string':

--- a/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
+++ b/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
@@ -176,14 +176,12 @@ def primitive_value_to_cpp(type_, value):
         'int16', 'uint16',
         'int32', 'uint32',
         'int64', 'uint64',
+        'float64'
     ]:
         return str(value)
 
     if type_.type in ['float32']:
         return '%sf' % value
-
-    if type_.type in ['float64']:
-        return '%sl' % value
 
     if type_.type == 'string':
         return '"%s"' % escape_string(value)

--- a/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
+++ b/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
@@ -197,7 +197,7 @@ def default_cpp_value_from_type(type_):
     elif type_ in ['float32', 'float64']:
         return '0.0'
     elif type_ == 'bool':
-        return 'false'
+        return False
     return '0'
 
 

--- a/rosidl_generator_cpp/test/test_msg_initialization.cpp
+++ b/rosidl_generator_cpp/test/test_msg_initialization.cpp
@@ -18,6 +18,8 @@
 
 #include <string>
 
+#include "rosidl_generator_cpp/msg/primitives_default.hpp"
+#include "rosidl_generator_cpp/msg/primitives_static.hpp"
 #include "rosidl_generator_cpp/msg/various.hpp"
 
 template<typename Callable>
@@ -44,43 +46,93 @@ make_scope_exit(Callable callable)
   auto STRING_JOIN(scope_exit_, __LINE__) = make_scope_exit([&]() {code;})
 
 TEST(Test_msg_initialization, no_arg_constructor) {
-  rosidl_generator_cpp::msg::Various def;
+  rosidl_generator_cpp::msg::PrimitivesDefault primitives_def;
+  ASSERT_TRUE(primitives_def.bool_value);
+  ASSERT_EQ(50, primitives_def.byte_value);
+  ASSERT_EQ(100, primitives_def.char_value);
+  ASSERT_EQ(1.125f, primitives_def.float32_value);
+  ASSERT_EQ(1.125, primitives_def.float64_value);
+  ASSERT_EQ(-50, primitives_def.int8_value);
+  ASSERT_EQ(200, primitives_def.uint8_value);
+  ASSERT_EQ(-1000, primitives_def.int16_value);
+  ASSERT_EQ(2000, primitives_def.uint16_value);
+  ASSERT_EQ(-30000L, primitives_def.int32_value);
+  ASSERT_EQ(60000UL, primitives_def.uint32_value);
+  ASSERT_EQ(-40000000LL, primitives_def.int64_value);
+  ASSERT_EQ(50000000ULL, primitives_def.uint64_value);
+  ASSERT_EQ("bar", primitives_def.string_value);
 
-  ASSERT_EQ(1.125f, def.float32_value);
-  ASSERT_EQ(2.4, def.float64_value);
-  ASSERT_EQ(0ULL, def.uint64_value);
-  ASSERT_EQ("bar", def.string_value);
-  ASSERT_TRUE(std::all_of(def.float32_arr.begin(), def.float32_arr.end(), [](float i) {
-      return 0.0f == i;
-    }));
-  ASSERT_EQ(8.5, def.float64_arr[0]);
-  ASSERT_EQ(1.2, def.float64_arr[1]);
-  ASSERT_EQ(3.4, def.float64_arr[2]);
-  ASSERT_TRUE(std::all_of(def.string_arr.begin(), def.string_arr.end(), [](std::string i) {
-      return "" == i;
-    }));
-  ASSERT_EQ(2UL, def.unbounded.size());
-  ASSERT_EQ(1.0f, def.unbounded[0]);
-  ASSERT_EQ(2.0f, def.unbounded[1]);
-  ASSERT_EQ(0UL, def.bounded_no_def.size());
-  ASSERT_EQ(2UL, def.bounded_def.size());
-  ASSERT_EQ(3.0f, def.bounded_def[0]);
-  ASSERT_EQ(4.0f, def.bounded_def[1]);
-  ASSERT_EQ(0UL, def.vec3.x);
-  ASSERT_EQ(45UL, def.vec3.y);
-  ASSERT_EQ(0UL, def.vec3.z);
-  ASSERT_EQ(2UL, def.vec3_fixed.size());
-  ASSERT_EQ(0UL, def.vec3_fixed[0].x);
-  ASSERT_EQ(0UL, def.vec3_fixed[1].x);
-  ASSERT_EQ(45UL, def.vec3_fixed[0].y);
-  ASSERT_EQ(45UL, def.vec3_fixed[1].y);
-  ASSERT_EQ(0UL, def.vec3_fixed[0].z);
-  ASSERT_EQ(0UL, def.vec3_fixed[1].z);
-  ASSERT_EQ(0UL, def.vec3_unbounded.size());
-  ASSERT_EQ(0UL, def.vec3_bounded.size());
+  rosidl_generator_cpp::msg::PrimitivesStatic primitives_static;
+  ASSERT_FALSE(primitives_static.bool_value);
+  ASSERT_EQ(0, primitives_static.byte_value);
+  ASSERT_EQ(0, primitives_static.char_value);
+  ASSERT_EQ(0.0f, primitives_static.float32_value);
+  ASSERT_EQ(0.0, primitives_static.float64_value);
+  ASSERT_EQ(0, primitives_static.int8_value);
+  ASSERT_EQ(0, primitives_static.uint8_value);
+  ASSERT_EQ(0, primitives_static.int16_value);
+  ASSERT_EQ(0, primitives_static.uint16_value);
+  ASSERT_EQ(0L, primitives_static.int32_value);
+  ASSERT_EQ(0UL, primitives_static.uint32_value);
+  ASSERT_EQ(0LL, primitives_static.int64_value);
+  ASSERT_EQ(0ULL, primitives_static.uint64_value);
+
+  rosidl_generator_cpp::msg::Various various_def;
+
+  ASSERT_EQ(1.125f, various_def.float32_value);
+  ASSERT_EQ(2.4, various_def.float64_value);
+  ASSERT_EQ(0ULL, various_def.uint64_value);
+  ASSERT_EQ("bar", various_def.string_value);
+  ASSERT_TRUE(std::all_of(
+      various_def.float32_arr.begin(), various_def.float32_arr.end(), [](float i) {
+        return 0.0f == i;
+      }));
+  ASSERT_EQ(8.5, various_def.float64_arr[0]);
+  ASSERT_EQ(1.2, various_def.float64_arr[1]);
+  ASSERT_EQ(3.4, various_def.float64_arr[2]);
+  ASSERT_TRUE(std::all_of(
+      various_def.string_arr.begin(), various_def.string_arr.end(), [](std::string i) {
+        return "" == i;
+      }));
+  ASSERT_EQ(2UL, various_def.unbounded.size());
+  ASSERT_EQ(1.0f, various_def.unbounded[0]);
+  ASSERT_EQ(2.0f, various_def.unbounded[1]);
+  ASSERT_EQ(0UL, various_def.bounded_no_def.size());
+  ASSERT_EQ(2UL, various_def.bounded_def.size());
+  ASSERT_EQ(3.0f, various_def.bounded_def[0]);
+  ASSERT_EQ(4.0f, various_def.bounded_def[1]);
+  ASSERT_EQ(0UL, various_def.vec3.x);
+  ASSERT_EQ(45UL, various_def.vec3.y);
+  ASSERT_EQ(0UL, various_def.vec3.z);
+  ASSERT_EQ(2UL, various_def.vec3_fixed.size());
+  ASSERT_EQ(0UL, various_def.vec3_fixed[0].x);
+  ASSERT_EQ(0UL, various_def.vec3_fixed[1].x);
+  ASSERT_EQ(45UL, various_def.vec3_fixed[0].y);
+  ASSERT_EQ(45UL, various_def.vec3_fixed[1].y);
+  ASSERT_EQ(0UL, various_def.vec3_fixed[0].z);
+  ASSERT_EQ(0UL, various_def.vec3_fixed[1].z);
+  ASSERT_EQ(0UL, various_def.vec3_unbounded.size());
+  ASSERT_EQ(0UL, various_def.vec3_bounded.size());
 }
 
 TEST(Test_msg_initialization, all_constructor) {
+  rosidl_generator_cpp::msg::PrimitivesDefault primitives_def(
+    rosidl_generator_cpp::MessageInitialization::ALL);
+  ASSERT_TRUE(primitives_def.bool_value);
+  ASSERT_EQ(50, primitives_def.byte_value);
+  ASSERT_EQ(100, primitives_def.char_value);
+  ASSERT_EQ(1.125f, primitives_def.float32_value);
+  ASSERT_EQ(1.125, primitives_def.float64_value);
+  ASSERT_EQ(-50, primitives_def.int8_value);
+  ASSERT_EQ(200, primitives_def.uint8_value);
+  ASSERT_EQ(-1000, primitives_def.int16_value);
+  ASSERT_EQ(2000, primitives_def.uint16_value);
+  ASSERT_EQ(-30000L, primitives_def.int32_value);
+  ASSERT_EQ(60000UL, primitives_def.uint32_value);
+  ASSERT_EQ(-40000000LL, primitives_def.int64_value);
+  ASSERT_EQ(50000000ULL, primitives_def.uint64_value);
+  ASSERT_EQ("bar", primitives_def.string_value);
+
   rosidl_generator_cpp::msg::Various def(
     rosidl_generator_cpp::MessageInitialization::ALL);
 
@@ -119,6 +171,23 @@ TEST(Test_msg_initialization, all_constructor) {
 }
 
 TEST(Test_msg_initialization, zero_constructor) {
+  rosidl_generator_cpp::msg::PrimitivesDefault primitives_def(
+    rosidl_generator_cpp::MessageInitialization::ZERO);
+  ASSERT_FALSE(primitives_def.bool_value);
+  ASSERT_EQ(0, primitives_def.byte_value);
+  ASSERT_EQ(0, primitives_def.char_value);
+  ASSERT_EQ(0.0f, primitives_def.float32_value);
+  ASSERT_EQ(0.0, primitives_def.float64_value);
+  ASSERT_EQ(0, primitives_def.int8_value);
+  ASSERT_EQ(0, primitives_def.uint8_value);
+  ASSERT_EQ(0, primitives_def.int16_value);
+  ASSERT_EQ(0, primitives_def.uint16_value);
+  ASSERT_EQ(0L, primitives_def.int32_value);
+  ASSERT_EQ(0UL, primitives_def.uint32_value);
+  ASSERT_EQ(0LL, primitives_def.int64_value);
+  ASSERT_EQ(0ULL, primitives_def.uint64_value);
+  ASSERT_EQ("", primitives_def.string_value);
+
   rosidl_generator_cpp::msg::Various def(
     rosidl_generator_cpp::MessageInitialization::ZERO);
 
@@ -157,6 +226,23 @@ TEST(Test_msg_initialization, zero_constructor) {
 }
 
 TEST(Test_msg_initialization, defaults_only_constructor) {
+  rosidl_generator_cpp::msg::PrimitivesDefault primitives_def(
+    rosidl_generator_cpp::MessageInitialization::DEFAULTS_ONLY);
+  ASSERT_TRUE(primitives_def.bool_value);
+  ASSERT_EQ(50, primitives_def.byte_value);
+  ASSERT_EQ(100, primitives_def.char_value);
+  ASSERT_EQ(1.125f, primitives_def.float32_value);
+  ASSERT_EQ(1.125, primitives_def.float64_value);
+  ASSERT_EQ(-50, primitives_def.int8_value);
+  ASSERT_EQ(200, primitives_def.uint8_value);
+  ASSERT_EQ(-1000, primitives_def.int16_value);
+  ASSERT_EQ(2000, primitives_def.uint16_value);
+  ASSERT_EQ(-30000L, primitives_def.int32_value);
+  ASSERT_EQ(60000UL, primitives_def.uint32_value);
+  ASSERT_EQ(-40000000LL, primitives_def.int64_value);
+  ASSERT_EQ(50000000ULL, primitives_def.uint64_value);
+  ASSERT_EQ("bar", primitives_def.string_value);
+
   char * memory = new char[sizeof(rosidl_generator_cpp::msg::Various)];
   ASSERT_NE(memory, nullptr);
   std::memset(memory, 0xfe, sizeof(rosidl_generator_cpp::msg::Various));


### PR DESCRIPTION
When debugging parameters I noticed that boolean were default initialized to true since we refactored the message initialization.
The first commit fixes the issue
The second commit extends the test suite to test all primitive types' initialization

(this is obviously not the proper fix as the code should behave the same if the passed value was the expected bool, my take is that `primitive_value_to_cpp` expects an actual value of the right Python builtin type but is now called in multiple places with the result of `default_cpp_value_from_type` that returns a string of questionable content)