### PR TITLE
Change #if to #ifdef.

### DIFF
--- a/rosidl_generator_c/include/rosidl_generator_c/primitives_array_functions.h
+++ b/rosidl_generator_c/include/rosidl_generator_c/primitives_array_functions.h
@@ -21,7 +21,7 @@
 #include "rosidl_generator_c/primitives_array.h"
 #include "rosidl_generator_c/visibility_control.h"
 
-#if __cplusplus
+#ifdef __cplusplus
 extern "C"
 {
 #endif
@@ -50,7 +50,7 @@ ROSIDL_GENERATOR_C__DECLARE_PRIMITIVE_ARRAY_FUNCTIONS(uint32, uint32_t)
 ROSIDL_GENERATOR_C__DECLARE_PRIMITIVE_ARRAY_FUNCTIONS(int64, int64_t)
 ROSIDL_GENERATOR_C__DECLARE_PRIMITIVE_ARRAY_FUNCTIONS(uint64, uint64_t)
 
-#if __cplusplus
+#ifdef __cplusplus
 }
 #endif
 

--- a/rosidl_generator_c/include/rosidl_generator_c/string_functions.h
+++ b/rosidl_generator_c/include/rosidl_generator_c/string_functions.h
@@ -20,7 +20,7 @@
 #include "rosidl_generator_c/string.h"
 #include "rosidl_generator_c/visibility_control.h"
 
-#if __cplusplus
+#ifdef __cplusplus
 extern "C"
 {
 #endif
@@ -69,7 +69,7 @@ void
 rosidl_generator_c__String__Array__destroy(
   rosidl_generator_c__String__Array * array);
 
-#if __cplusplus
+#ifdef __cplusplus
 }
 #endif
 

--- a/rosidl_generator_c/include/rosidl_generator_c/visibility_control.h
+++ b/rosidl_generator_c/include/rosidl_generator_c/visibility_control.h
@@ -15,7 +15,7 @@
 #ifndef ROSIDL_GENERATOR_C__VISIBILITY_CONTROL_H_
 #define ROSIDL_GENERATOR_C__VISIBILITY_CONTROL_H_
 
-#if __cplusplus
+#ifdef __cplusplus
 extern "C"
 {
 #endif
@@ -51,7 +51,7 @@ extern "C"
   #define ROSIDL_GENERATOR_C_PUBLIC_TYPE
 #endif
 
-#if __cplusplus
+#ifdef __cplusplus
 }
 #endif
 

--- a/rosidl_generator_c/resource/msg__functions.h.em
+++ b/rosidl_generator_c/resource/msg__functions.h.em
@@ -28,7 +28,7 @@ array_typename = '%s__Array' % msg_typename
 #ifndef @(header_guard_variable)
 #define @(header_guard_variable)
 
-#if __cplusplus
+#ifdef __cplusplus
 extern "C"
 {
 #endif
@@ -135,7 +135,7 @@ ROSIDL_GENERATOR_C_PUBLIC_@(spec.base_type.pkg_name)
 void
 @(array_typename)__destroy(@(array_typename) * array);
 
-#if __cplusplus
+#ifdef __cplusplus
 }
 #endif
 

--- a/rosidl_generator_c/resource/msg__struct.h.em
+++ b/rosidl_generator_c/resource/msg__struct.h.em
@@ -29,7 +29,7 @@ array_typename = '%s__Array' % msg_typename
 #ifndef @(header_guard_variable)
 #define @(header_guard_variable)
 
-#if __cplusplus
+#ifdef __cplusplus
 extern "C"
 {
 #endif
@@ -173,7 +173,7 @@ typedef struct @(array_typename)
   size_t capacity;
 } @(array_typename);
 
-#if __cplusplus
+#ifdef __cplusplus
 }
 #endif
 

--- a/rosidl_generator_c/resource/msg__type_support.h.em
+++ b/rosidl_generator_c/resource/msg__type_support.h.em
@@ -30,7 +30,7 @@ msg_typename = '%s__%s__%s' % (spec.base_type.pkg_name, subfolder, spec.base_typ
 #ifndef @(header_guard_variable)
 #define @(header_guard_variable)
 
-#if __cplusplus
+#ifdef __cplusplus
 extern "C"
 {
 #endif
@@ -45,7 +45,7 @@ ROSIDL_GENERATOR_C_PUBLIC_@(spec.base_type.pkg_name)
 const rosidl_message_type_support_t *
   ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_c, @(pkg), @(subfolder), @(type))();
 
-#if __cplusplus
+#ifdef __cplusplus
 }
 #endif
 

--- a/rosidl_generator_c/resource/rosidl_generator_c__visibility_control.h.in
+++ b/rosidl_generator_c/resource/rosidl_generator_c__visibility_control.h.in
@@ -4,7 +4,7 @@
 #ifndef @PROJECT_NAME_UPPER@__MSG__ROSIDL_GENERATOR_C__VISIBILITY_CONTROL_H_
 #define @PROJECT_NAME_UPPER@__MSG__ROSIDL_GENERATOR_C__VISIBILITY_CONTROL_H_
 
-#if __cplusplus
+#ifdef __cplusplus
 extern "C"
 {
 #endif
@@ -35,7 +35,7 @@ extern "C"
   #endif
 #endif
 
-#if __cplusplus
+#ifdef __cplusplus
 }
 #endif
 

--- a/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/field_types.h
+++ b/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/field_types.h
@@ -17,7 +17,7 @@
 
 #include <stdint.h>
 
-#if __cplusplus
+#ifdef __cplusplus
 extern "C"
 {
 #endif
@@ -42,7 +42,7 @@ enum
   rosidl_typesupport_introspection_c__ROS_TYPE_MESSAGE = 15
 };
 
-#if __cplusplus
+#ifdef __cplusplus
 }
 #endif
 

--- a/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/identifier.h
+++ b/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/identifier.h
@@ -17,7 +17,7 @@
 
 #include "rosidl_typesupport_introspection_c/visibility_control.h"
 
-#if __cplusplus
+#ifdef __cplusplus
 extern "C"
 {
 #endif
@@ -25,7 +25,7 @@ extern "C"
 ROSIDL_TYPESUPPORT_INTROSPECTION_C_PUBLIC
 extern const char * rosidl_typesupport_introspection_c__identifier;
 
-#if __cplusplus
+#ifdef __cplusplus
 }
 #endif
 

--- a/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/visibility_control.h
+++ b/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/visibility_control.h
@@ -15,7 +15,7 @@
 #ifndef ROSIDL_TYPESUPPORT_INTROSPECTION_C__VISIBILITY_CONTROL_H_
 #define ROSIDL_TYPESUPPORT_INTROSPECTION_C__VISIBILITY_CONTROL_H_
 
-#if __cplusplus
+#ifdef __cplusplus
 extern "C"
 {
 #endif
@@ -49,7 +49,7 @@ extern "C"
   #endif
 #endif
 
-#if __cplusplus
+#ifdef __cplusplus
 }
 #endif
 

--- a/rosidl_typesupport_introspection_c/resource/msg__rosidl_typesupport_introspection_c.h.em
+++ b/rosidl_typesupport_introspection_c/resource/msg__rosidl_typesupport_introspection_c.h.em
@@ -30,7 +30,7 @@ function_prefix = '%s__%s__rosidl_typesupport_introspection_c' % (spec.base_type
 
 #include "@(spec.base_type.pkg_name)/msg/rosidl_typesupport_introspection_c__visibility_control.h"
 
-#if __cplusplus
+#ifdef __cplusplus
 extern "C"
 {
 #endif
@@ -39,7 +39,7 @@ ROSIDL_TYPESUPPORT_INTROSPECTION_C_PUBLIC_@(spec.base_type.pkg_name)
 const rosidl_message_type_support_t *
   ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_c, @(spec.base_type.pkg_name), @(subfolder), @(spec.msg_name))();
 
-#if __cplusplus
+#ifdef __cplusplus
 }
 #endif
 

--- a/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
+++ b/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
@@ -64,7 +64,7 @@ for field in spec.fields:
 @[  end for]@
 
 @[end if]@
-#if __cplusplus
+#ifdef __cplusplus
 extern "C"
 {
 #endif
@@ -217,6 +217,6 @@ ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspecti
   return &@(function_prefix)__@(spec.base_type.type)_message_type_support_handle;
 }
 
-#if __cplusplus
+#ifdef __cplusplus
 }
 #endif

--- a/rosidl_typesupport_introspection_c/resource/rosidl_typesupport_introspection_c__visibility_control.h.in
+++ b/rosidl_typesupport_introspection_c/resource/rosidl_typesupport_introspection_c__visibility_control.h.in
@@ -5,7 +5,7 @@
 #ifndef @PROJECT_NAME_UPPER@__MSG__ROSIDL_TYPESUPPORT_INTROSPECTION_C__VISIBILITY_CONTROL_H_
 #define @PROJECT_NAME_UPPER@__MSG__ROSIDL_TYPESUPPORT_INTROSPECTION_C__VISIBILITY_CONTROL_H_
 
-#if __cplusplus
+#ifdef __cplusplus
 extern "C"
 {
 #endif
@@ -36,7 +36,7 @@ extern "C"
   #endif
 #endif
 
-#if __cplusplus
+#ifdef __cplusplus
 }
 #endif
 

--- a/rosidl_typesupport_introspection_c/resource/srv__rosidl_typesupport_introspection_c.h.em
+++ b/rosidl_typesupport_introspection_c/resource/srv__rosidl_typesupport_introspection_c.h.em
@@ -28,7 +28,7 @@ function_prefix = '%s__%s__rosidl_typesupport_introspection_c' % (spec.pkg_name,
 
 #include "@(spec.pkg_name)/msg/rosidl_typesupport_introspection_c__visibility_control.h"
 
-#if __cplusplus
+#ifdef __cplusplus
 extern "C"
 {
 #endif
@@ -37,7 +37,7 @@ ROSIDL_TYPESUPPORT_INTROSPECTION_C_PUBLIC_@(spec.pkg_name)
 const rosidl_service_type_support_t *
   ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(rosidl_typesupport_introspection_c, @(spec.pkg_name), @(spec.srv_name))();
 
-#if __cplusplus
+#ifdef __cplusplus
 }
 #endif
 

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/visibility_control.h
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/visibility_control.h
@@ -15,7 +15,7 @@
 #ifndef ROSIDL_TYPESUPPORT_INTROSPECTION_CPP__VISIBILITY_CONTROL_H_
 #define ROSIDL_TYPESUPPORT_INTROSPECTION_CPP__VISIBILITY_CONTROL_H_
 
-#if __cplusplus
+#ifdef __cplusplus
 extern "C"
 {
 #endif
@@ -49,7 +49,7 @@ extern "C"
   #endif
 #endif
 
-#if __cplusplus
+#ifdef __cplusplus
 }
 #endif
 


### PR DESCRIPTION
Needed because you can't use preprocessor on undefined variables in
MISRA.

Connects to ros2/rcl#229