### PR TITLE
add new macro to export ts libraries through different CMake variable

### DIFF
--- a/rosidl_cmake/cmake/rosidl_cmake_export_typesupport_libraries-extras.cmake.in
+++ b/rosidl_cmake/cmake/rosidl_cmake_export_typesupport_libraries-extras.cmake.in
@@ -1,0 +1,46 @@
+# generated from
+# rosidl_cmake/cmake/template/rosidl_cmake_export_typesupport_libraries.cmake.in
+
+set(_exported_typesupport_libraries
+  "@_ROSIDL_CMAKE_EXPORT_TYPESUPPORT_LIBRARIES@")
+
+# populate @PROJECT_NAME@_LIBRARIES_<suffix>
+if(NOT _exported_typesupport_libraries STREQUAL "")
+  # loop over typesupport libraries
+  foreach(_tuple ${_exported_typesupport_libraries})
+    string(REPLACE ":" ";" _tuple "${_tuple}")
+    list(GET _tuple 0 _suffix)
+    list(GET _tuple 1 _library)
+
+    if(NOT IS_ABSOLUTE "${_library}")
+      # search for library target relative to this CMake file
+      set(_lib "NOTFOUND")
+      find_library(
+        _lib NAMES "${_library}"
+        PATHS "${@PROJECT_NAME@_DIR}/../../../lib"
+        NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH
+      )
+
+      if(NOT _lib)
+        # the library wasn't found
+        message(FATAL_ERROR "Package '@PROJECT_NAME@' exports the typesupport library '${_library}' which couldn't be found")
+      elseif(NOT IS_ABSOLUTE "${_lib}")
+        # the found library must be an absolute path
+        message(FATAL_ERROR "Package '@PROJECT_NAME@' found the typesupport library '${_library}' at '${_lib}' which is not an absolute path")
+      elseif(NOT EXISTS "${_lib}")
+        # the found library must exist
+        message(FATAL_ERROR "Package '@PROJECT_NAME@' found the typesupport library '${_lib}' which doesn't exist")
+      else()
+        list(APPEND @PROJECT_NAME@_LIBRARIES${_suffix} ${_cfg} "${_lib}")
+      endif()
+
+    else()
+      if(NOT EXISTS "${_library}")
+        # the found library must exist
+        message(WARNING "Package '@PROJECT_NAME@' exports the typesupport library '${_library}' which doesn't exist")
+      else()
+        list(APPEND @PROJECT_NAME@_LIBRARIES${_suffix} "${_library}")
+      endif()
+    endif()
+  endforeach()
+endif()

--- a/rosidl_cmake/cmake/rosidl_cmake_export_typesupport_libraries_package_hook.cmake
+++ b/rosidl_cmake/cmake/rosidl_cmake_export_typesupport_libraries_package_hook.cmake
@@ -1,0 +1,23 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# generate and register extra file for typesupport libraries
+set(_generated_extra_file
+  "${CMAKE_CURRENT_BINARY_DIR}/rosidl_cmake/rosidl_cmake_export_typesupport_libraries-extras.cmake")
+configure_file(
+  "${rosidl_cmake_DIR}/rosidl_cmake_export_typesupport_libraries-extras.cmake.in"
+  "${_generated_extra_file}"
+  @ONLY
+)
+list(APPEND ${PROJECT_NAME}_CONFIG_EXTRAS "${_generated_extra_file}")

--- a/rosidl_cmake/cmake/rosidl_export_typesupport_libraries.cmake
+++ b/rosidl_cmake/cmake/rosidl_export_typesupport_libraries.cmake
@@ -1,0 +1,51 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Export typesupport libraries to downstream packages.
+#
+# :param library_suffix: the suffix of the library
+# :param ARGN: a list of libraries.
+#   Each element must be a CMake library target.
+# :type ARGN: list of strings
+#
+# @public
+#
+macro(rosidl_export_typesupport_libraries library_suffix)
+  if(_${PROJECT_NAME}_AMENT_PACKAGE)
+    message(FATAL_ERROR
+      "rosidl_export_typesupport_libraries() must be called before "
+      "ament_package()")
+  endif()
+
+  if(${ARGC} GREATER 0)
+    _rosidl_cmake_export_typesupport_libraries_register_package_hook()
+    # loop over libraries
+    foreach(_lib ${ARGN})
+      if(NOT TARGET "${_lib}")
+        message(FATAL_ERROR
+          "rosidl_export_typesupport_libraries() must be called with targets")
+      endif()
+
+      get_target_property(_is_imported "${_lib}" IMPORTED)
+      if(_is_imported)
+        message(FATAL_ERROR
+          "rosidl_export_typesupport_libraries() must be called with "
+          "not-imported targets")
+      endif()
+
+      list(APPEND _ROSIDL_CMAKE_EXPORT_TYPESUPPORT_LIBRARIES "${library_suffix}:${_lib}")
+    endforeach()
+  endif()
+endmacro()

--- a/rosidl_cmake/rosidl_cmake-extras.cmake
+++ b/rosidl_cmake/rosidl_cmake-extras.cmake
@@ -1,4 +1,4 @@
-# Copyright 2014 Open Source Robotics Foundation, Inc.
+# Copyright 2014-2018 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,3 +31,16 @@ include("${rosidl_cmake_DIR}/rosidl_generate_interfaces.cmake")
 include("${rosidl_cmake_DIR}/rosidl_target_interfaces.cmake")
 include("${rosidl_cmake_DIR}/rosidl_write_generator_arguments.cmake")
 include("${rosidl_cmake_DIR}/string_camel_case_to_lower_case_underscore.cmake")
+
+# register ament_package() hook for typesupport libraries once
+macro(_rosidl_cmake_export_typesupport_libraries_register_package_hook)
+  if(NOT DEFINED _ROSIDL_CMAKE_EXPORT_TYPESUPPORT_LIBRARIES_PACKAGE_HOOK_REGISTERED)
+    set(_ROSIDL_CMAKE_EXPORT_TYPESUPPORT_LIBRARIES_PACKAGE_HOOK_REGISTERED TRUE)
+
+    find_package(ament_cmake_core QUIET REQUIRED)
+    ament_register_extension("ament_package" "rosidl_cmake"
+      "rosidl_cmake_export_typesupport_libraries_package_hook.cmake")
+  endif()
+endmacro()
+
+include("${rosidl_cmake_DIR}/rosidl_export_typesupport_libraries.cmake")


### PR DESCRIPTION
The vendor specific typesupport libraries must not be exported through the message packages `<pkgname>_LIBRARIES` variable in order to address ros2/ros2#437.

This patch provides a macro to export the typesupport libraries through a separate variable which can be used by the vendor specific packages.