### PR TITLE
Generate imports for assert only in debug mode

### DIFF
--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -175,81 +175,81 @@ class @(spec.base_type.type)(metaclass=Metaclass):
     def @(field.name)(self, value):
         if __debug__:
 @[  if not field.type.is_primitive_type()]@
-          from @(field.type.pkg_name).msg import @(field.type.type)
+            from @(field.type.pkg_name).msg import @(field.type.type)
 @[  end if]@
 @[  if field.type.is_array]@
-          from collections import Sequence
-          from collections import Set
-          from collections import UserList
-          from collections import UserString
+            from collections import Sequence
+            from collections import Set
+            from collections import UserList
+            from collections import UserString
 @[  elif field.type.string_upper_bound]@
-          from collections import UserString
+            from collections import UserString
 @[  elif field.type.type == 'byte']@
-          from collections import ByteString
+            from collections import ByteString
 @[  elif field.type.type in ['char']]@
-          from collections import UserString
+            from collections import UserString
 @[  end if]@
-          assert \
+            assert \
 @[  if field.type.is_array]@
-            ((isinstance(value, Sequence) or
-              isinstance(value, Set) or
-              isinstance(value, UserList)) and
-             not isinstance(value, str) and
-             not isinstance(value, UserString) and
+                ((isinstance(value, Sequence) or
+                  isinstance(value, Set) or
+                  isinstance(value, UserList)) and
+                 not isinstance(value, str) and
+                 not isinstance(value, UserString) and
 @{assert_msg_suffixes = ['a set or sequence']}@
 @[    if field.type.type == 'string' and field.type.string_upper_bound]@
-             all(len(val) <= @field.type.string_upper_bound for val in value) and
+                 all(len(val) <= @field.type.string_upper_bound for val in value) and
 @{assert_msg_suffixes.append('and each string value not longer than %d' % field.type.string_upper_bound)}@
 @[    end if]@
 @[    if field.type.array_size]@
 @[      if field.type.is_upper_bound]@
-             len(value) <= @(field.type.array_size) and
+                 len(value) <= @(field.type.array_size) and
 @{assert_msg_suffixes.insert(1, 'with length <= %d' % field.type.array_size)}@
 @[      else]@
-             len(value) == @(field.type.array_size) and
+                 len(value) == @(field.type.array_size) and
 @{assert_msg_suffixes.insert(1, 'with length %d' % field.type.array_size)}@
 @[      end if]@
 @[    end if]@
-             all(isinstance(v, @(get_python_type(field.type))) for v in value) and
+                 all(isinstance(v, @(get_python_type(field.type))) for v in value) and
 @{assert_msg_suffixes.append("and each value of type '%s'" % get_python_type(field.type))}@
 @[    if field.type.type.startswith('int')]@
 @{
 nbits = int(field.type.type[3:])
 bound = 2**(nbits - 1)
 }@
-             all(val >= -@(bound) and val < @(bound) for val in value)), \
+                 all(val >= -@(bound) and val < @(bound) for val in value)), \
 @{assert_msg_suffixes.append('and each integer in [%d, %d]' % (-bound, bound - 1))}@
 @[    elif field.type.type.startswith('uint')]@
 @{
 nbits = int(field.type.type[4:])
 bound = 2**nbits
 }@
-             all(val >= 0 and val < @(bound) for val in value)), \
+                 all(val >= 0 and val < @(bound) for val in value)), \
 @{assert_msg_suffixes.append('and each unsigned integer in [0, %d]' % (bound - 1))}@
 @[    elif field.type.type == 'char']@
-             all(ord(val) >= -128 and ord(val) < 128 for val in value)), \
+                 all(ord(val) >= -128 and ord(val) < 128 for val in value)), \
 @{assert_msg_suffixes.append('and each characters ord() in [-128, 127]')}@
 @[    else]@
-             True), \
+                 True), \
 @[    end if]@
-            "The '@(field.name)' field must be @(' '.join(assert_msg_suffixes))"
+                "The '@(field.name)' field must be @(' '.join(assert_msg_suffixes))"
 @[  elif field.type.string_upper_bound]@
-            ((isinstance(value, str) or isinstance(value, UserString)) and
-             len(value) <= @(field.type.string_upper_bound)), \
-            "The '@(field.name)' field must be string value " \
-            'not longer than @(field.type.string_upper_bound)'
+                ((isinstance(value, str) or isinstance(value, UserString)) and
+                 len(value) <= @(field.type.string_upper_bound)), \
+                "The '@(field.name)' field must be string value " \
+                'not longer than @(field.type.string_upper_bound)'
 @[  elif not field.type.is_primitive_type()]@
-            isinstance(value, @(field.type.type)), \
-            "The '@(field.name)' field must be a sub message of type '@(field.type.type)'"
+                isinstance(value, @(field.type.type)), \
+                "The '@(field.name)' field must be a sub message of type '@(field.type.type)'"
 @[  elif field.type.type == 'byte']@
-            ((isinstance(value, bytes) or isinstance(value, ByteString)) and
-             len(value) == 1), \
-            "The '@(field.name)' field must of type 'bytes' or 'ByteString' with a length 1"
+                ((isinstance(value, bytes) or isinstance(value, ByteString)) and
+                 len(value) == 1), \
+                "The '@(field.name)' field must of type 'bytes' or 'ByteString' with a length 1"
 @[  elif field.type.type == 'char']@
-            ((isinstance(value, str) or isinstance(value, UserString)) and
-             len(value) == 1 and ord(value) >= -128 and ord(value) < 128), \
-            "The '@(field.name)' field must of type 'str' or 'UserString' " \
-            'with a length 1 and the character ord() in [-128, 127]'
+                ((isinstance(value, str) or isinstance(value, UserString)) and
+                 len(value) == 1 and ord(value) >= -128 and ord(value) < 128), \
+                "The '@(field.name)' field must of type 'str' or 'UserString' " \
+                'with a length 1 and the character ord() in [-128, 127]'
 @[  elif field.type.type in [
         'bool',
         'float32', 'float64',
@@ -259,25 +259,25 @@ bound = 2**nbits
         'int64', 'uint64',
         'string',
     ]]@
-            isinstance(value, @(get_python_type(field.type))), \
-            "The '@(field.name)' field must of type '@(get_python_type(field.type))'"
+                isinstance(value, @(get_python_type(field.type))), \
+                "The '@(field.name)' field must of type '@(get_python_type(field.type))'"
 @[    if field.type.type.startswith('int')]@
 @{
 nbits = int(field.type.type[3:])
 bound = 2**(nbits - 1)
 }@
-        assert value >= -@(bound) and value < @(bound), \
-            "The '@(field.name)' field must be an integer in [@(-bound), @(bound - 1)]"
+            assert value >= -@(bound) and value < @(bound), \
+                "The '@(field.name)' field must be an integer in [@(-bound), @(bound - 1)]"
 @[    elif field.type.type.startswith('uint')]@
 @{
 nbits = int(field.type.type[4:])
 bound = 2**nbits
 }@
-        assert value >= 0 and value < @(bound), \
-            "The '@(field.name)' field must be an unsigned integer in [0, @(bound - 1)]"
+            assert value >= 0 and value < @(bound), \
+                "The '@(field.name)' field must be an unsigned integer in [0, @(bound - 1)]"
 @[    end if]@
 @[  else]@
-            False
+                False
 @[  end if]@
         self._@(field.name) = value
 @[end for]@


### PR DESCRIPTION
Reduce amount of imports are executed at runtime by doing them only when python runs in debug mode (`PYTHONOPTIMIZE=0`). If python runs in optimized mode, assert statements are not executed, but currently there are a lot of imports happening. This patch moves imports inside `if __debug__` condition.

This significantly reduces amount of import statements executed at runtime. We have seen significant performance gains on Raspberry Pi 3 when messages contain arrays - because accessing each array element would trigger many imports.