### PR TITLE
Rosidl type support struct typedef redefinition.

### DIFF
--- a/rosidl_generator_c/include/rosidl_generator_c/message_type_support_struct.h
+++ b/rosidl_generator_c/include/rosidl_generator_c/message_type_support_struct.h
@@ -28,12 +28,12 @@ typedef struct rosidl_message_type_support_t rosidl_message_type_support_t;
 typedef const rosidl_message_type_support_t * (* rosidl_message_typesupport_handle_function)(
   const rosidl_message_type_support_t *, const char *);
 
-typedef struct rosidl_message_type_support_t
+struct rosidl_message_type_support_t
 {
   const char * typesupport_identifier;
   const void * data;
   rosidl_message_typesupport_handle_function func;
-} rosidl_message_type_support_t;
+};
 
 ROSIDL_GENERATOR_C_PUBLIC
 const rosidl_message_type_support_t * get_message_typesupport_handle(

--- a/rosidl_generator_c/include/rosidl_generator_c/service_type_support_struct.h
+++ b/rosidl_generator_c/include/rosidl_generator_c/service_type_support_struct.h
@@ -29,12 +29,12 @@ typedef struct rosidl_service_type_support_t rosidl_service_type_support_t;
 typedef const rosidl_service_type_support_t * (* rosidl_service_typesupport_handle_function)(
   const rosidl_service_type_support_t *, const char *);
 
-typedef struct rosidl_service_type_support_t
+struct rosidl_service_type_support_t
 {
   const char * typesupport_identifier;
   const void * data;
   rosidl_service_typesupport_handle_function func;
-} rosidl_service_type_support_t;
+};
 
 ROSIDL_GENERATOR_C_PUBLIC
 const rosidl_service_type_support_t * get_service_typesupport_handle(


### PR DESCRIPTION
This change solves #297.
Avoids the redefinition of rosidl_message_type_support_t and rosidl_service_type_support_t.