### PR TITLE
enforce membership to rosidl_interface_packages

### DIFF
--- a/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
@@ -114,6 +114,16 @@ macro(rosidl_generate_interfaces target)
   )
 
   if(NOT _ARG_SKIP_INSTALL)
+    set(_interface_packages_group_name "rosidl_interface_packages")
+    if(NOT _AMENT_PACKAGE_NAME)
+      ament_package_xml()
+    endif()
+    if(NOT _interface_packages_group_name IN_LIST ${_AMENT_PACKAGE_NAME}_MEMBER_OF_GROUPS)
+      message(FATAL_ERROR
+        "Packages installing interfaces must include \
+        '<member_of_group>${_interface_packages_group_name}</member_of_group>' in their package.xml"
+      )
+    endif()
     # register interfaces with the ament index
     set(_idl_files_lines)
     foreach(_idl_file ${_ARG_UNPARSED_ARGUMENTS})


### PR DESCRIPTION
This enforces that any package installing interfaces declares membership to the `rosidl_interface_packages` group.

requires https://github.com/ament/ament_cmake/pull/119