### PR TITLE
declare missing dependency

### DIFF
--- a/rosidl_generator_py/CMakeLists.txt
+++ b/rosidl_generator_py/CMakeLists.txt
@@ -5,6 +5,7 @@ project(rosidl_generator_py)
 find_package(ament_cmake REQUIRED)
 
 ament_export_dependencies(ament_cmake)
+ament_export_dependencies(rmw)
 ament_export_dependencies(rosidl_cmake)
 
 ament_python_install_package(${PROJECT_NAME})
@@ -12,6 +13,7 @@ ament_python_install_package(${PROJECT_NAME})
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
 
+  find_package(rmw REQUIRED)
   find_package(rosidl_cmake REQUIRED)
   find_package(rosidl_generator_c REQUIRED)
 

--- a/rosidl_generator_py/package.xml
+++ b/rosidl_generator_py/package.xml
@@ -10,6 +10,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_export_depend>rmw</build_export_depend>
+
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
   <buildtool_export_depend>ament_index_python</buildtool_export_depend>
   <buildtool_export_depend>python_cmake_module</buildtool_export_depend>
@@ -27,6 +29,7 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>python_cmake_module</test_depend>
+  <test_depend>rmw</test_depend>
   <test_depend>rmw_implementation</test_depend>
   <test_depend>rmw_implementation_cmake</test_depend>
   <test_depend>rosidl_cmake</test_depend>


### PR DESCRIPTION
The `rmw` CMake funtion `get_rmw_typesupport` is being called in one of the exported CMake files: https://github.com/ros2/rosidl/blob/f3e6a75052b2ebfc15f9106ba214d739a1fde554/rosidl_generator_py/cmake/rosidl_generator_py_get_typesupports.cmake#L18

And the CMake function in `rosidl_generator_py` is invoked during the tests: https://github.com/ros2/rosidl/blob/f3e6a75052b2ebfc15f9106ba214d739a1fde554/rosidl_generator_py/CMakeLists.txt#L56