### PR TITLE
fix comparison

### DIFF
--- a/rosidl_generator_cpp/test/test_msg_datatype.cpp
+++ b/rosidl_generator_cpp/test/test_msg_datatype.cpp
@@ -18,8 +18,10 @@
 
 
 TEST(Test_rosidl_generator_traits, check_data_type) {
-  ASSERT_EQ(rosidl_generator_traits::data_type<rosidl_generator_cpp::msg::String>(),
-    "rosidl_generator_cpp::msg::String");
-  ASSERT_EQ(rosidl_generator_traits::data_type<rosidl_generator_cpp::msg::Empty>(),
-    "rosidl_generator_cpp::msg::Empty");
+  ASSERT_STREQ(
+    "rosidl_generator_cpp::msg::String",
+    rosidl_generator_traits::data_type<rosidl_generator_cpp::msg::String>());
+  ASSERT_STREQ(
+    "rosidl_generator_cpp::msg::Empty",
+    rosidl_generator_traits::data_type<rosidl_generator_cpp::msg::Empty>());
 }


### PR DESCRIPTION
Follow up of #291. @sagniknitr FYI.

Fixes the comparison of the string in the test: https://ci.ros2.org/view/nightly/job/nightly_win_deb/943/testReport/junit/rosidl_generator_cpp/Test_rosidl_generator_traits/check_data_type/

After: https://ci.ros2.org/job/ci_windows/4932/testReport/rosidl_generator_cpp/Test_rosidl_generator_traits/check_data_type/