### PR TITLE
use pytest instead of nose

### DIFF
--- a/rosidl_parser/CMakeLists.txt
+++ b/rosidl_parser/CMakeLists.txt
@@ -16,5 +16,5 @@ ament_package()
 
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
-  ament_add_pytest_test(nosetests test)
+  ament_add_pytest_test(pytest test)
 endif()

--- a/rosidl_parser/package.xml
+++ b/rosidl_parser/package.xml
@@ -12,6 +12,7 @@
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>pytest</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rosidl_parser/test/test_base_type.py
+++ b/rosidl_parser/test/test_base_type.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nose.tools import assert_raises
+import pytest
 
 from rosidl_parser import BaseType
 from rosidl_parser import InvalidResourceName
@@ -45,9 +45,9 @@ def test_base_type_constructor():
     assert base_type.type == 'string'
     assert base_type.string_upper_bound == 23
 
-    with assert_raises(TypeError):
+    with pytest.raises(TypeError):
         BaseType('string<=upperbound')
-    with assert_raises(TypeError):
+    with pytest.raises(TypeError):
         BaseType('string<=0')
 
     base_type = BaseType('pkg/Msg')
@@ -60,13 +60,13 @@ def test_base_type_constructor():
     assert base_type.type == 'Msg'
     assert base_type.string_upper_bound is None
 
-    with assert_raises(InvalidResourceName):
+    with pytest.raises(InvalidResourceName):
         BaseType('Foo')
 
-    with assert_raises(InvalidResourceName):
+    with pytest.raises(InvalidResourceName):
         BaseType('pkg name/Foo')
 
-    with assert_raises(InvalidResourceName):
+    with pytest.raises(InvalidResourceName):
         BaseType('pkg/Foo Bar')
 
 

--- a/rosidl_parser/test/test_constant.py
+++ b/rosidl_parser/test/test_constant.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nose.tools import assert_raises
+import pytest
 
 from rosidl_parser import Constant
 
@@ -21,13 +21,13 @@ def test_constant_constructor():
     value = Constant('bool', 'FOO', '1')
     assert value
 
-    with assert_raises(TypeError):
+    with pytest.raises(TypeError):
         Constant('pkg/Foo', 'FOO', '')
 
-    with assert_raises(NameError):
+    with pytest.raises(NameError):
         Constant('bool', 'FOO BAR', '')
 
-    with assert_raises(ValueError):
+    with pytest.raises(ValueError):
         Constant('bool', 'FOO', None)
 
 

--- a/rosidl_parser/test/test_field.py
+++ b/rosidl_parser/test/test_field.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nose.tools import assert_raises
+import pytest
 
 from rosidl_parser import Field
 from rosidl_parser import InvalidValue
@@ -29,10 +29,10 @@ def test_field_constructor():
     field = Field(type_, 'foo', '1')
     assert field.default_value
 
-    with assert_raises(TypeError):
+    with pytest.raises(TypeError):
         Field('type', 'foo')
 
-    with assert_raises(NameError):
+    with pytest.raises(NameError):
         Field(type_, 'foo bar')
 
     type_ = Type('bool[2]')
@@ -44,7 +44,7 @@ def test_field_constructor():
     assert field.default_value == [False, True, False]
 
     type_ = Type('bool[3]')
-    with assert_raises(InvalidValue):
+    with pytest.raises(InvalidValue):
         Field(type_, 'foo', '[false, true]')
 
 

--- a/rosidl_parser/test/test_message_specification.py
+++ b/rosidl_parser/test/test_message_specification.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nose.tools import assert_raises
+import pytest
 
 from rosidl_parser import Constant
 from rosidl_parser import Field
@@ -27,13 +27,13 @@ def test_message_specification_constructor():
     assert len(msg_spec.fields) == 0
     assert len(msg_spec.constants) == 0
 
-    with assert_raises(TypeError):
+    with pytest.raises(TypeError):
         MessageSpecification('pkg', 'Foo', None, [])
-    with assert_raises(TypeError):
+    with pytest.raises(TypeError):
         MessageSpecification('pkg', 'Foo', [], None)
-    with assert_raises(TypeError):
+    with pytest.raises(TypeError):
         MessageSpecification('pkg', 'Foo', ['field'], [])
-    with assert_raises(TypeError):
+    with pytest.raises(TypeError):
         MessageSpecification('pkg', 'Foo', [], ['constant'])
 
     field = Field(Type('bool'), 'foo', '1')
@@ -44,9 +44,9 @@ def test_message_specification_constructor():
     assert len(msg_spec.constants) == 1
     assert msg_spec.constants[0] == constant
 
-    with assert_raises(ValueError):
+    with pytest.raises(ValueError):
         MessageSpecification('pkg', 'Foo', [field, field], [])
-    with assert_raises(ValueError):
+    with pytest.raises(ValueError):
         MessageSpecification('pkg', 'Foo', [], [constant, constant])
 
 

--- a/rosidl_parser/test/test_parse_message_file.py
+++ b/rosidl_parser/test/test_parse_message_file.py
@@ -16,7 +16,7 @@ import os
 import shutil
 import tempfile
 
-from nose.tools import assert_raises
+import pytest
 
 from rosidl_parser import parse_message_file
 
@@ -37,8 +37,8 @@ def test_parse_message_file():
 
         with open(filename, 'a') as handle:
             handle.write('\nbool foo')
-        with assert_raises(ValueError) as ctx:
+        with pytest.raises(ValueError) as e:
             parse_message_file('pkg', filename)
-        assert 'foo' in str(ctx.exception)
+        assert 'foo' in str(e)
     finally:
         shutil.rmtree(path)

--- a/rosidl_parser/test/test_parse_message_string.py
+++ b/rosidl_parser/test/test_parse_message_string.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nose.tools import assert_raises
+import pytest
 
 from rosidl_parser import InvalidFieldDefinition
 from rosidl_parser import InvalidResourceName
@@ -30,7 +30,7 @@ def test_parse_message_string():
     assert len(msg_spec.fields) == 0
     assert len(msg_spec.constants) == 0
 
-    with assert_raises(InvalidFieldDefinition):
+    with pytest.raises(InvalidFieldDefinition):
         parse_message_string('pkg', 'Foo', 'bool  # comment')
 
     msg_spec = parse_message_string('pkg', 'Foo', 'bool foo')
@@ -47,15 +47,15 @@ def test_parse_message_string():
     assert msg_spec.fields[0].default_value
     assert len(msg_spec.constants) == 0
 
-    with assert_raises(InvalidResourceName):
+    with pytest.raises(InvalidResourceName):
         parse_message_string('pkg', 'Foo', 'Ty_pe foo')
-    with assert_raises(TypeError):
+    with pytest.raises(TypeError):
         parse_message_string('pkg', 'Foo', 'bool] foo')
-    with assert_raises(TypeError):
+    with pytest.raises(TypeError):
         parse_message_string('pkg', 'Foo', 'bool[max]] foo')
-    with assert_raises(ValueError) as ctx:
+    with pytest.raises(ValueError) as e:
         parse_message_string('pkg', 'Foo', 'bool foo\nbool foo')
-    assert 'foo' in str(ctx.exception)
+    assert 'foo' in str(e)
 
     msg_spec = parse_message_string('pkg', 'Foo', 'bool FOO=1')
     assert len(msg_spec.fields) == 0
@@ -64,10 +64,10 @@ def test_parse_message_string():
     assert msg_spec.constants[0].name == 'FOO'
     assert msg_spec.constants[0].value
 
-    with assert_raises(TypeError):
+    with pytest.raises(TypeError):
         parse_message_string('pkg', 'Foo', 'pkg/Bar foo=1')
-    with assert_raises(NameError):
+    with pytest.raises(NameError):
         parse_message_string('pkg', 'Foo', 'bool foo=1')
-    with assert_raises(ValueError) as ctx:
+    with pytest.raises(ValueError) as e:
         parse_message_string('pkg', 'Foo', 'bool FOO=1\nbool FOO=1')
-    assert 'FOO' in str(ctx.exception)
+    assert 'FOO' in str(e)

--- a/rosidl_parser/test/test_parse_primitive_value_string.py
+++ b/rosidl_parser/test/test_parse_primitive_value_string.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nose.tools import assert_raises
+import pytest
 
 from rosidl_parser import InvalidValue
 from rosidl_parser import parse_primitive_value_string
@@ -20,9 +20,9 @@ from rosidl_parser import Type
 
 
 def test_parse_primitive_value_string_invalid():
-    with assert_raises(ValueError):
+    with pytest.raises(ValueError):
         parse_primitive_value_string(Type('pkg/Foo'), '')
-    with assert_raises(ValueError):
+    with pytest.raises(ValueError):
         parse_primitive_value_string(Type('bool[]'), '')
 
 
@@ -41,9 +41,9 @@ def test_parse_primitive_value_string_bool():
         value = parse_primitive_value_string(Type('bool'), string_value)
         assert value == expected_value
 
-    with assert_raises(InvalidValue):
+    with pytest.raises(InvalidValue):
         parse_primitive_value_string(Type('bool'), '5')
-    with assert_raises(InvalidValue):
+    with pytest.raises(InvalidValue):
         parse_primitive_value_string(Type('bool'), 'true ')
 
 
@@ -74,13 +74,13 @@ def test_parse_primitive_value_string_integer():
             Type(integer_type), str(upper_bound))
         assert value == upper_bound
 
-        with assert_raises(InvalidValue):
+        with pytest.raises(InvalidValue):
             parse_primitive_value_string(
                 Type(integer_type), 'value')
-        with assert_raises(InvalidValue):
+        with pytest.raises(InvalidValue):
             parse_primitive_value_string(
                 Type(integer_type), str(lower_bound - 1))
-        with assert_raises(InvalidValue):
+        with pytest.raises(InvalidValue):
             parse_primitive_value_string(
                 Type(integer_type), str(upper_bound + 1))
 
@@ -97,7 +97,7 @@ def test_parse_primitive_value_string_float():
             Type(float_type), '3.14')
         assert value == 3.14
 
-        with assert_raises(InvalidValue):
+        with pytest.raises(InvalidValue):
             parse_primitive_value_string(
                 Type(float_type), 'value')
 
@@ -127,15 +127,15 @@ def test_parse_primitive_value_string_string():
         Type('string<=3'), 'foo')
     assert value == 'foo'
 
-    with assert_raises(InvalidValue):
+    with pytest.raises(InvalidValue):
         parse_primitive_value_string(
             Type('string<=3'), 'foobar')
 
-    with assert_raises(InvalidValue):
+    with pytest.raises(InvalidValue):
         parse_primitive_value_string(
             Type('string'), r"""'foo''""")
 
-    with assert_raises(InvalidValue):
+    with pytest.raises(InvalidValue):
         parse_primitive_value_string(
             Type('string'), r'''"foo"bar\"baz"''')  # noqa: Q001
 
@@ -179,5 +179,5 @@ def test_parse_primitive_value_string_unknown():
             return True
     type_ = CustomType('pkg/Foo')
 
-    with assert_raises(AssertionError):
+    with pytest.raises(AssertionError):
         parse_primitive_value_string(type_, '')

--- a/rosidl_parser/test/test_parse_service_string.py
+++ b/rosidl_parser/test/test_parse_service_string.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nose.tools import assert_raises
+import pytest
 
 from rosidl_parser import InvalidFieldDefinition
 from rosidl_parser import InvalidServiceSpecification
@@ -20,7 +20,7 @@ from rosidl_parser import parse_service_string
 
 
 def test_parse_service_string():
-    with assert_raises(InvalidServiceSpecification):
+    with pytest.raises(InvalidServiceSpecification):
         parse_service_string('pkg', 'Foo', '')
 
     srv_spec = parse_service_string('pkg', 'Foo', '---')
@@ -41,7 +41,7 @@ def test_parse_service_string():
     assert len(srv_spec.response.fields) == 0
     assert len(srv_spec.response.constants) == 0
 
-    with assert_raises(InvalidFieldDefinition):
+    with pytest.raises(InvalidFieldDefinition):
         parse_service_string('pkg', 'Foo', 'bool  # comment\n---')
 
     srv_spec = parse_service_string('pkg', 'Foo', 'bool foo\n---\nint8 bar')

--- a/rosidl_parser/test/test_parse_value_string.py
+++ b/rosidl_parser/test/test_parse_value_string.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nose.tools import assert_raises
+import pytest
 
 from rosidl_parser import InvalidValue
 from rosidl_parser import parse_value_string
@@ -24,15 +24,15 @@ def test_parse_value_string_primitive():
 
 
 def test_parse_value_string():
-    with assert_raises(InvalidValue):
+    with pytest.raises(InvalidValue):
         parse_value_string(Type('bool[]'), '1')
 
-    with assert_raises(InvalidValue):
+    with pytest.raises(InvalidValue):
         parse_value_string(Type('bool[2]'), '[1]')
-    with assert_raises(InvalidValue):
+    with pytest.raises(InvalidValue):
         parse_value_string(Type('bool[<=1]'), '[1, 0]')
 
-    with assert_raises(InvalidValue):
+    with pytest.raises(InvalidValue):
         parse_value_string(Type('bool[]'), '[2]')
 
     value = parse_value_string(Type('bool[]'), '[1]')
@@ -41,16 +41,16 @@ def test_parse_value_string():
     value = parse_value_string(Type('string[]'), "['foo', 'bar']")
     assert value == ['foo', 'bar']
 
-    with assert_raises(InvalidValue):
+    with pytest.raises(InvalidValue):
         parse_value_string(Type('string[<=2]'), '[foo, bar, baz]')
 
-    with assert_raises(InvalidValue):
+    with pytest.raises(InvalidValue):
         parse_value_string(Type('string[<=2]'), """["foo", 'ba"r', "ba,z"]""")
 
-    with assert_raises(ValueError):
+    with pytest.raises(ValueError):
         parse_value_string(Type('string[<=3]'), """[,"foo", 'ba"r', "ba,z"]""")
 
-    with assert_raises(ValueError):
+    with pytest.raises(ValueError):
         parse_value_string(Type('string[<=3]'), """["foo", ,'ba"r', "ba,z"]""")
 
     parse_value_string(Type('string[<=2]'), """["fo'o\\\", bar", baz]""")
@@ -58,5 +58,5 @@ def test_parse_value_string():
 
 
 def test_parse_value_string_not_implemented():
-    with assert_raises(NotImplementedError):
+    with pytest.raises(NotImplementedError):
         parse_value_string(Type('pkg/Foo[]'), '')

--- a/rosidl_parser/test/test_type.py
+++ b/rosidl_parser/test/test_type.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nose.tools import assert_raises
+import pytest
 
 from rosidl_parser import Type
 
@@ -34,7 +34,7 @@ def test_type_constructor():
     assert type_.array_size is None
     assert not type_.is_upper_bound
 
-    with assert_raises(TypeError):
+    with pytest.raises(TypeError):
         Type('bool]')
 
     type_ = Type('bool[5]')
@@ -53,13 +53,13 @@ def test_type_constructor():
     assert type_.array_size == 5
     assert type_.is_upper_bound
 
-    with assert_raises(TypeError):
+    with pytest.raises(TypeError):
         Type('bool[size]')
-    with assert_raises(TypeError):
+    with pytest.raises(TypeError):
         Type('bool[0]')
-    with assert_raises(TypeError):
+    with pytest.raises(TypeError):
         Type('bool[<=size]')
-    with assert_raises(TypeError):
+    with pytest.raises(TypeError):
         Type('bool[<=0]')
 
 

--- a/rosidl_parser/test/test_valid_names.py
+++ b/rosidl_parser/test/test_valid_names.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nose.tools import assert_raises
+import pytest
 
 from rosidl_parser import InvalidResourceName
 from rosidl_parser import is_valid_constant_name
@@ -28,7 +28,7 @@ def test_is_valid_package_name():
     for invalid_package_name in [
             '_foo', 'foo_', 'foo__bar', 'foo-bar']:
         assert not is_valid_package_name(invalid_package_name)
-    with assert_raises(InvalidResourceName):
+    with pytest.raises(InvalidResourceName):
         is_valid_package_name(None)
 
 
@@ -39,7 +39,7 @@ def test_is_valid_field_name():
     for invalid_field_name in [
             '_foo', 'foo_', 'foo__bar', 'foo-bar']:
         assert not is_valid_field_name(invalid_field_name)
-    with assert_raises(InvalidResourceName):
+    with pytest.raises(InvalidResourceName):
         is_valid_field_name(None)
 
 
@@ -50,7 +50,7 @@ def test_is_valid_message_name():
     for invalid_message_name in [
             '0foo', '_Foo', 'Foo_', 'Foo_Bar']:
         assert not is_valid_message_name(invalid_message_name)
-    with assert_raises(InvalidResourceName):
+    with pytest.raises(InvalidResourceName):
         is_valid_message_name(None)
 
 
@@ -61,5 +61,5 @@ def test_is_valid_constant_name():
     for invalid_constant_name in [
             '_FOO', 'FOO_', 'FOO__BAR', 'Foo']:
         assert not is_valid_constant_name(invalid_constant_name)
-    with assert_raises(InvalidResourceName):
+    with pytest.raises(InvalidResourceName):
         is_valid_constant_name(None)

--- a/rosidl_parser/test/test_validate_field_types.py
+++ b/rosidl_parser/test/test_validate_field_types.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nose.tools import assert_raises
+import pytest
 
 from rosidl_parser import BaseType
 from rosidl_parser import Field
@@ -31,7 +31,7 @@ def test_validate_field_types():
     validate_field_types(msg_spec, known_msg_type)
 
     msg_spec.fields.append(Field(Type('pkg/Bar'), 'bar'))
-    with assert_raises(UnknownMessageType):
+    with pytest.raises(UnknownMessageType):
         validate_field_types(msg_spec, known_msg_type)
 
     known_msg_type.append(BaseType('pkg/Bar'))


### PR DESCRIPTION
The package doesn't declare a test dependency on `nose` and therefore the tests fail in the devel jobs: http://build.ros2.org/view/Bdev/job/Bdev__rosidl__ubuntu_bionic_amd64/2/testReport/

Instead of adding that test dependency the patch switched the tests to use `pytest` instead and adds an explicit test dependency on it.

* Linux only: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4818)](https://ci.ros2.org/job/ci_linux/4818/)