### PR TITLE
Ardent patch release

### DIFF
--- a/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
@@ -230,8 +230,6 @@ foreach(_typesupport_impl ${_typesupport_impls})
     ${PythonExtra_LIBRARIES}
     ${PROJECT_NAME}__${_typesupport_impl}
   )
-  rosidl_target_interfaces(${_target_name}
-    ${PROJECT_NAME} rosidl_typesupport_c)
 
   target_include_directories(${_target_name}
     PUBLIC
@@ -239,6 +237,9 @@ foreach(_typesupport_impl ${_typesupport_impls})
     ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_py
     ${PythonExtra_INCLUDE_DIRS}
   )
+
+  rosidl_target_interfaces(${_target_name}
+    ${PROJECT_NAME} rosidl_typesupport_c)
 
   ament_target_dependencies(${_target_name}
     "rosidl_generator_c"


### PR DESCRIPTION
include directories before invoking rosidl_target_interfaces as the directories added in that macro may contain older version of the same files making them take precedence in the include path

Cherry-pick of #261 to ardent branch

Connects to ros2/ros2#454