### PR TITLE
Use buffer protocol and byte type for byte arrays in python

### DIFF
--- a/rosidl_generator_py/resource/_msg_support.c.em
+++ b/rosidl_generator_py/resource/_msg_support.c.em
@@ -179,94 +179,122 @@ nested_type = '%s__%s__%s' % (field.type.pkg_name, 'msg', field.type.type)
     ros_message->@(field.name) = *tmp;
 @[    end if]@
 @[  elif field.type.is_array]@
-    PyObject * seq_field = PySequence_Fast(field, "expected a sequence in '@(field.name)'");
-    if (!seq_field) {
-      Py_DECREF(field);
-      return NULL;
-    }
-@[    if field.type.array_size is None or field.type.is_upper_bound]@
-    Py_ssize_t size = PySequence_Size(field);
-    if (-1 == size) {
-      Py_DECREF(seq_field);
-      Py_DECREF(field);
-      return NULL;
-    }
-@[      if field.type.type == 'string']@
-    if (!rosidl_generator_c__String__Array__init(&(ros_message->@(field.name)), size)) {
-      PyErr_SetString(PyExc_RuntimeError, "unable to create String__Array ros_message");
-      Py_DECREF(seq_field);
-      Py_DECREF(field);
-      return NULL;
-    }
+@[    if field.type.type == 'uint8' or field.type.type == 'byte']@
+    if (PyObject_CheckBuffer(field)) {
+      Py_buffer view;
+      view.format = NULL;
+      if (PyObject_GetBuffer(field, &view, PyBUF_CONTIG_RO) != 0) {
+        Py_DECREF(field);
+        return NULL;
+      }
+@[      if field.type.array_size is None or field.type.is_upper_bound]@
+      Py_ssize_t size = view.len;
+      if (!rosidl_generator_c__@(field.type.type)__Array__init(&(ros_message->@(field.name)), size)) {
+        PyErr_SetString(PyExc_RuntimeError, "unable to create @(field.type.type)__Array ros_message");
+        PyBuffer_Release(&view);
+        Py_DECREF(field);
+        return NULL;
+      }
+      @primitive_msg_type_to_c(field.type.type) * dest = ros_message->@(field.name).data;
 @[      else]@
-    if (!rosidl_generator_c__@(field.type.type)__Array__init(&(ros_message->@(field.name)), size)) {
-      PyErr_SetString(PyExc_RuntimeError, "unable to create @(field.type.type)__Array ros_message");
-      Py_DECREF(seq_field);
-      Py_DECREF(field);
-      return NULL;
-    }
+      Py_ssize_t size = @(field.type.array_size);
+      @primitive_msg_type_to_c(field.type.type) * dest = ros_message->@(field.name);
 @[      end if]@
-    @primitive_msg_type_to_c(field.type.type) * dest = ros_message->@(field.name).data;
+      memcpy(dest, view.buf, size < view.len ? size : view.len);
+      PyBuffer_Release(&view);
+    } else {
 @[    else]@
-    Py_ssize_t size = @(field.type.array_size);
-    @primitive_msg_type_to_c(field.type.type) * dest = ros_message->@(field.name);
+    {
 @[    end if]@
-    for (Py_ssize_t i = 0; i < size; ++i) {
-      PyObject * item = PySequence_Fast_GET_ITEM(seq_field, i);
-      if (!item) {
+      PyObject * seq_field = PySequence_Fast(field, "expected a sequence in '@(field.name)'");
+      if (!seq_field) {
+        Py_DECREF(field);
+        return NULL;
+      }
+@[    if field.type.array_size is None or field.type.is_upper_bound]@
+      Py_ssize_t size = PySequence_Size(field);
+      if (-1 == size) {
         Py_DECREF(seq_field);
         Py_DECREF(field);
         return NULL;
       }
-@[    if field.type.type == 'char']@
-      assert(PyUnicode_Check(item));
-      @primitive_msg_type_to_c(field.type.type) tmp = PyUnicode_1BYTE_DATA(item)[0];
-@[    elif field.type.type == 'byte']@
-      assert(PyBytes_Check(item));
-      @primitive_msg_type_to_c(field.type.type) tmp = PyBytes_AS_STRING(item)[0];
-@[    elif field.type.type == 'string']@
-      assert(PyUnicode_Check(item));
-      rosidl_generator_c__String__assign(&dest[i], (char *)PyUnicode_1BYTE_DATA(item));
-@[    elif field.type.type == 'bool']@
-      assert(PyBool_Check(item));
-      @primitive_msg_type_to_c(field.type.type) tmp = (item == Py_True);
-@[    elif field.type.type in ['float32', 'float64']]@
-      assert(PyFloat_Check(item));
-@[      if field.type.type == 'float32']@
-      @primitive_msg_type_to_c(field.type.type) tmp = (float)PyFloat_AS_DOUBLE(item);
+@[      if field.type.type == 'string']@
+      if (!rosidl_generator_c__String__Array__init(&(ros_message->@(field.name)), size)) {
+        PyErr_SetString(PyExc_RuntimeError, "unable to create String__Array ros_message");
+        Py_DECREF(seq_field);
+        Py_DECREF(field);
+        return NULL;
+      }
 @[      else]@
-      @primitive_msg_type_to_c(field.type.type) tmp = PyFloat_AS_DOUBLE(item);
+      if (!rosidl_generator_c__@(field.type.type)__Array__init(&(ros_message->@(field.name)), size)) {
+        PyErr_SetString(PyExc_RuntimeError, "unable to create @(field.type.type)__Array ros_message");
+        Py_DECREF(seq_field);
+        Py_DECREF(field);
+        return NULL;
+      }
+@[      end if]@
+      @primitive_msg_type_to_c(field.type.type) * dest = ros_message->@(field.name).data;
+@[    else]@
+      Py_ssize_t size = @(field.type.array_size);
+      @primitive_msg_type_to_c(field.type.type) * dest = ros_message->@(field.name);
+@[    end if]@
+      for (Py_ssize_t i = 0; i < size; ++i) {
+        PyObject * item = PySequence_Fast_GET_ITEM(seq_field, i);
+        if (!item) {
+          Py_DECREF(seq_field);
+          Py_DECREF(field);
+          return NULL;
+        }
+@[    if field.type.type == 'char']@
+        assert(PyUnicode_Check(item));
+        @primitive_msg_type_to_c(field.type.type) tmp = PyUnicode_1BYTE_DATA(item)[0];
+@[    elif field.type.type == 'byte']@
+        assert(PyBytes_Check(item));
+        @primitive_msg_type_to_c(field.type.type) tmp = PyBytes_AS_STRING(item)[0];
+@[    elif field.type.type == 'string']@
+        assert(PyUnicode_Check(item));
+        rosidl_generator_c__String__assign(&dest[i], (char *)PyUnicode_1BYTE_DATA(item));
+@[    elif field.type.type == 'bool']@
+        assert(PyBool_Check(item));
+        @primitive_msg_type_to_c(field.type.type) tmp = (item == Py_True);
+@[    elif field.type.type in ['float32', 'float64']]@
+        assert(PyFloat_Check(item));
+@[      if field.type.type == 'float32']@
+        @primitive_msg_type_to_c(field.type.type) tmp = (float)PyFloat_AS_DOUBLE(item);
+@[      else]@
+        @primitive_msg_type_to_c(field.type.type) tmp = PyFloat_AS_DOUBLE(item);
 @[      end if]@
 @[    elif field.type.type in [
         'int8',
         'int16',
         'int32',
     ]]@
-      assert(PyLong_Check(item));
-      @primitive_msg_type_to_c(field.type.type) tmp = (@(primitive_msg_type_to_c(field.type.type)))PyLong_AsLong(item);
+        assert(PyLong_Check(item));
+        @primitive_msg_type_to_c(field.type.type) tmp = (@(primitive_msg_type_to_c(field.type.type)))PyLong_AsLong(item);
 @[    elif field.type.type in [
         'uint8',
         'uint16',
         'uint32',
     ]]@
-      assert(PyLong_Check(item));
+        assert(PyLong_Check(item));
 @[      if field.type.type == 'uint32']@
-      @primitive_msg_type_to_c(field.type.type) tmp = PyLong_AsUnsignedLong(item);
+        @primitive_msg_type_to_c(field.type.type) tmp = PyLong_AsUnsignedLong(item);
 @[      else]@
-      @primitive_msg_type_to_c(field.type.type) tmp = (@(primitive_msg_type_to_c(field.type.type)))PyLong_AsUnsignedLong(item);
+        @primitive_msg_type_to_c(field.type.type) tmp = (@(primitive_msg_type_to_c(field.type.type)))PyLong_AsUnsignedLong(item);
 @[      end if]
 @[    elif field.type.type == 'int64']@
-      assert(PyLong_Check(item));
-      @primitive_msg_type_to_c(field.type.type) tmp = PyLong_AsLongLong(item);
+        assert(PyLong_Check(item));
+        @primitive_msg_type_to_c(field.type.type) tmp = PyLong_AsLongLong(item);
 @[    elif field.type.type == 'uint64']@
-      assert(PyLong_Check(item));
-      @primitive_msg_type_to_c(field.type.type) tmp = PyLong_AsUnsignedLongLong(item);
+        assert(PyLong_Check(item));
+        @primitive_msg_type_to_c(field.type.type) tmp = PyLong_AsUnsignedLongLong(item);
 @[    end if]@
 @[    if field.type.type != 'string']@
-      memcpy(&dest[i], &tmp, sizeof(@primitive_msg_type_to_c(field.type.type)));
+        memcpy(&dest[i], &tmp, sizeof(@primitive_msg_type_to_c(field.type.type)));
 @[    end if]@
+      }
+      Py_DECREF(seq_field);
     }
-    Py_DECREF(seq_field);
 @[  elif field.type.type == 'char']@
     assert(PyUnicode_Check(field));
     ros_message->@(field.name) = PyUnicode_1BYTE_DATA(field)[0];
@@ -423,58 +451,62 @@ nested_type = '%s__%s__%s' % (field.type.pkg_name, 'msg', field.type.type)
     size_t size = @(field.type.array_size);
     @primitive_msg_type_to_c(field.type.type) * src = ros_message->@(field.name);
 @[    end if]@
+@[    if field.type.type == 'uint8' or field.type.type == 'byte']@
+    field = PyBytes_FromStringAndSize((const char *)src, size);
+@[    else]@
     field = PyList_New(size);
     if (!field) {
       return NULL;
     }
     for (size_t i = 0; i < size; ++i) {
-@[    if field.type.type == 'char']@
+@[      if field.type.type == 'char']@
       int rc = PyList_SetItem(field, i, Py_BuildValue("C", src[i]));
       (void)rc;
       assert(rc == 0);
-@[    elif field.type.type == 'byte']@
+@[      elif field.type.type == 'byte']@
       int rc = PyList_SetItem(field, i, PyBytes_FromStringAndSize((const char *)&src[i], 1));
       (void)rc;
       assert(rc == 0);
-@[    elif field.type.type == 'string']@
+@[      elif field.type.type == 'string']@
       int rc = PyList_SetItem(field, i, PyUnicode_FromString(src[i].data));
       (void)rc;
       assert(rc == 0);
-@[    elif field.type.type == 'bool']@
+@[      elif field.type.type == 'bool']@
 @# using PyBool_FromLong because PyList_SetItem will steal ownership of the passed item
       int rc = PyList_SetItem(field, i, PyBool_FromLong(src[i] ? 1 : 0));
       (void)rc;
       assert(rc == 0);
-@[    elif field.type.type in ['float32', 'float64']]@
+@[      elif field.type.type in ['float32', 'float64']]@
       int rc = PyList_SetItem(field, i, PyFloat_FromDouble(src[i]));
       (void)rc;
       assert(rc == 0);
-@[    elif field.type.type in [
-        'int8',
-        'int16',
-        'int32',
-    ]]@
+@[      elif field.type.type in [
+          'int8',
+          'int16',
+          'int32',
+      ]]@
       int rc = PyList_SetItem(field, i, PyLong_FromLong(src[i]));
       (void)rc;
       assert(rc == 0);
-@[    elif field.type.type in [
-        'uint8',
-        'uint16',
-        'uint32',
-    ]]@
+@[      elif field.type.type in [
+          'uint8',
+          'uint16',
+          'uint32',
+      ]]@
       int rc = PyList_SetItem(field, i, PyLong_FromUnsignedLong(src[i]));
       (void)rc;
       assert(rc == 0);
-@[    elif field.type.type == 'int64']@
+@[      elif field.type.type == 'int64']@
       int rc = PyList_SetItem(field, i, PyLong_FromLongLong(src[i]));
       (void)rc;
       assert(rc == 0);
-@[    elif field.type.type == 'uint64']@
+@[      elif field.type.type == 'uint64']@
       int rc = PyList_SetItem(field, i, PyLong_FromUnsignedLongLong(src[i]));
       (void)rc;
       assert(rc == 0);
-@[    end if]@
+@[      end if]@
     }
+@[    end if]@
     assert(PySequence_Check(field));
 @[  elif field.type.type == 'char']@
     field = Py_BuildValue("C", ros_message->@(field.name));


### PR DESCRIPTION
These changes improve performance and reduces memory usage for byte buffers when converting messages to and from python.

1) it uses [buffer protocol](https://docs.python.org/3/c-api/buffer.html) to convert from python arrays - its more efficient to do just one memcpy instead for calling PySequence_Fast_GET_ITEM per each array element. Buffer protocol is used only if member is bytes or bytesarray or similar type.

2) it uses byte type to return byte array to python instead of creating list of integers. byte object can be created with one call to PyBytes_FromStringAndSize function instead of looping and calling PyList_SetItem per each array element. Also this allows to use numpy.frombuffer method to share Python byte memory with numpy array instead of making duplicate copy.

With these changes I have seen good performance increase when passing CompressedImage between ros2 nodes on Raspberry Pi 3.
