### PR TITLE
add groups for generator and runtime packages

### DIFF
--- a/rosidl_generator_c/CMakeLists.txt
+++ b/rosidl_generator_c/CMakeLists.txt
@@ -38,6 +38,8 @@ ament_export_dependencies(rosidl_typesupport_interface)
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})
 
+ament_index_register_resource("rosidl_generator_packages")
+
 ament_python_install_package(${PROJECT_NAME})
 
 if(BUILD_TESTING)

--- a/rosidl_generator_c/package.xml
+++ b/rosidl_generator_c/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>rosidl_generator_c</name>
   <version>0.4.0</version>
   <description>Generate the ROS interfaces in C.</description>
@@ -22,6 +22,8 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>rosidl_cmake</test_depend>
+
+  <member_of_group>rosidl_generator_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rosidl_generator_cpp/CMakeLists.txt
+++ b/rosidl_generator_cpp/CMakeLists.txt
@@ -9,6 +9,9 @@ ament_export_dependencies(rosidl_cmake)
 ament_export_dependencies(rosidl_generator_c)
 ament_export_include_directories(include)
 
+ament_index_register_resource("rosidl_generator_packages")
+ament_index_register_resource("rosidl_runtime_packages")
+
 ament_python_install_package(${PROJECT_NAME})
 
 if(BUILD_TESTING)

--- a/rosidl_generator_cpp/package.xml
+++ b/rosidl_generator_cpp/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>rosidl_generator_cpp</name>
   <version>0.4.0</version>
   <description>Generate the ROS interfaces in C++.</description>
@@ -22,6 +22,9 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>rosidl_cmake</test_depend>
   <test_depend>rosidl_generator_c</test_depend>
+
+  <member_of_group>rosidl_generator_packages</member_of_group>
+  <member_of_group>rosidl_runtime_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rosidl_generator_py/CMakeLists.txt
+++ b/rosidl_generator_py/CMakeLists.txt
@@ -9,7 +9,6 @@ ament_export_dependencies(rmw)
 ament_export_dependencies(rosidl_cmake)
 
 ament_index_register_resource("rosidl_generator_packages")
-ament_index_register_resource("rosidl_runtime_packages")
 
 ament_python_install_package(${PROJECT_NAME})
 

--- a/rosidl_generator_py/CMakeLists.txt
+++ b/rosidl_generator_py/CMakeLists.txt
@@ -8,6 +8,9 @@ ament_export_dependencies(ament_cmake)
 ament_export_dependencies(rmw)
 ament_export_dependencies(rosidl_cmake)
 
+ament_index_register_resource("rosidl_generator_packages")
+ament_index_register_resource("rosidl_runtime_packages")
+
 ament_python_install_package(${PROJECT_NAME})
 
 if(BUILD_TESTING)

--- a/rosidl_generator_py/package.xml
+++ b/rosidl_generator_py/package.xml
@@ -38,7 +38,6 @@
   <test_depend>rosidl_typesupport_c</test_depend>
 
   <member_of_group>rosidl_generator_packages</member_of_group>
-  <member_of_group>rosidl_runtime_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rosidl_generator_py/package.xml
+++ b/rosidl_generator_py/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>rosidl_generator_py</name>
   <version>0.4.0</version>
   <description>Generate the ROS interfaces in Python.</description>
@@ -36,6 +36,9 @@
   <test_depend>rosidl_generator_c</test_depend>
   <test_depend>rosidl_parser</test_depend>
   <test_depend>rosidl_typesupport_c</test_depend>
+
+  <member_of_group>rosidl_generator_packages</member_of_group>
+  <member_of_group>rosidl_runtime_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rosidl_typesupport_introspection_c/CMakeLists.txt
+++ b/rosidl_typesupport_introspection_c/CMakeLists.txt
@@ -36,6 +36,7 @@ target_include_directories(${PROJECT_NAME}
 ament_export_libraries(${PROJECT_NAME})
 
 ament_index_register_resource("rosidl_typesupport_c")
+ament_index_register_resource("rosidl_runtime_packages")
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/rosidl_typesupport_introspection_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_introspection_cpp/CMakeLists.txt
@@ -37,6 +37,7 @@ target_include_directories(${PROJECT_NAME}
 ament_export_libraries(${PROJECT_NAME})
 
 ament_index_register_resource("rosidl_typesupport_cpp")
+ament_index_register_resource("rosidl_runtime_packages")
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)


### PR DESCRIPTION
The rosidl generator | runtime packages declare being a member of a group as well as register themselves at the resource index.