### PR TITLE
Don't allocate any memory for std::vector types with ZERO.

### DIFF
--- a/rosidl_generator_cpp/resource/msg__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.em
@@ -119,7 +119,7 @@ def generate_zero_string(membset, fill_args):
                 strlist.append('this->%s.fill(%s{%s});' % (member.name, msg_type_only_to_cpp(member.type), fill_args))
             else:
                 strlist.append('std::fill(this->%s.begin(), this->%s.end(), %s);' % (member.name, member.name, member.zero_value[0]))
-        elif member.zero_value is not None:
+        else:
             strlist.append('this->%s = %s;' % (member.name, member.zero_value))
     return strlist
 }@
@@ -139,12 +139,14 @@ def generate_zero_string(membset, fill_args):
 @[  for line in generate_default_string(membset)]@
       @(line)
 @[  end for]@
+@[  if membset.members[0].zero_value is not None]@
     } else if (rosidl_generator_cpp::MessageInitialization::ZERO == _init) {
-@[  for line in generate_zero_string(membset, '_init')]@
+@[   for line in generate_zero_string(membset, '_init')]@
       @(line)
-@[  end for]@
+@[   end for]@
+@[  end if]@
     }
-@[ else]@
+@[ elif membset.members[0].zero_value is not None]@
     if (rosidl_generator_cpp::MessageInitialization::ALL == _init ||
       rosidl_generator_cpp::MessageInitialization::ZERO == _init)
     {
@@ -175,12 +177,14 @@ def generate_zero_string(membset, fill_args):
 @[  for line in generate_default_string(membset)]@
       @(line)
 @[  end for]@
+@[  if membset.members[0].zero_value is not None]@
     } else if (rosidl_generator_cpp::MessageInitialization::ZERO == _init) {
-@[  for line in generate_zero_string(membset, '_alloc, _init')]@
+@[   for line in generate_zero_string(membset, '_alloc, _init')]@
       @(line)
-@[  end for]@
+@[   end for]@
+@[  end if]@
     }
-@[ else]@
+@[ elif membset.members[0].zero_value is not None]@
     if (rosidl_generator_cpp::MessageInitialization::ALL == _init ||
       rosidl_generator_cpp::MessageInitialization::ZERO == _init)
     {

--- a/rosidl_generator_cpp/resource/msg__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.em
@@ -119,7 +119,7 @@ def generate_zero_string(membset, fill_args):
                 strlist.append('this->%s.fill(%s{%s});' % (member.name, msg_type_only_to_cpp(member.type), fill_args))
             else:
                 strlist.append('std::fill(this->%s.begin(), this->%s.end(), %s);' % (member.name, member.name, member.zero_value[0]))
-        else:
+        elif member.zero_value is not None:
             strlist.append('this->%s = %s;' % (member.name, member.zero_value))
     return strlist
 }@

--- a/rosidl_generator_cpp/resource/msg__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.em
@@ -136,21 +136,21 @@ def generate_zero_string(membset, fill_args):
     if (rosidl_generator_cpp::MessageInitialization::ALL == _init ||
       rosidl_generator_cpp::MessageInitialization::DEFAULTS_ONLY == _init)
     {
-@[for line in generate_default_string(membset)]@
+@[  for line in generate_default_string(membset)]@
       @(line)
-@[end for]@
+@[  end for]@
     } else if (rosidl_generator_cpp::MessageInitialization::ZERO == _init) {
-@[for line in generate_zero_string(membset, '_init')]@
+@[  for line in generate_zero_string(membset, '_init')]@
       @(line)
-@[end for]@
+@[  end for]@
     }
 @[ else]@
     if (rosidl_generator_cpp::MessageInitialization::ALL == _init ||
       rosidl_generator_cpp::MessageInitialization::ZERO == _init)
     {
-@[for line in generate_zero_string(membset, '_init')]@
+@[  for line in generate_zero_string(membset, '_init')]@
       @(line)
-@[end for]@
+@[  end for]@
     }
 @[ end if]@
 @[end for]@
@@ -172,21 +172,21 @@ def generate_zero_string(membset, fill_args):
     if (rosidl_generator_cpp::MessageInitialization::ALL == _init ||
       rosidl_generator_cpp::MessageInitialization::DEFAULTS_ONLY == _init)
     {
-@[for line in generate_default_string(membset)]@
+@[  for line in generate_default_string(membset)]@
       @(line)
-@[end for]@
+@[  end for]@
     } else if (rosidl_generator_cpp::MessageInitialization::ZERO == _init) {
-@[for line in generate_zero_string(membset, '_alloc, _init')]@
+@[  for line in generate_zero_string(membset, '_alloc, _init')]@
       @(line)
-@[end for]@
+@[  end for]@
     }
 @[ else]@
     if (rosidl_generator_cpp::MessageInitialization::ALL == _init ||
       rosidl_generator_cpp::MessageInitialization::ZERO == _init)
     {
-@[for line in generate_zero_string(membset, '_alloc, _init')]@
+@[  for line in generate_zero_string(membset, '_alloc, _init')]@
       @(line)
-@[end for]@
+@[  end for]@
     }
 @[ end if]@
 @[end for]@

--- a/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
+++ b/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
@@ -306,10 +306,6 @@ def create_init_alloc_and_member_lists(spec):
             else:
                 if field.default_value is not None:
                     member.default_value = value_to_cpp(field.type, field.default_value)
-                    length = len(field.default_value)
-                    field_type = field.type.type
-                    defaults = [default_value_from_type(field_type) for x in range(0, length)]
-                    member.zero_value = value_to_cpp(field.type, defaults)
                     member.num_prealloc = len(field.default_value)
         else:
             if field.type.is_primitive_type():

--- a/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
+++ b/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
@@ -156,8 +156,8 @@ def value_to_cpp(type_, value):
     @type value: python builtin (bool, int, float, str or list)
     @returns: a string containing the C++ representation of the value
     """
-    assert type_.is_primitive_type(), 'Could not convert non-primitive type "%s" to CPP' % (type_)
-    assert value is not None, 'Value for type "%s" must not be None' % (type_)
+    assert type_.is_primitive_type(), "Could not convert non-primitive type '%s' to CPP" % (type_)
+    assert value is not None, "Value for type '%s' must not be None" % (type_)
 
     if not type_.is_array:
         return primitive_value_to_cpp(type_, value)
@@ -186,8 +186,8 @@ def primitive_value_to_cpp(type_, value):
     @type value: python builtin (bool, int, float or str)
     @returns: a string containing the C++ representation of the value
     """
-    assert type_.is_primitive_type(), 'Could not convert non-primitive type "%s" to CPP' % (type_)
-    assert value is not None, 'Value for type "%s" must not be None' % (type_)
+    assert type_.is_primitive_type(), "Could not convert non-primitive type '%s' to CPP" % (type_)
+    assert value is not None, "Value for type '%s' must not be None" % (type_)
 
     if type_.type == 'bool':
         return 'true' if value else 'false'

--- a/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
+++ b/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
@@ -286,8 +286,8 @@ def create_init_alloc_and_member_lists(spec):
         member.type = field.type
         if field.type.is_array:
             if field.type.is_fixed_size_array():
+                alloc_list.append(field.name + '(_alloc)')
                 if field.type.is_primitive_type():
-                    alloc_list.append(field.name + '(_alloc)')
                     default = default_value_from_type(field.type.type)
                     single = primitive_value_to_cpp(field.type, default)
                     member.zero_value = [single] * field.type.array_size
@@ -296,7 +296,6 @@ def create_init_alloc_and_member_lists(spec):
                         for val in field.default_value:
                             member.default_value.append(primitive_value_to_cpp(field.type, val))
                 else:
-                    alloc_list.append(field.name + '(_alloc)')
                     member.zero_value = []
                     member.zero_need_array_override = True
             else:

--- a/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
+++ b/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
@@ -156,10 +156,8 @@ def value_to_cpp(type_, value):
     @type value: python builtin (bool, int, float, str or list)
     @returns: a string containing the C++ representation of the value
     """
-    # TODO(mikaelarguedas) this should raise proper exceptions rather than asserting
-    # without error message
-    assert type_.is_primitive_type()
-    assert value is not None
+    assert type_.is_primitive_type(), 'Could not convert non-primitive type "%s" to CPP' % (type_)
+    assert value is not None, 'Value for type "%s" must not be None' % (type_)
 
     if not type_.is_array:
         return primitive_value_to_cpp(type_, value)
@@ -188,10 +186,8 @@ def primitive_value_to_cpp(type_, value):
     @type value: python builtin (bool, int, float or str)
     @returns: a string containing the C++ representation of the value
     """
-    # TODO(mikaelarguedas) this should raise proper exceptions rather than asserting
-    # without error message
-    assert type_.is_primitive_type()
-    assert value is not None
+    assert type_.is_primitive_type(), 'Could not convert non-primitive type "%s" to CPP' % (type_)
+    assert value is not None, 'Value for type "%s" must not be None' % (type_)
 
     if type_.type == 'bool':
         return 'true' if value else 'false'

--- a/rosidl_generator_cpp/test/test_msg_initialization.cpp
+++ b/rosidl_generator_cpp/test/test_msg_initialization.cpp
@@ -204,13 +204,9 @@ TEST(Test_msg_initialization, zero_constructor) {
   ASSERT_TRUE(std::all_of(def.string_arr.begin(), def.string_arr.end(), [](std::string i) {
       return "" == i;
     }));
-  ASSERT_EQ(2UL, def.unbounded.size());
-  ASSERT_EQ(0.0f, def.unbounded[0]);
-  ASSERT_EQ(0.0f, def.unbounded[1]);
+  ASSERT_EQ(0UL, def.unbounded.size());
   ASSERT_EQ(0UL, def.bounded_no_def.size());
-  ASSERT_EQ(2UL, def.bounded_def.size());
-  ASSERT_EQ(0.0f, def.bounded_def[0]);
-  ASSERT_EQ(0.0f, def.bounded_def[1]);
+  ASSERT_EQ(0UL, def.bounded_def.size());
   ASSERT_EQ(0UL, def.vec3.x);
   ASSERT_EQ(0UL, def.vec3.y);
   ASSERT_EQ(0UL, def.vec3.z);


### PR DESCRIPTION
I'm still working on/testing this, but opening for visibility.

As discussed in https://github.com/ros2/rosidl/issues/251,
it makes more sense for the std::vector types to get no
items with ZERO initialization.  Change to that here.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>