### PR TITLE
Fix a double free problem in the generated C code.

### DIFF
--- a/rosidl_generator_c/resource/msg__functions.c.em
+++ b/rosidl_generator_c/resource/msg__functions.c.em
@@ -82,7 +82,7 @@ for field in spec.fields:
         if field.type.is_primitive_type():
             if field.type.type == 'string':
                 lines.append('if (!rosidl_generator_c__String__init(&msg->%s)) {' % field.name)
-                lines.append('  %s__destroy(msg);' % msg_typename)
+                lines.append('  %s__fini(msg);' % msg_typename)
                 lines.append('  return false;')
                 lines.append('}')
                 if field.default_value is not None:
@@ -105,7 +105,7 @@ for field in spec.fields:
         else:
             # initialize the sub message
             lines.append('if (!%s__%s__%s__init(&msg->%s)) {' % (field.type.pkg_name, 'msg', field.type.type, field.name))
-            lines.append('  %s__destroy(msg);' % msg_typename)
+            lines.append('  %s__fini(msg);' % msg_typename)
             lines.append('  return false;')
             lines.append('}')
         # no default value for nested messages yet
@@ -119,7 +119,7 @@ for field in spec.fields:
             # initialize each array element
             lines.append('for (size_t i = 0; i < %d; ++i) {' % field.type.array_size)
             lines.append('  if (!%s__init(&msg->%s[i])) {' % (get_typename_of_base_type(field.type), field.name))
-            lines.append('    %s__destroy(msg);' % msg_typename)
+            lines.append('    %s__fini(msg);' % msg_typename)
             lines.append('    return false;')
             lines.append('  }')
             lines.append('}')
@@ -145,7 +145,7 @@ for field in spec.fields:
         if field.default_value is None:
             # initialize the dynamic array with a capacity of zero
             lines.append('if (!%s__Array__init(&msg->%s, 0)) {' % (get_typename_of_base_type(field.type), field.name))
-            lines.append('  %s__destroy(msg);' % msg_typename)
+            lines.append('  %s__fini(msg);' % msg_typename)
             lines.append('  return false;')
             lines.append('}')
         else:


### PR DESCRIPTION
When the generated C code is doing an array initialization,
the initialization of one of the array members may fail.  If
that happens with the current code, then it will call "__destroy"
on each of the already-initialized members.  In turn, the
"__destroy" method will uninitialize each of the members of
the structure, then free the whole structure.  The final
freeing is incorrect; the freeing of the memory should be
done when the whole array is freed, not on a member-by-member
basis.  The solution here is to call the "__fini" method during
a failure, which will uninitialize members, but not free the
entire structure.  This should get rid of double-free warnings
that come from clang static analysis.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5273)](http://ci.ros2.org/job/ci_linux/5273/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2029)](http://ci.ros2.org/job/ci_linux-aarch64/2029/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4389)](http://ci.ros2.org/job/ci_osx/4389/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5252)](http://ci.ros2.org/job/ci_windows/5252/)