### PR TITLE
Add static cast when assigning values to arrays or vectors

### DIFF
--- a/rosidl_generator_cpp/resource/msg__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.em
@@ -100,10 +100,10 @@ def generate_default_string(membset):
                 strlist.append('this->%s.resize(%d);' % (member.name, member.num_prealloc))
             if isinstance(member.default_value, list):
                 if all(v == member.default_value[0] for v in member.default_value):
-                    strlist.append('std::fill(this->%s.begin(), this->%s.end(), %s);' % (member.name, member.name, member.default_value[0]))
+                    strlist.append('std::fill(this->%s.begin(), this->%s.end(), static_cast<typename decltype(this->%s)::value_type>(%s));' % (member.name, member.name, member.name, member.default_value[0]))
                 else:
                     for index, val in enumerate(member.default_value):
-                        strlist.append('this->%s[%d] = %s;' % (member.name, index, val))
+                        strlist.append('this->%s[%d] = static_cast<typename decltype(this->%s)::value_type>(%s);' % (member.name, index, member.name, val))
             else:
                 strlist.append('this->%s = %s;' % (member.name, member.default_value))
 
@@ -118,7 +118,7 @@ def generate_zero_string(membset, fill_args):
             if member.zero_need_array_override:
                 strlist.append('this->%s.fill(%s{%s});' % (member.name, msg_type_only_to_cpp(member.type), fill_args))
             else:
-                strlist.append('std::fill(this->%s.begin(), this->%s.end(), %s);' % (member.name, member.name, member.zero_value[0]))
+                strlist.append('std::fill(this->%s.begin(), this->%s.end(), static_cast<typename decltype(this->%s)::value_type>(%s));' % (member.name, member.name, member.name, member.zero_value[0]))
         else:
             strlist.append('this->%s = %s;' % (member.name, member.zero_value))
     return strlist

--- a/rosidl_generator_cpp/resource/msg__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.em
@@ -100,10 +100,13 @@ def generate_default_string(membset):
                 strlist.append('this->%s.resize(%d);' % (member.name, member.num_prealloc))
             if isinstance(member.default_value, list):
                 if all(v == member.default_value[0] for v in member.default_value):
-                    strlist.append('std::fill(this->%s.begin(), this->%s.end(), static_cast<typename decltype(this->%s)::value_type>(%s));' % (member.name, member.name, member.name, member.default_value[0]))
+                    # Specifying type for std::fill because of MSBuild warning about cast (C4244)
+                    # TODO(jacobperron): Investigate reason build warnings on Windows
+                    # TODO(jacobperron): Write test case for this path of execution
+                    strlist.append('std::fill<typename %s::iterator, %s>(this->%s.begin(), this->%s.end(), %s);' % (msg_type_to_cpp(member.type), msg_type_only_to_cpp(member.type), member.name, member.name, member.default_value[0]))
                 else:
                     for index, val in enumerate(member.default_value):
-                        strlist.append('this->%s[%d] = static_cast<typename decltype(this->%s)::value_type>(%s);' % (member.name, index, member.name, val))
+                        strlist.append('this->%s[%d] = %s;' % (member.name, index, val))
             else:
                 strlist.append('this->%s = %s;' % (member.name, member.default_value))
 
@@ -118,7 +121,9 @@ def generate_zero_string(membset, fill_args):
             if member.zero_need_array_override:
                 strlist.append('this->%s.fill(%s{%s});' % (member.name, msg_type_only_to_cpp(member.type), fill_args))
             else:
-                strlist.append('std::fill(this->%s.begin(), this->%s.end(), static_cast<typename decltype(this->%s)::value_type>(%s));' % (member.name, member.name, member.name, member.zero_value[0]))
+                # Specifying type for std::fill because of MSBuild warning about cast (C4244)
+                # TODO(jacobperron): Investigate reason build warnings on Windows
+                strlist.append('std::fill<typename %s::iterator, %s>(this->%s.begin(), this->%s.end(), %s);' % (msg_type_to_cpp(member.type), msg_type_only_to_cpp(member.type), member.name, member.name, member.zero_value[0]))
         else:
             strlist.append('this->%s = %s;' % (member.name, member.zero_value))
     return strlist

--- a/rosidl_generator_cpp/resource/msg__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.em
@@ -100,8 +100,9 @@ def generate_default_string(membset):
                 strlist.append('this->%s.resize(%d);' % (member.name, member.num_prealloc))
             if isinstance(member.default_value, list):
                 if all(v == member.default_value[0] for v in member.default_value):
-                    # Specifying type for std::fill because of MSBuild warning about cast (C4244)
-                    # TODO(jacobperron): Investigate reason build warnings on Windows
+                    # Specifying type for std::fill because of MSVC 14.12 warning about casting 'const int' to smaller types (C4244)
+                    # For more info, see https://github.com/ros2/rosidl/issues/309
+                    # TODO(jacobperron): Investigate reason for build warnings on Windows
                     # TODO(jacobperron): Write test case for this path of execution
                     strlist.append('std::fill<typename %s::iterator, %s>(this->%s.begin(), this->%s.end(), %s);' % (msg_type_to_cpp(member.type), msg_type_only_to_cpp(member.type), member.name, member.name, member.default_value[0]))
                 else:
@@ -121,8 +122,9 @@ def generate_zero_string(membset, fill_args):
             if member.zero_need_array_override:
                 strlist.append('this->%s.fill(%s{%s});' % (member.name, msg_type_only_to_cpp(member.type), fill_args))
             else:
-                # Specifying type for std::fill because of MSBuild warning about cast (C4244)
-                # TODO(jacobperron): Investigate reason build warnings on Windows
+                # Specifying type for std::fill because of MSVC 14.12 warning about casting 'const int' to smaller types (C4244)
+                # For more info, see https://github.com/ros2/rosidl/issues/309
+                # TODO(jacobperron): Investigate reason for build warnings on Windows
                 strlist.append('std::fill<typename %s::iterator, %s>(this->%s.begin(), this->%s.end(), %s);' % (msg_type_to_cpp(member.type), msg_type_only_to_cpp(member.type), member.name, member.name, member.zero_value[0]))
         else:
             strlist.append('this->%s = %s;' % (member.name, member.zero_value))


### PR DESCRIPTION
This resolves bugs due to implicit casts.

Specifically, resolves ros2/rcl_interfaces#42

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5328)](http://ci.ros2.org/job/ci_linux/5328/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2064)](http://ci.ros2.org/job/ci_linux-aarch64/2064/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4427)](http://ci.ros2.org/job/ci_osx/4427/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5295)](http://ci.ros2.org/job/ci_windows/5295/)