### PR TITLE
generate __eq__ for Python messages

### DIFF
--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -173,13 +173,6 @@ class @(spec.base_type.type)(metaclass=Metaclass):
             return False
 @[end for]@
         return True
-
-    def __hash__(self):
-        return hash((
-@[for field in spec.fields]@
-            self.@(field.name),
-@[end for]@
-        ))
 @[for field in spec.fields]@
 
     @@property

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -164,6 +164,22 @@ class @(spec.base_type.type)(metaclass=Metaclass):
         typename.append(self.__class__.__name__)
         args = [s[1:] + '=' + repr(getattr(self, s, None)) for s in self.__slots__]
         return '%s(%s)' % ('.'.join(typename), ', '.join(args))
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+@[for field in spec.fields]@
+        if self.@(field.name) != other.@(field.name):
+            return False
+@[end for]@
+        return True
+
+    def __hash__(self):
+        return hash((
+@[for field in spec.fields]@
+            self.@(field.name),
+@[end for]@
+        ))
 @[for field in spec.fields]@
 
     @@property


### PR DESCRIPTION
Treating Python message classes as *data* (same as in C++) and implementing `__eq__` ~~and `__hash__`~~ based on all the fields.

CI for Linux only: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4585)](https://ci.ros2.org/job/ci_linux/4585/)