### PR TITLE
Generate structures with MISRA-compliant constants.

### DIFF
--- a/rosidl_generator_cpp/resource/msg__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.em
@@ -215,13 +215,7 @@ def generate_zero_string(membset, fill_args):
 
   // constants
 @[for constant in spec.constants]@
-@[  if (constant.type in ['byte', 'int8', 'int16', 'int32', 'int64', 'char'])]@
-  enum { @(constant.name) = @(int(constant.value)) };
-@[  elif (constant.type in ['uint8', 'uint16', 'uint32', 'uint64'])]@
-  enum { @(constant.name) = @(int(constant.value))u };
-@[  else]@
   static const @(MSG_TYPE_TO_CPP[constant.type]) @(constant.name);
-@[  end if]@
 @[end for]@
 
   // pointer types
@@ -286,17 +280,17 @@ using @(spec.base_type.type) =
 
 // constants requiring out of line definition
 @[for c in spec.constants]@
-@[  if c.type not in ['byte', 'int8', 'int16', 'int32', 'int64', 'char', 'uint8', 'uint16', 'uint32', 'uint64']]@
 template<typename ContainerAllocator>
 const @(MSG_TYPE_TO_CPP[c.type])
 @(spec.base_type.type)_<ContainerAllocator>::@(c.name) =
-@[    if c.type == 'string']@
+@[  if c.type == 'string']@
   "@(escape_string(c.value))";
-@[    elif c.type == 'bool']@
+@[  elif (c.type in ['bool', 'byte', 'int8', 'int16', 'int32', 'int64', 'char'])]@
   @(int(c.value));
-@[    else]@
+@[  elif (c.type in ['uint8', 'uint16', 'uint32', 'uint64'])]@
+  @(int(c.value))u;
+@[  else]@
   @(c.value);
-@[    end if]@
 @[  end if]@
 @[end for]@
 

--- a/rosidl_generator_cpp/resource/msg__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.em
@@ -213,7 +213,7 @@ def generate_zero_string(membset, fill_args):
   }
 @[end for]@
 
-  // constants
+  // constant declarations
 @[for constant in spec.constants]@
   static const @(MSG_TYPE_TO_CPP[constant.type]) @(constant.name);
 @[end for]@
@@ -278,16 +278,16 @@ def generate_zero_string(membset, fill_args):
 using @(spec.base_type.type) =
   @(cpp_full_name)<std::allocator<void>>;
 
-// constants requiring out of line definition
+// constant definitions
 @[for c in spec.constants]@
 template<typename ContainerAllocator>
 const @(MSG_TYPE_TO_CPP[c.type])
 @(spec.base_type.type)_<ContainerAllocator>::@(c.name) =
 @[  if c.type == 'string']@
   "@(escape_string(c.value))";
-@[  elif (c.type in ['bool', 'byte', 'int8', 'int16', 'int32', 'int64', 'char'])]@
+@[  elif c.type in ('bool', 'byte', 'int8', 'int16', 'int32', 'int64', 'char')]@
   @(int(c.value));
-@[  elif (c.type in ['uint8', 'uint16', 'uint32', 'uint64'])]@
+@[  elif c.type in ('uint8', 'uint16', 'uint32', 'uint64')]@
   @(int(c.value))u;
 @[  else]@
   @(c.value);

--- a/rosidl_generator_cpp/resource/msg__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.em
@@ -215,7 +215,18 @@ def generate_zero_string(membset, fill_args):
 
   // constant declarations
 @[for constant in spec.constants]@
+@[if constant.type == 'string']
   static const @(MSG_TYPE_TO_CPP[constant.type]) @(constant.name);
+@[else]@
+  static constexpr @(MSG_TYPE_TO_CPP[constant.type]) @(constant.name) =
+@[if constant.type in ('bool', 'byte', 'int8', 'int16', 'int32', 'int64', 'char')]@
+    @(int(constant.value));
+@[elif constant.type in ('uint8', 'uint16', 'uint32', 'uint64')]@
+    @(int(constant.value))u;
+@[else]@
+    @(constant.value);
+@[  end if]@
+@[end if]@
 @[end for]@
 
   // pointer types
@@ -280,18 +291,14 @@ using @(spec.base_type.type) =
 
 // constant definitions
 @[for c in spec.constants]@
+@[if c.type == 'string']@
 template<typename ContainerAllocator>
 const @(MSG_TYPE_TO_CPP[c.type])
-@(spec.base_type.type)_<ContainerAllocator>::@(c.name) =
-@[  if c.type == 'string']@
-  "@(escape_string(c.value))";
-@[  elif c.type in ('bool', 'byte', 'int8', 'int16', 'int32', 'int64', 'char')]@
-  @(int(c.value));
-@[  elif c.type in ('uint8', 'uint16', 'uint32', 'uint64')]@
-  @(int(c.value))u;
-@[  else]@
-  @(c.value);
-@[  end if]@
+@(spec.base_type.type)_<ContainerAllocator>::@(c.name) = "@(escape_string(c.value))";
+@[ else ]
+template<typename ContainerAllocator>
+constexpr @(MSG_TYPE_TO_CPP[c.type]) @(spec.base_type.type)_<ContainerAllocator>::@(c.name);
+@[end if]@
 @[end for]@
 
 }  // namespace @(subfolder)

--- a/rosidl_generator_cpp/resource/msg__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.em
@@ -295,7 +295,7 @@ using @(spec.base_type.type) =
 template<typename ContainerAllocator>
 const @(MSG_TYPE_TO_CPP[c.type])
 @(spec.base_type.type)_<ContainerAllocator>::@(c.name) = "@(escape_string(c.value))";
-@[ else ]
+@[ else ]@
 template<typename ContainerAllocator>
 constexpr @(MSG_TYPE_TO_CPP[c.type]) @(spec.base_type.type)_<ContainerAllocator>::@(c.name);
 @[end if]@

--- a/rosidl_generator_cpp/test/test_interfaces.cpp
+++ b/rosidl_generator_cpp/test/test_interfaces.cpp
@@ -516,13 +516,13 @@ TEST(Test_messages, primitives_constants) {
   ASSERT_EQ(1.125f, message.FLOAT32_CONST);
   ASSERT_EQ(1.125, message.FLOAT64_CONST);
   ASSERT_EQ(-50, message.INT8_CONST);
-  ASSERT_EQ(200, message.UINT8_CONST);
+  ASSERT_EQ(200u, message.UINT8_CONST);
   ASSERT_EQ(-1000, message.INT16_CONST);
-  ASSERT_EQ(2000, message.UINT16_CONST);
+  ASSERT_EQ(2000u, message.UINT16_CONST);
   ASSERT_EQ(-30000, message.INT32_CONST);
-  ASSERT_EQ(60000, message.UINT32_CONST);
+  ASSERT_EQ(60000ul, message.UINT32_CONST);
   ASSERT_EQ(-40000000, message.INT64_CONST);
-  ASSERT_EQ(50000000, message.UINT64_CONST);
+  ASSERT_EQ(50000000ull, message.UINT64_CONST);
   ASSERT_STREQ("foo", message.STRING_CONST.c_str());
 }
 


### PR DESCRIPTION
Because the underlying type of an enum isn't defined (it should
generally be the width of an int), it makes comparisons with the
constants differ in sign, which is against MISRA rules.

Connects to #271 