### PR TITLE
Error on all msg/srv names with underscores

### DIFF
--- a/rosidl_parser/test/test_valid_names.py
+++ b/rosidl_parser/test/test_valid_names.py
@@ -48,7 +48,7 @@ def test_is_valid_message_name():
             'Foo', 'FooBar']:
         assert is_valid_message_name(valid_message_name)
     for invalid_message_name in [
-            '0foo', '_Foo', 'Foo_', 'Foo_Bar']:
+            '0foo', '_Foo', 'Foo_', 'Foo_Bar', 'Sample_Foo']:
         assert not is_valid_message_name(invalid_message_name)
     with pytest.raises(InvalidResourceName):
         is_valid_message_name(None)


### PR DESCRIPTION
While discussing https://github.com/ros2/rmw_opensplice/issues/239 we noticed that, while msg/srv filenames with underscores don't work in general, an msg file that starts with `Sample_` can pass the [`is_valid_message_name` check](https://github.com/ros2/rosidl/blob/6549399b496ee394cda964cede24718e0a38af9c/rosidl_parser/rosidl_parser/__init__.py#L106) because of the `Sample_` prefix stripping that is in place for srv support for opensplice.

At the moment this PR just includes a test that highlights it.