### PR TITLE
include directories before invoking rosidl_target_interfaces as the d…

### DIFF
--- a/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
@@ -230,8 +230,6 @@ foreach(_typesupport_impl ${_typesupport_impls})
     ${PythonExtra_LIBRARIES}
     ${PROJECT_NAME}__${_typesupport_impl}
   )
-  rosidl_target_interfaces(${_target_name}
-    ${PROJECT_NAME} rosidl_typesupport_c)
 
   target_include_directories(${_target_name}
     PUBLIC
@@ -239,6 +237,9 @@ foreach(_typesupport_impl ${_typesupport_impls})
     ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_py
     ${PythonExtra_INCLUDE_DIRS}
   )
+
+  rosidl_target_interfaces(${_target_name}
+    ${PROJECT_NAME} rosidl_typesupport_c)
 
   ament_target_dependencies(${_target_name}
     "rosidl_generator_c"


### PR DESCRIPTION
…irectories added in that macro may contain older version of the same files making them take precedence in the include path

Connects to https://github.com/ros2/rcl_interfaces/issues/31

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3908)](http://ci.ros2.org/job/ci_linux/3908/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1027)](http://ci.ros2.org/job/ci_linux-aarch64/1027/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3232)](http://ci.ros2.org/job/ci_osx/3232/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4002)](http://ci.ros2.org/job/ci_windows/4002/)