### PR TITLE
Add rosidl_generator_cpp templates for actions

### DIFF
--- a/rosidl_actions/rosidl_actions/__init__.py
+++ b/rosidl_actions/rosidl_actions/__init__.py
@@ -43,6 +43,7 @@ def generate_msg_and_srv(generator_arguments_file):
                 with open(rsp_file, 'w+') as fout:
                     fout.write(str(service.response))
 
-            generated_file = os.path.join(args['output_dir'], subfolder, action.feedback.msg_name + '.msg')
+            generated_file = os.path.join(
+                args['output_dir'], subfolder, action.feedback.msg_name + '.msg')
             with open(generated_file, 'w+') as fout:
                 fout.write(str(action.feedback))

--- a/rosidl_actions/rosidl_actions/__init__.py
+++ b/rosidl_actions/rosidl_actions/__init__.py
@@ -26,13 +26,13 @@ def generate_msg_and_srv(generator_arguments_file):
         extension = os.path.splitext(ros_interface_file)[1]
         subfolder = os.path.basename(os.path.dirname(ros_interface_file))
         if extension == '.action':
-            services, message = parse_action_file(args['package_name'], ros_interface_file)
+            action = parse_action_file(args['package_name'], ros_interface_file)
 
             # create folder if necessary
             os.makedirs(os.path.join(args['output_dir'], subfolder), exist_ok=True)
 
             generated_folder = os.path.join(args['output_dir'], subfolder)
-            for service in services:
+            for service in action.services:
                 srv_file = os.path.join(generated_folder, service.srv_name + '.srv')
                 req_file = os.path.join(generated_folder, service.srv_name + '_Request.msg')
                 rsp_file = os.path.join(generated_folder, service.srv_name + '_Response.msg')
@@ -43,6 +43,6 @@ def generate_msg_and_srv(generator_arguments_file):
                 with open(rsp_file, 'w+') as fout:
                     fout.write(str(service.response))
 
-            generated_file = os.path.join(args['output_dir'], subfolder, message.msg_name + '.msg')
+            generated_file = os.path.join(args['output_dir'], subfolder, action.feedback.msg_name + '.msg')
             with open(generated_file, 'w+') as fout:
-                fout.write(str(message))
+                fout.write(str(action.feedback))

--- a/rosidl_cmake/cmake/rosidl_generate_action_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_generate_action_interfaces.cmake
@@ -55,7 +55,7 @@ function(rosidl_generate_action_interfaces target)
   set(_idl_files ${_ARG_UNPARSED_ARGUMENTS})
 
   # Create a custom target
-  set(_sub_target "${target}+convert_action_to_msg_and_srv")
+  set(_sub_target "${target}+generate_action_interfaces")
   add_custom_target(
     ${_sub_target} ALL
     DEPENDS

--- a/rosidl_cmake/cmake/rosidl_generate_action_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_generate_action_interfaces.cmake
@@ -1,0 +1,81 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Generate Interfaces for Actions
+#
+# This executes the extension point ``rosidl_generate_action_interfaces``.
+# An extension of this type should expect a list of `.action` files and
+# generate new files in response.
+# Extensions should create a target that generates the files with the input
+# `.action` file as a dependency.
+#
+# :param target: the _name of the generation target,
+#   specific generators might use the _name as a prefix for their own
+#   generation step
+# :type target: string
+# :param ARGN: a list of include directories where each value might
+#   be either an absolute path or path relative to the
+#   CMAKE_INSTALL_PREFIX.
+# :type ARGN: list of strings
+# :param TARGET_DEPENDENCIES: cmake targets or files the generated target
+#   should depend on
+# :type TARGET_DEPENDENCIES: list of strings
+# :param LIBRARY_NAME: the base name of the library, specific generators might
+#   append their own suffix
+# :type LIBRARY_NAME: string
+# :param SKIP_INSTALL: if set skip installing the interface files
+# :type SKIP_INSTALL: option
+# :param ADD_LINTER_TESTS: if set lint the interface files using
+#   the ``ament_lint`` package
+# :type ADD_LINTER_TESTS: option
+#
+# @public
+#
+function(rosidl_generate_action_interfaces target)
+  cmake_parse_arguments(_ARG
+    "ADD_LINTER_TESTS;SKIP_INSTALL"
+    "LIBRARY_NAME" "TARGET_DEPENDENCIES"
+    ${ARGN})
+  if(NOT _ARG_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "rosidl_generate_action_interfaces() called without any idl "
+      "files")
+  endif()
+
+  set(_idl_files ${_ARG_UNPARSED_ARGUMENTS})
+
+  # Create a custom target
+  set(_sub_target "${target}+convert_action_to_msg_and_srv")
+  add_custom_target(
+    ${_sub_target} ALL
+    DEPENDS
+    ${_idl_files}
+    ${_ARG_TARGET_DEPENDENCIES}
+    SOURCES
+    ${_idl_files}
+  )
+
+  # A target name that generators may want to use to prefix their own target names
+  set(rosidl_generate_action_interfaces_TARGET ${target})
+  # Give extensions a list of .action files to generate interfaces from
+  set(rosidl_generate_action_interfaces_IDL_FILES ${_idl_files})
+  # TODO(sloretz) Where is LIBRARY_NAME used?
+  set(rosidl_generate_action_interfaces_LIBRARY_NAME ${_ARG_LIBRARY_NAME})
+  # If true the extension should not install anything it generates
+  set(rosidl_generate_action_interfaces_SKIP_INSTALL ${_ARG_SKIP_INSTALL})
+  # If true the extension should create tests for language specific linters
+  set(rosidl_generate_action_interfaces_ADD_LINTER_TESTS ${_ARG_ADD_LINTER_TESTS})
+  ament_execute_extensions("rosidl_generate_action_interfaces")
+
+  add_dependencies(${target} ${_sub_target})
+endfunction()

--- a/rosidl_cmake/cmake/rosidl_generate_action_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_generate_action_interfaces.cmake
@@ -68,6 +68,10 @@ function(rosidl_generate_action_interfaces target)
     ${_idl_files}
   )
 
+  # downstream packages need to depend on action_msgs if they have actions
+  list_append_unique(_ARG_DEPENDENCY_PACKAGE_NAMES "action_msgs")
+  ament_export_dependencies(action_msgs)
+
   # A target name that generators may want to use to prefix their own target names
   set(rosidl_generate_action_interfaces_TARGET ${target})
   # Give extensions a list of .action files to generate interfaces from

--- a/rosidl_cmake/cmake/rosidl_generate_action_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_generate_action_interfaces.cmake
@@ -68,9 +68,12 @@ function(rosidl_generate_action_interfaces target)
     ${_idl_files}
   )
 
-  # downstream packages need to depend on action_msgs if they have actions
+  # downstream packages need to depend on action_msgs for cancel and status messages
   list_append_unique(_ARG_DEPENDENCY_PACKAGE_NAMES "action_msgs")
+  # downstream packages need to depend on builtin_interfaces for builtin_interfaces/Time
+  list_append_unique(_ARG_DEPENDENCY_PACKAGE_NAMES "builtin_interfaces")
   ament_export_dependencies(action_msgs)
+  ament_export_dependencies(builtin_interfaces)
 
   # A target name that generators may want to use to prefix their own target names
   set(rosidl_generate_action_interfaces_TARGET ${target})

--- a/rosidl_cmake/cmake/rosidl_generate_action_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_generate_action_interfaces.cmake
@@ -45,49 +45,49 @@
 #
 # @public
 #
-function(rosidl_generate_action_interfaces target)
-  cmake_parse_arguments(_ARG
+macro(rosidl_generate_action_interfaces target)
+  cmake_parse_arguments(_ARG_RGAI
     "ADD_LINTER_TESTS;SKIP_INSTALL"
     "LIBRARY_NAME" "TARGET_DEPENDENCIES"
     ${ARGN})
-  if(NOT _ARG_UNPARSED_ARGUMENTS)
+  if(NOT _ARG_RGAI_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "rosidl_generate_action_interfaces() called without any idl "
       "files")
   endif()
 
-  set(_idl_files ${_ARG_UNPARSED_ARGUMENTS})
+  set(_rgai_idl_files ${_ARG_RGAI_UNPARSED_ARGUMENTS})
 
   # Create a custom target
-  set(_sub_target "${target}+generate_action_interfaces")
+  set(_rgai_sub_target "${target}+generate_action_interfaces")
   add_custom_target(
-    ${_sub_target} ALL
+    ${_rgai_sub_target} ALL
     DEPENDS
-    ${_idl_files}
-    ${_ARG_TARGET_DEPENDENCIES}
+    ${_rgai_idl_files}
+    ${_ARG_RGAI_TARGET_DEPENDENCIES}
     SOURCES
-    ${_idl_files}
+    ${_rgai_idl_files}
   )
 
   # downstream packages need to depend on action_msgs for cancel and status messages
-  list_append_unique(_ARG_DEPENDENCY_PACKAGE_NAMES "action_msgs")
+  list_append_unique(_ARG_RGAI_DEPENDENCY_PACKAGE_NAMES "action_msgs")
   # downstream packages need to depend on builtin_interfaces for builtin_interfaces/Time
-  list_append_unique(_ARG_DEPENDENCY_PACKAGE_NAMES "builtin_interfaces")
+  list_append_unique(_ARG_RGAI_DEPENDENCY_PACKAGE_NAMES "builtin_interfaces")
   ament_export_dependencies(action_msgs)
   ament_export_dependencies(builtin_interfaces)
 
   # A target name that generators may want to use to prefix their own target names
   set(rosidl_generate_action_interfaces_TARGET ${target})
   # Give extensions a list of .action files to generate interfaces from
-  set(rosidl_generate_action_interfaces_IDL_FILES ${_idl_files})
+  set(rosidl_generate_action_interfaces_IDL_FILES ${_rgai_idl_files})
   # TODO(sloretz) Where is LIBRARY_NAME used?
-  set(rosidl_generate_action_interfaces_LIBRARY_NAME ${_ARG_LIBRARY_NAME})
+  set(rosidl_generate_action_interfaces_LIBRARY_NAME ${_ARG_RGAI_LIBRARY_NAME})
   # If true the extension should not install anything it generates
-  set(rosidl_generate_action_interfaces_SKIP_INSTALL ${_ARG_SKIP_INSTALL})
+  set(rosidl_generate_action_interfaces_SKIP_INSTALL ${_ARG_RGAI_SKIP_INSTALL})
   # If true the extension should create tests for language specific linters
-  set(rosidl_generate_action_interfaces_ADD_LINTER_TESTS ${_ARG_ADD_LINTER_TESTS})
+  set(rosidl_generate_action_interfaces_ADD_LINTER_TESTS ${_ARG_RGAI_ADD_LINTER_TESTS})
   # Packages that generated code should depend on
-  set(rosidl_generate_action_interfaces_DEPENDENCY_PACKAGE_NAMES ${_ARG_DEPENDENCY_PACKAGE_NAMES})
+  set(rosidl_generate_action_interfaces_DEPENDENCY_PACKAGE_NAMES ${_ARG_RGAI_DEPENDENCY_PACKAGE_NAMES})
   ament_execute_extensions("rosidl_generate_action_interfaces")
 
-  add_dependencies(${target} ${_sub_target})
-endfunction()
+  add_dependencies(${target} ${_rgai_sub_target})
+endmacro()

--- a/rosidl_cmake/cmake/rosidl_generate_action_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_generate_action_interfaces.cmake
@@ -28,6 +28,9 @@
 #   be either an absolute path or path relative to the
 #   CMAKE_INSTALL_PREFIX.
 # :type ARGN: list of strings
+# :param DEPENDENCY_PACKAGE_NAMES: Packages with interface files generation
+# should depend on
+# :type DEPENDENCY_PACKAGE_NAMES: list of strings
 # :param TARGET_DEPENDENCIES: cmake targets or files the generated target
 #   should depend on
 # :type TARGET_DEPENDENCIES: list of strings
@@ -75,6 +78,8 @@ function(rosidl_generate_action_interfaces target)
   set(rosidl_generate_action_interfaces_SKIP_INSTALL ${_ARG_SKIP_INSTALL})
   # If true the extension should create tests for language specific linters
   set(rosidl_generate_action_interfaces_ADD_LINTER_TESTS ${_ARG_ADD_LINTER_TESTS})
+  # Packages that generated code should depend on
+  set(rosidl_generate_action_interfaces_DEPENDENCY_PACKAGE_NAMES ${_ARG_DEPENDENCY_PACKAGE_NAMES})
   ament_execute_extensions("rosidl_generate_action_interfaces")
 
   add_dependencies(${target} ${_sub_target})

--- a/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
@@ -207,6 +207,28 @@ macro(rosidl_generate_interfaces target)
   set(rosidl_generate_interfaces_ADD_LINTER_TESTS ${_ARG_ADD_LINTER_TESTS})
   ament_execute_extensions("rosidl_generate_interfaces")
 
+  if(_action_files)
+    # Invoke generation for `.action` files
+    set(_skip_install "")
+    if(_ARG_SKIP_INSTALL)
+      set(_skip_install "SKIP_INSTALL")
+    endif()
+    set(_add_linter_tests "")
+    if(_ARG_ADD_LINTER_TESTS)
+      set(_add_linter_tests "ADD_LINTER_TESTS")
+    endif()
+    set(_library_name "")
+    if(_ARG_LIBRARY_NAME)
+      set(_library_name "LIBRARY ${_ARG_LIBRARY_NAME}")
+    endif()
+    rosidl_generate_action_interfaces(${target}
+      ${_skip_install}
+      ${_add_linter_tests}
+      ${_library_name}
+      ${_action_files}
+    )
+  endif()
+
   if(NOT _ARG_SKIP_INSTALL)
     # install interface files to subfolders based on their extension
     foreach(_idl_file ${_idl_files})

--- a/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
@@ -221,6 +221,10 @@ macro(rosidl_generate_interfaces target)
     if(_ARG_LIBRARY_NAME)
       set(_library_name "LIBRARY ${_ARG_LIBRARY_NAME}")
     endif()
+    set(_pkg_depends "")
+    if(_recursive_dependencies)
+      set(_pkg_depends "DEPENDENCY_PACKAGE_NAMES ${_recursive_dependencies}")
+    endif()
     rosidl_generate_action_interfaces(${target}
       ${_skip_install}
       ${_add_linter_tests}

--- a/rosidl_cmake/rosidl_cmake-extras.cmake
+++ b/rosidl_cmake/rosidl_cmake-extras.cmake
@@ -28,6 +28,7 @@ macro(_rosidl_cmake_register_package_hook)
 endmacro()
 
 include("${rosidl_cmake_DIR}/rosidl_convert_actions_to_msg_and_srv.cmake")
+include("${rosidl_cmake_DIR}/rosidl_generate_action_interfaces.cmake")
 include("${rosidl_cmake_DIR}/rosidl_generate_interfaces.cmake")
 include("${rosidl_cmake_DIR}/rosidl_identify_action_idls.cmake")
 include("${rosidl_cmake_DIR}/rosidl_target_interfaces.cmake")

--- a/rosidl_generator_c/cmake/register_c.cmake
+++ b/rosidl_generator_c/cmake/register_c.cmake
@@ -19,6 +19,11 @@ macro(rosidl_generator_c_extras BIN GENERATOR_FILES TEMPLATE_DIR)
     "rosidl_generator_c"
     "rosidl_generator_c_generate_interfaces.cmake")
 
+  ament_register_extension(
+    "rosidl_generate_action_interfaces"
+    "rosidl_generator_c"
+    "rosidl_generator_c_generate_action_interfaces.cmake")
+
   normalize_path(BIN "${BIN}")
   set(rosidl_generator_c_BIN "${BIN}")
 

--- a/rosidl_generator_c/cmake/rosidl_generator_c_generate_action_interfaces.cmake
+++ b/rosidl_generator_c/cmake/rosidl_generator_c_generate_action_interfaces.cmake
@@ -1,0 +1,169 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(_output_path
+  "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_c/${PROJECT_NAME}")
+set(_generated_files "")
+
+foreach(_idl_file ${rosidl_generate_action_interfaces_IDL_FILES})
+  get_filename_component(_extension "${_idl_file}" EXT)
+  get_filename_component(_parent_folder "${_idl_file}" DIRECTORY)
+  get_filename_component(_parent_folder "${_parent_folder}" NAME)
+  if(_extension STREQUAL ".action")
+    set(_allowed_parent_folders "action")
+    if(NOT _parent_folder IN_LIST _allowed_parent_folders)
+      message(FATAL_ERROR "Interface file with unknown parent folder: ${_idl_file}")
+    endif()
+  else()
+    message(FATAL_ERROR "Interface file with unknown extension: ${_idl_file}")
+  endif()
+  get_filename_component(_msg_name "${_idl_file}" NAME_WE)
+  string_camel_case_to_lower_case_underscore("${_msg_name}" _header_name)
+  list(APPEND _generated_files
+    "${_output_path}/${_parent_folder}/${_header_name}.h"
+  )
+endforeach()
+
+set(_dependency_files "")
+set(_dependencies "")
+foreach(_pkg_name ${rosidl_generate_action_interfaces_DEPENDENCY_PACKAGE_NAMES})
+  foreach(_idl_file ${${_pkg_name}_INTERFACE_FILES})
+  get_filename_component(_extension "${_idl_file}" EXT)
+  if(_extension STREQUAL ".msg")
+    set(_abs_idl_file "${${_pkg_name}_DIR}/../${_idl_file}")
+    normalize_path(_abs_idl_file "${_abs_idl_file}")
+    list(APPEND _dependency_files "${_abs_idl_file}")
+    list(APPEND _dependencies "${_pkg_name}:${_abs_idl_file}")
+  endif()
+  endforeach()
+endforeach()
+
+set(target_dependencies
+  "${rosidl_generator_c_BIN}"
+  ${rosidl_generator_c_GENERATOR_FILES}
+  "${rosidl_generator_c_TEMPLATE_DIR}/action.h.em"
+  "${rosidl_generator_c_TEMPLATE_DIR}/action__type_support.h.em"
+  ${rosidl_generate_action_interfaces_IDL_FILES}
+  ${_dependency_files})
+foreach(dep ${target_dependencies})
+  if(NOT EXISTS "${dep}")
+    get_property(is_generated SOURCE "${dep}" PROPERTY GENERATED)
+    if(NOT ${_is_generated})
+      message(FATAL_ERROR "Target dependency '${dep}' does not exist")
+    endif()
+  endif()
+endforeach()
+
+set(generator_arguments_file "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_c__generate_action_interfaces__arguments.json")
+rosidl_write_generator_arguments(
+  "${generator_arguments_file}"
+  PACKAGE_NAME "${PROJECT_NAME}"
+  ROS_INTERFACE_FILES "${rosidl_generate_action_interfaces_IDL_FILES}"
+  ROS_INTERFACE_DEPENDENCIES "${_dependencies}"
+  OUTPUT_DIR "${_output_path}"
+  TEMPLATE_DIR "${rosidl_generator_c_TEMPLATE_DIR}"
+  TARGET_DEPENDENCIES ${target_dependencies}
+)
+
+add_custom_command(
+  OUTPUT ${_generated_files}
+  COMMAND ${PYTHON_EXECUTABLE} ${rosidl_generator_c_BIN}
+  --generator-arguments-file "${generator_arguments_file}"
+  DEPENDS ${target_dependencies}
+  COMMENT "Generating C++ type support dispatch for ROS interfaces"
+  VERBATIM
+)
+
+# generate header to switch between export and import for a specific package
+set(_visibility_control_file
+  "${_output_path}/action/rosidl_generator_c__visibility_control.h")
+string(TOUPPER "${PROJECT_NAME}" PROJECT_NAME_UPPER)
+configure_file(
+  "${rosidl_generator_c_TEMPLATE_DIR}/rosidl_generator_c__action_visibility_control.h.in"
+  "${_visibility_control_file}"
+  @ONLY
+)
+
+set(_target_suffix "__generate_action_interfaces__rosidl_generator_c")
+
+add_library(${rosidl_generate_action_interfaces_TARGET}${_target_suffix} ${rosidl_generator_c_LIBRARY_TYPE} ${_generated_files})
+set_target_properties(${rosidl_generate_action_interfaces_TARGET}${_target_suffix} PROPERTIES LINKER_LANGUAGE CXX)
+if(rosidl_generate_action_interfaces_LIBRARY_NAME)
+  set_target_properties(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+    PROPERTIES OUTPUT_NAME "${rosidl_generate_action_interfaces_LIBRARY_NAME}${_target_suffix}")
+endif()
+if(WIN32)
+  target_compile_definitions(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+    PRIVATE "ROSIDL_GENERATOR_c_BUILDING_DLL")
+endif()
+set_target_properties(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+  PROPERTIES CXX_STANDARD 14)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set_target_properties(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+    PROPERTIES COMPILE_OPTIONS -Wall -Wextra -Wpedantic)
+endif()
+target_include_directories(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+  PUBLIC
+  ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_c
+)
+
+ament_target_dependencies(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+  "rosidl_generator_c"
+  "rosidl_typesupport_interface")
+foreach(_pkg_name ${rosidl_generate_action_interfaces_DEPENDENCY_PACKAGE_NAMES})
+  ament_target_dependencies(
+    ${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+    ${_pkg_name})
+endforeach()
+
+add_dependencies(
+  ${rosidl_generate_action_interfaces_TARGET}
+  ${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+)
+
+if(NOT rosidl_generate_action_interfaces_SKIP_INSTALL)
+  install(
+    TARGETS ${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+  )
+  ament_export_libraries(${rosidl_generate_action_interfaces_TARGET}${_target_suffix})
+endif()
+
+if(BUILD_TESTING AND rosidl_generate_action_interfaces_ADD_LINTER_TESTS)
+  if(NOT _generated_files STREQUAL "")
+    find_package(ament_cmake_cppcheck REQUIRED)
+    ament_cppcheck(
+      TESTNAME "cppcheck_rosidl_generator_c_generate_action_interfaces"
+      "${_output_path}")
+
+    find_package(ament_cmake_cpplint REQUIRED)
+    get_filename_component(_cpplint_root "${_output_path}" DIRECTORY)
+    ament_cpplint(
+      TESTNAME "cpplint_rosidl_generator_c_generate_action_interfaces"
+      # the generated code might contain longer lines for templated types
+      MAX_LINE_LENGTH 999
+      ROOT "${_cpplint_root}"
+      "${_output_path}")
+
+    find_package(ament_cmake_uncrustify REQUIRED)
+    ament_uncrustify(
+      TESTNAME "uncrustify_rosidl_generator_c_generate_action_interfaces"
+      # the generated code might contain longer lines for templated types
+      MAX_LINE_LENGTH 999
+      "${_output_path}")
+  endif()
+endif()

--- a/rosidl_generator_c/cmake/rosidl_generator_c_generate_action_interfaces.cmake
+++ b/rosidl_generator_c/cmake/rosidl_generator_c_generate_action_interfaces.cmake
@@ -95,6 +95,7 @@ configure_file(
   "${_visibility_control_file}"
   @ONLY
 )
+list(APPEND _generated_files ${_visibility_control_file})
 
 set(_target_suffix "__c__actions")
 

--- a/rosidl_generator_c/cmake/rosidl_generator_c_generate_action_interfaces.cmake
+++ b/rosidl_generator_c/cmake/rosidl_generator_c_generate_action_interfaces.cmake
@@ -100,18 +100,18 @@ list(APPEND _generated_files ${_visibility_control_file})
 set(_target_suffix "__c__actions")
 
 if(TARGET ${rosidl_generate_action_interfaces_TARGET}${_target_suffix})
-  message(WARNING "Custom target ${rosidl_generate_interfaces_TARGET}${_target_suffix} already exists")
+  message(WARNING "Custom target ${rosidl_generate_action_interfaces_TARGET}${_target_suffix} already exists")
 else()
   add_custom_target(
-    ${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    ${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
     DEPENDS
     ${_generated_files}
   )
 endif()
 
 add_dependencies(
-  ${rosidl_generate_interfaces_TARGET}
-  ${rosidl_generate_interfaces_TARGET}${_target_suffix}
+  ${rosidl_generate_action_interfaces_TARGET}
+  ${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
 )
 
 if(NOT rosidl_generate_action_interfaces_SKIP_INSTALL)

--- a/rosidl_generator_c/resource/action.h.em
+++ b/rosidl_generator_c/resource/action.h.em
@@ -1,0 +1,43 @@
+// generated from rosidl_generator_c/resource/action.h.em
+// generated code does not contain a copyright notice
+
+@#######################################################################
+@# EmPy template for generating <action>.hp files
+@#
+@# Context:
+@#  - spec (rosidl_parser.ActionSpecification)
+@#    Parsed specification of the .action file
+@#  - subfolder (string)
+@#    The subfolder / subnamespace of the message, usually 'action'
+@#  - get_header_filename_from_msg_name (function)
+@#######################################################################
+@
+@{
+header_guard_parts = [
+    spec.pkg_name, subfolder,
+    get_header_filename_from_msg_name(spec.action_name) + '_h']
+header_guard_variable = '__'.join([x.upper() for x in header_guard_parts]) + '_'
+}@
+
+#ifndef @(header_guard_variable)
+#define @(header_guard_variable)
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <action_msgs/msg/goal_info.h>
+#include <action_msgs/msg/goal_status_array.h>
+#include <action_msgs/srv/cancel_goal.h>
+
+#include <@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.action_name))__feedback.h>
+#include <@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.action_name))__goal.h>
+#include <@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.action_name))__result.h>
+#include "@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.action_name))__type_support.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif @(header_guard_variable)

--- a/rosidl_generator_c/resource/action__type_support.h.em
+++ b/rosidl_generator_c/resource/action__type_support.h.em
@@ -30,7 +30,7 @@ extern "C"
 #include "rosidl_generator_c/action_type_support_struct.h"
 #include "rosidl_typesupport_interface/macros.h"
 
-#include "test_msgs/action/rosidl_generator_c__visibility_control.h"
+#include "@(spec.pkg_name)/@(subfolder)/rosidl_generator_c__visibility_control.h"
 
 /* *INDENT-OFF* */
 // Forward declare the get type support functions for this type.

--- a/rosidl_generator_c/resource/action__type_support.h.em
+++ b/rosidl_generator_c/resource/action__type_support.h.em
@@ -1,8 +1,8 @@
-// generated from rosidl_generator_c/resource/action.h.em
+// generated from rosidl_generator_c/resource/action__type_support.h.em
 // generated code does not contain a copyright notice
 
 @#######################################################################
-@# EmPy template for generating <action>.hp files
+@# EmPy template for generating <action>__type_support.h files
 @#
 @# Context:
 @#  - spec (rosidl_parser.ActionSpecification)
@@ -15,7 +15,7 @@
 @{
 header_guard_parts = [
     spec.pkg_name, subfolder,
-    get_header_filename_from_msg_name(spec.action_name) + '_h']
+    get_header_filename_from_msg_name(spec.action_name) + '__type_support_h']
 header_guard_variable = '__'.join([x.upper() for x in header_guard_parts]) + '_'
 }@
 
@@ -27,14 +27,18 @@ extern "C"
 {
 #endif
 
-#include <action_msgs/msg/goal_info.h>
-#include <action_msgs/msg/goal_status_array.h>
-#include <action_msgs/srv/cancel_goal.h>
+#include "rosidl_generator_c/action_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
 
-#include <@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.action_name))__feedback.h>
-#include <@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.action_name))__goal.h>
-#include <@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.action_name))__result.h>
-#include "@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.action_name))__type_support.h"
+#include "test_msgs/action/rosidl_generator_c__visibility_control.h"
+
+/* *INDENT-OFF* */
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_@(spec.pkg_name)_ACTION
+const rosidl_action_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__ACTION_SYMBOL_NAME(
+  rosidl_typesupport_c, @(spec.pkg_name), @(subfolder), @(spec.action_name))();
+/* *INDENT-ON* */
 
 #ifdef __cplusplus
 }

--- a/rosidl_generator_c/resource/rosidl_generator_c__action_visibility_control.h.in
+++ b/rosidl_generator_c/resource/rosidl_generator_c__action_visibility_control.h.in
@@ -1,0 +1,43 @@
+// generated from
+// rosidl_generator_c/resource/rosidl_generator_c__action_visibility_control.h.in
+// generated code does not contain a copyright notice
+
+#ifndef @PROJECT_NAME_UPPER@__ACTION__ROSIDL_GENERATOR_C__VISIBILITY_CONTROL_H_
+#define @PROJECT_NAME_UPPER@__ACTION__ROSIDL_GENERATOR_C__VISIBILITY_CONTROL_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define ROSIDL_GENERATOR_C_EXPORT_@PROJECT_NAME@_ACTION __attribute__ ((dllexport))
+    #define ROSIDL_GENERATOR_C_IMPORT_@PROJECT_NAME@_ACTION __attribute__ ((dllimport))
+  #else
+    #define ROSIDL_GENERATOR_C_EXPORT_@PROJECT_NAME@_ACTION __declspec(dllexport)
+    #define ROSIDL_GENERATOR_C_IMPORT_@PROJECT_NAME@_ACTION __declspec(dllimport)
+  #endif
+  #ifdef ROSIDL_GENERATOR_C_BUILDING_DLL_@PROJECT_NAME@_ACTION
+    #define ROSIDL_GENERATOR_C_PUBLIC_@PROJECT_NAME@_ACTION ROSIDL_GENERATOR_C_EXPORT_@PROJECT_NAME@_ACTION
+  #else
+    #define ROSIDL_GENERATOR_C_PUBLIC_@PROJECT_NAME@_ACTION ROSIDL_GENERATOR_C_IMPORT_@PROJECT_NAME@_ACTION
+  #endif
+#else
+  #define ROSIDL_GENERATOR_C_EXPORT_@PROJECT_NAME@_ACTION __attribute__ ((visibility("default")))
+  #define ROSIDL_GENERATOR_C_IMPORT_@PROJECT_NAME@_ACTION
+  #if __GNUC__ >= 4
+    #define ROSIDL_GENERATOR_C_PUBLIC_@PROJECT_NAME@_ACTION __attribute__ ((visibility("default")))
+  #else
+    #define ROSIDL_GENERATOR_C_PUBLIC_@PROJECT_NAME@_ACTION
+  #endif
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // @PROJECT_NAME_UPPER@__ACTION__ROSIDL_GENERATOR_C__VISIBILITY_CONTROL_H_

--- a/rosidl_generator_c/rosidl_generator_c/__init__.py
+++ b/rosidl_generator_c/rosidl_generator_c/__init__.py
@@ -18,6 +18,7 @@ from rosidl_cmake import convert_camel_case_to_lower_case_underscore
 from rosidl_cmake import expand_template
 from rosidl_cmake import get_newest_modification_time
 from rosidl_cmake import read_generator_arguments
+from rosidl_parser import parse_action_file
 from rosidl_parser import parse_message_file
 from rosidl_parser import parse_service_file
 
@@ -35,6 +36,9 @@ def generate_c(generator_arguments_file):
     }
     mapping_srvs = {
         os.path.join(template_dir, 'srv.h.em'): '%s.h',
+    }
+    mapping_action = {
+        os.path.join(template_dir, 'action.h.em'): '%s.h',
     }
     for template_file in list(mapping_msgs.keys()) + list(mapping_srvs.keys()):
         assert os.path.exists(template_file), 'Could not find template: ' + template_file
@@ -72,6 +76,17 @@ def generate_c(generator_arguments_file):
                 generated_file = os.path.join(
                     args['output_dir'], subfolder, generated_filename %
                     convert_camel_case_to_lower_case_underscore(spec.srv_name))
+                expand_template(
+                    template_file, data, generated_file,
+                    minimum_timestamp=latest_target_timestamp)
+        elif extension == '.action':
+            spec = parse_action_file(args['package_name'], ros_interface_file)
+            for template_file, generated_filename in mapping_action.items():
+                data = {'spec': spec, 'subfolder': subfolder}
+                data.update(functions)
+                generated_file = os.path.join(
+                    args['output_dir'], subfolder, generated_filename %
+                    convert_camel_case_to_lower_case_underscore(spec.action_name))
                 expand_template(
                     template_file, data, generated_file,
                     minimum_timestamp=latest_target_timestamp)

--- a/rosidl_generator_c/rosidl_generator_c/__init__.py
+++ b/rosidl_generator_c/rosidl_generator_c/__init__.py
@@ -39,6 +39,7 @@ def generate_c(generator_arguments_file):
     }
     mapping_action = {
         os.path.join(template_dir, 'action.h.em'): '%s.h',
+        os.path.join(template_dir, 'action__type_support.h.em'): '%s__type_support.h',
     }
     for template_file in list(mapping_msgs.keys()) + list(mapping_srvs.keys()):
         assert os.path.exists(template_file), 'Could not find template: ' + template_file

--- a/rosidl_generator_cpp/cmake/register_cpp.cmake
+++ b/rosidl_generator_cpp/cmake/register_cpp.cmake
@@ -19,6 +19,11 @@ macro(rosidl_generator_cpp_extras BIN GENERATOR_FILES TEMPLATE_DIR)
     "rosidl_generator_cpp"
     "rosidl_generator_cpp_generate_interfaces.cmake")
 
+ament_register_extension(
+  "rosidl_generate_action_interfaces"
+  "rosidl_generator_cpp"
+  "rosidl_generator_cpp_generate_action_interfaces.cmake")
+
   normalize_path(BIN "${BIN}")
   set(rosidl_generator_cpp_BIN "${BIN}")
 

--- a/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_action_interfaces.cmake
+++ b/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_action_interfaces.cmake
@@ -1,0 +1,165 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(_output_path
+  "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp/${PROJECT_NAME}")
+set(_generated_files "")
+
+foreach(_idl_file ${rosidl_generate_action_interfaces_IDL_FILES})
+  get_filename_component(_extension "${_idl_file}" EXT)
+  get_filename_component(_parent_folder "${_idl_file}" DIRECTORY)
+  get_filename_component(_parent_folder "${_parent_folder}" NAME)
+  if(_extension STREQUAL ".action")
+    set(_allowed_parent_folders "action")
+    if(NOT _parent_folder IN_LIST _allowed_parent_folders)
+      message(FATAL_ERROR "Interface file with unknown parent folder: ${_idl_file}")
+    endif()
+  else()
+    message(FATAL_ERROR "Interface file with unknown extension: ${_idl_file}")
+  endif()
+  get_filename_component(_msg_name "${_idl_file}" NAME_WE)
+  string_camel_case_to_lower_case_underscore("${_msg_name}" _header_name)
+  list(APPEND _generated_files
+    "${_output_path}/${_parent_folder}/${_header_name}__struct.hpp"
+    "${_output_path}/${_parent_folder}/${_header_name}.hpp"
+  )
+endforeach()
+
+set(_dependency_files "")
+set(_dependencies "")
+foreach(_pkg_name ${rosidl_generate_action_interfaces_DEPENDENCY_PACKAGE_NAMES})
+  foreach(_idl_file ${${_pkg_name}_INTERFACE_FILES})
+  get_filename_component(_extension "${_idl_file}" EXT)
+  if(_extension STREQUAL ".msg")
+    set(_abs_idl_file "${${_pkg_name}_DIR}/../${_idl_file}")
+    normalize_path(_abs_idl_file "${_abs_idl_file}")
+    list(APPEND _dependency_files "${_abs_idl_file}")
+    list(APPEND _dependencies "${_pkg_name}:${_abs_idl_file}")
+  endif()
+  endforeach()
+endforeach()
+
+set(target_dependencies
+  "${rosidl_generator_cpp_BIN}"
+  ${rosidl_generator_cpp_GENERATOR_FILES}
+  "${rosidl_generator_cpp_TEMPLATE_DIR}/action__struct.hpp.em"
+  "${rosidl_generator_cpp_TEMPLATE_DIR}/action.hpp.em"
+  ${rosidl_generate_action_interfaces_IDL_FILES}
+  ${_dependency_files})
+foreach(dep ${target_dependencies})
+  if(NOT EXISTS "${dep}")
+    get_property(is_generated SOURCE "${dep}" PROPERTY GENERATED)
+    if(NOT ${_is_generated})
+      message(FATAL_ERROR "Target dependency '${dep}' does not exist")
+    endif()
+  endif()
+endforeach()
+
+set(generator_arguments_file "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp__generate_action_interfaces__arguments.json")
+rosidl_write_generator_arguments(
+  "${generator_arguments_file}"
+  PACKAGE_NAME "${PROJECT_NAME}"
+  ROS_INTERFACE_FILES "${rosidl_generate_action_interfaces_IDL_FILES}"
+  ROS_INTERFACE_DEPENDENCIES "${_dependencies}"
+  OUTPUT_DIR "${_output_path}"
+  TEMPLATE_DIR "${rosidl_generator_cpp_TEMPLATE_DIR}"
+  TARGET_DEPENDENCIES ${target_dependencies}
+)
+
+add_custom_command(
+  OUTPUT ${_generated_files}
+  COMMAND ${PYTHON_EXECUTABLE} ${rosidl_generator_cpp_BIN}
+  --generator-arguments-file "${generator_arguments_file}"
+  DEPENDS ${target_dependencies}
+  COMMENT "Generating C++ type support dispatch for ROS interfaces"
+  VERBATIM
+)
+
+set(_target_suffix "__generate_action_interfaces__rosidl_generator_cpp")
+
+add_library(${rosidl_generate_action_interfaces_TARGET}${_target_suffix} ${rosidl_generator_cpp_LIBRARY_TYPE} ${_generated_files})
+set_target_properties(${rosidl_generate_action_interfaces_TARGET}${_target_suffix} PROPERTIES LINKER_LANGUAGE CXX)
+if(rosidl_generate_action_interfaces_LIBRARY_NAME)
+  set_target_properties(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+    PROPERTIES OUTPUT_NAME "${rosidl_generate_action_interfaces_LIBRARY_NAME}${_target_suffix}")
+endif()
+if(WIN32)
+  target_compile_definitions(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+    PRIVATE "ROSIDL_GENERATOR_CPP_BUILDING_DLL")
+endif()
+set_target_properties(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+  PROPERTIES CXX_STANDARD 14)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set_target_properties(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+    PROPERTIES COMPILE_OPTIONS -Wall -Wextra -Wpedantic)
+endif()
+target_include_directories(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+  PUBLIC
+  ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp
+)
+
+ament_target_dependencies(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+  "rosidl_generator_c"
+  "rosidl_generator_cpp"
+  "rosidl_typesupport_interface")
+foreach(_pkg_name ${rosidl_generate_action_interfaces_DEPENDENCY_PACKAGE_NAMES})
+  ament_target_dependencies(
+    ${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+    ${_pkg_name})
+endforeach()
+
+add_dependencies(
+  ${rosidl_generate_action_interfaces_TARGET}
+  ${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+)
+add_dependencies(
+  ${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+  ${rosidl_generate_action_interfaces_TARGET}__cpp
+)
+
+if(NOT rosidl_generate_action_interfaces_SKIP_INSTALL)
+  install(
+    TARGETS ${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+  )
+  ament_export_libraries(${rosidl_generate_action_interfaces_TARGET}${_target_suffix})
+endif()
+
+if(BUILD_TESTING AND rosidl_generate_action_interfaces_ADD_LINTER_TESTS)
+  if(NOT _generated_files STREQUAL "")
+    find_package(ament_cmake_cppcheck REQUIRED)
+    ament_cppcheck(
+      TESTNAME "cppcheck_rosidl_generator_cpp_generate_action_interfaces"
+      "${_output_path}")
+
+    find_package(ament_cmake_cpplint REQUIRED)
+    get_filename_component(_cpplint_root "${_output_path}" DIRECTORY)
+    ament_cpplint(
+      TESTNAME "cpplint_rosidl_generator_cpp_generate_action_interfaces"
+      # the generated code might contain longer lines for templated types
+      MAX_LINE_LENGTH 999
+      ROOT "${_cpplint_root}"
+      "${_output_path}")
+
+    find_package(ament_cmake_uncrustify REQUIRED)
+    ament_uncrustify(
+      TESTNAME "uncrustify_rosidl_generator_cpp_generate_action_interfaces"
+      # the generated code might contain longer lines for templated types
+      MAX_LINE_LENGTH 999
+      "${_output_path}")
+  endif()
+endif()

--- a/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_action_interfaces.cmake
+++ b/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_action_interfaces.cmake
@@ -89,18 +89,18 @@ add_custom_command(
 set(_target_suffix "__cpp__actions")
 
 if(TARGET ${rosidl_generate_action_interfaces_TARGET}${_target_suffix})
-  message(WARNING "Custom target ${rosidl_generate_interfaces_TARGET}${_target_suffix} already exists")
+  message(WARNING "Custom target ${rosidl_generate_action_interfaces_TARGET}${_target_suffix} already exists")
 else()
   add_custom_target(
-    ${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    ${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
     DEPENDS
     ${_generated_files}
   )
 endif()
 
 add_dependencies(
-  ${rosidl_generate_interfaces_TARGET}
-  ${rosidl_generate_interfaces_TARGET}${_target_suffix}
+  ${rosidl_generate_action_interfaces_TARGET}
+  ${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
 )
 
 if(NOT rosidl_generate_action_interfaces_SKIP_INSTALL)

--- a/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_action_interfaces.cmake
+++ b/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_action_interfaces.cmake
@@ -86,57 +86,31 @@ add_custom_command(
   VERBATIM
 )
 
-set(_target_suffix "__generate_action_interfaces__rosidl_generator_cpp")
+set(_target_suffix "__cpp__actions")
 
-add_library(${rosidl_generate_action_interfaces_TARGET}${_target_suffix} ${rosidl_generator_cpp_LIBRARY_TYPE} ${_generated_files})
-set_target_properties(${rosidl_generate_action_interfaces_TARGET}${_target_suffix} PROPERTIES LINKER_LANGUAGE CXX)
-if(rosidl_generate_action_interfaces_LIBRARY_NAME)
-  set_target_properties(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
-    PROPERTIES OUTPUT_NAME "${rosidl_generate_action_interfaces_LIBRARY_NAME}${_target_suffix}")
+if(TARGET ${rosidl_generate_action_interfaces_TARGET}${_target_suffix})
+  message(WARNING "Custom target ${rosidl_generate_interfaces_TARGET}${_target_suffix} already exists")
+else()
+  add_custom_target(
+    ${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    DEPENDS
+    ${_generated_files}
+  )
 endif()
-if(WIN32)
-  target_compile_definitions(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
-    PRIVATE "ROSIDL_GENERATOR_CPP_BUILDING_DLL")
-endif()
-set_target_properties(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
-  PROPERTIES CXX_STANDARD 14)
-
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  set_target_properties(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
-    PROPERTIES COMPILE_OPTIONS -Wall -Wextra -Wpedantic)
-endif()
-target_include_directories(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
-  PUBLIC
-  ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp
-)
-
-ament_target_dependencies(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
-  "rosidl_generator_c"
-  "rosidl_generator_cpp"
-  "rosidl_typesupport_interface")
-foreach(_pkg_name ${rosidl_generate_action_interfaces_DEPENDENCY_PACKAGE_NAMES})
-  ament_target_dependencies(
-    ${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
-    ${_pkg_name})
-endforeach()
 
 add_dependencies(
-  ${rosidl_generate_action_interfaces_TARGET}
-  ${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
-)
-add_dependencies(
-  ${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
-  ${rosidl_generate_action_interfaces_TARGET}__cpp
+  ${rosidl_generate_interfaces_TARGET}
+  ${rosidl_generate_interfaces_TARGET}${_target_suffix}
 )
 
 if(NOT rosidl_generate_action_interfaces_SKIP_INSTALL)
-  install(
-    TARGETS ${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION bin
-  )
-  ament_export_libraries(${rosidl_generate_action_interfaces_TARGET}${_target_suffix})
+  if(NOT _generated_files STREQUAL "")
+    install(
+      FILES ${_generated_files}
+      DESTINATION "include/${PROJECT_NAME}/action"
+    )
+  endif()
+  ament_export_include_directories(include)
 endif()
 
 if(BUILD_TESTING AND rosidl_generate_action_interfaces_ADD_LINTER_TESTS)

--- a/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_interfaces.cmake
+++ b/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_interfaces.cmake
@@ -61,8 +61,6 @@ set(target_dependencies
   "${rosidl_generator_cpp_TEMPLATE_DIR}/srv.hpp.em"
   "${rosidl_generator_cpp_TEMPLATE_DIR}/srv__struct.hpp.em"
   "${rosidl_generator_cpp_TEMPLATE_DIR}/srv__traits.hpp.em"
-  "${rosidl_generator_cpp_TEMPLATE_DIR}/action.hpp.em"
-  "${rosidl_generator_cpp_TEMPLATE_DIR}/action__struct.hpp.em"
   ${rosidl_generate_interfaces_IDL_FILES}
   ${_dependency_files})
 foreach(dep ${target_dependencies})

--- a/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_interfaces.cmake
+++ b/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_interfaces.cmake
@@ -61,6 +61,8 @@ set(target_dependencies
   "${rosidl_generator_cpp_TEMPLATE_DIR}/srv.hpp.em"
   "${rosidl_generator_cpp_TEMPLATE_DIR}/srv__struct.hpp.em"
   "${rosidl_generator_cpp_TEMPLATE_DIR}/srv__traits.hpp.em"
+  "${rosidl_generator_cpp_TEMPLATE_DIR}/action.hpp.em"
+  "${rosidl_generator_cpp_TEMPLATE_DIR}/action__struct.hpp.em"
   ${rosidl_generate_interfaces_IDL_FILES}
   ${_dependency_files})
 foreach(dep ${target_dependencies})

--- a/rosidl_generator_cpp/resource/action.hpp.em
+++ b/rosidl_generator_cpp/resource/action.hpp.em
@@ -21,6 +21,6 @@ header_guard_variable = '__'.join([x.upper() for x in header_guard_parts]) + '_'
 #ifndef @(header_guard_variable)
 #define @(header_guard_variable)
 
-#include "rosidl_generator_c/action_type_support_struct.h"
+#include <@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.action_name))__struct.hpp>
 
 #endif  // @(header_guard_variable)

--- a/rosidl_generator_cpp/resource/action.hpp.em
+++ b/rosidl_generator_cpp/resource/action.hpp.em
@@ -21,13 +21,6 @@ header_guard_variable = '__'.join([x.upper() for x in header_guard_parts]) + '_'
 #ifndef @(header_guard_variable)
 #define @(header_guard_variable)
 
-#include <action_msgs/msg/goal_info.hpp>
-#include <action_msgs/msg/goal_status_array.hpp>
-#include <action_msgs/srv/cancel_goal.hpp>
-#include <@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.action_name))__goal.hpp>
-#include <@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.action_name))__result.hpp>
-#include <@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.action_name))__feedback.hpp>
-#include <@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.action_name))__struct.hpp>
 #include "rosidl_generator_c/action_type_support_struct.h"
 
 #endif  // @(header_guard_variable)

--- a/rosidl_generator_cpp/resource/action.hpp.em
+++ b/rosidl_generator_cpp/resource/action.hpp.em
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_cpp/resource/action.hpp.em
+// generated code does not contain a copyright notice
+
+@#######################################################################
+@# EmPy template for generating <action>.hpp files
+@#
+@# Context:
+@#  - spec (rosidl_parser.ActionSpecification)
+@#    Parsed specification of the .action file
+@#  - subfolder (string)
+@#    The subfolder / subnamespace of the message, usually 'action'
+@#  - get_header_filename_from_msg_name (function)
+@#######################################################################
+@
+@{
+header_guard_parts = [
+    spec.pkg_name, subfolder,
+    get_header_filename_from_msg_name(spec.action_name) + '_hpp']
+header_guard_variable = '__'.join([x.upper() for x in header_guard_parts]) + '_'
+}@
+#ifndef @(header_guard_variable)
+#define @(header_guard_variable)
+
+#include <action_msgs/msg/goal_info.hpp>
+#include <action_msgs/msg/goal_status_array.hpp>
+#include <action_msgs/srv/cancel_goal.hpp>
+#include <@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.action_name))__goal.hpp>
+#include <@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.action_name))__result.hpp>
+#include <@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.action_name))__feedback.hpp>
+#include <@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.action_name))__struct.hpp>
+#include "rosidl_generator_c/action_type_support_struct.h"
+
+#endif  // @(header_guard_variable)

--- a/rosidl_generator_cpp/resource/action__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/action__struct.hpp.em
@@ -1,0 +1,55 @@
+// generated from rosidl_generator_cpp/resource/action__struct.hpp.em
+// generated code does not contain a copyright notice
+
+@#######################################################################
+@# EmPy template for generating <action>__struct.hpp files
+@#
+@# Context:
+@#  - spec (rosidl_parser.ActionSpecification)
+@#    Parsed specification of the .action file
+@#  - subfolder (string)
+@#    The subfolder / subnamespace of the message, usually 'action'
+@#  - get_header_filename_from_msg_name (function)
+@#######################################################################
+@
+@{
+header_guard_parts = [
+    spec.pkg_name, subfolder,
+    get_header_filename_from_msg_name(spec.action_name) + '__struct_hpp']
+header_guard_variable = '__'.join([x.upper() for x in header_guard_parts]) + '_'
+}@
+#ifndef @(header_guard_variable)
+#define @(header_guard_variable)
+
+#include <action_msgs/msg/cancel_goal.hpp>
+#include <action_msgs/msg/goal_info.hpp>
+#include <action_msgs/msg/goal_status_array.hpp>
+#include <@(spec.pkg_name)/action/@(get_header_filename_from_msg_name(spec.action_name))__feedback.hpp>
+#include <@(spec.pkg_name)/action/@(get_header_filename_from_msg_name(spec.action_name))__goal.hpp>
+#include <@(spec.pkg_name)/action/@(get_header_filename_from_msg_name(spec.action_name))__result.hpp>
+
+namespace @(spec.pkg_name)
+{
+
+namespace @(subfolder)
+{
+
+struct @(spec.action_name)
+{
+  using CancelGoalService = action_msgs::srv::CancelGoal;
+  using GoalStatusMessage = action_msgs::msg::GoalStatusArray;
+  using GoalRequestService = @(spec.pkg_name)::action::@(spec.action_name)_Goal;
+  using GoalResultService = @(spec.pkg_name)::action::@(spec.action_name)_Result;
+
+  using Goal = GoalRequestService::Request;
+  using Result = GoalResultService::Response;
+  using Feedback = @(spec.pkg_name)::action::@(spec.action_name)_Feedback;
+};
+
+typedef struct @(spec.action_name) @(spec.action_name);
+
+}  // namespace @(subfolder)
+
+}  // namespace @(spec.pkg_name)
+
+#endif  // @(header_guard_variable)

--- a/rosidl_generator_cpp/resource/action__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/action__struct.hpp.em
@@ -24,9 +24,9 @@ header_guard_variable = '__'.join([x.upper() for x in header_guard_parts]) + '_'
 #include <action_msgs/srv/cancel_goal.hpp>
 #include <action_msgs/msg/goal_info.hpp>
 #include <action_msgs/msg/goal_status_array.hpp>
-#include <@(spec.pkg_name)/action/@(get_header_filename_from_msg_name(spec.action_name))__feedback.hpp>
-#include <@(spec.pkg_name)/action/@(get_header_filename_from_msg_name(spec.action_name))__goal.hpp>
-#include <@(spec.pkg_name)/action/@(get_header_filename_from_msg_name(spec.action_name))__result.hpp>
+#include <@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.action_name))__feedback.hpp>
+#include <@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.action_name))__goal.hpp>
+#include <@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.action_name))__result.hpp>
 
 namespace @(spec.pkg_name)
 {
@@ -38,12 +38,12 @@ struct @(spec.action_name)
 {
   using CancelGoalService = action_msgs::srv::CancelGoal;
   using GoalStatusMessage = action_msgs::msg::GoalStatusArray;
-  using GoalRequestService = @(spec.pkg_name)::action::@(spec.action_name)_Goal;
-  using GoalResultService = @(spec.pkg_name)::action::@(spec.action_name)_Result;
+  using GoalRequestService = @(spec.pkg_name)::@(subfolder)::@(spec.action_name)_Goal;
+  using GoalResultService = @(spec.pkg_name)::@(subfolder)::@(spec.action_name)_Result;
 
   using Goal = GoalRequestService::Request;
   using Result = GoalResultService::Response;
-  using Feedback = @(spec.pkg_name)::action::@(spec.action_name)_Feedback;
+  using Feedback = @(spec.pkg_name)::@(subfolder)::@(spec.action_name)_Feedback;
 };
 
 typedef struct @(spec.action_name) @(spec.action_name);

--- a/rosidl_generator_cpp/resource/action__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/action__struct.hpp.em
@@ -21,7 +21,7 @@ header_guard_variable = '__'.join([x.upper() for x in header_guard_parts]) + '_'
 #ifndef @(header_guard_variable)
 #define @(header_guard_variable)
 
-#include <action_msgs/msg/cancel_goal.hpp>
+#include <action_msgs/srv/cancel_goal.hpp>
 #include <action_msgs/msg/goal_info.hpp>
 #include <action_msgs/msg/goal_status_array.hpp>
 #include <@(spec.pkg_name)/action/@(get_header_filename_from_msg_name(spec.action_name))__feedback.hpp>

--- a/rosidl_parser/rosidl_parser/__init__.py
+++ b/rosidl_parser/rosidl_parser/__init__.py
@@ -766,6 +766,7 @@ def parse_service_string(pkg_name, srv_name, message_string):
 
     return ServiceSpecification(pkg_name, srv_name, request_message, response_message)
 
+
 class ActionSpecification:
 
     def __init__(self, pkg_name, action_name, services, feedback_message):

--- a/rosidl_parser/rosidl_parser/__init__.py
+++ b/rosidl_parser/rosidl_parser/__init__.py
@@ -709,7 +709,7 @@ def validate_field_types(spec, known_msg_types):
         if base_type not in known_msg_types:
             raise UnknownMessageType(
                 "%s interface '%s' contains an unknown field type: %s" %
-                (spec_type, spec.base_type, field))
+                (spec_type, base_type, field))
 
 
 class ServiceSpecification:
@@ -760,6 +760,13 @@ def parse_service_string(pkg_name, srv_name, message_string):
 
     return ServiceSpecification(pkg_name, srv_name, request_message, response_message)
 
+class ActionSpecification:
+
+    def __init__(self, pkg_name, action_name, services, feedback_message):
+        self.pkg_name = pkg_name
+        self.action_name = action_name
+        self.services = services
+        self.feedback = feedback_message
 
 def parse_action_file(pkg_name, interface_filename):
     basename = os.path.basename(interface_filename)
@@ -833,4 +840,4 @@ def parse_action_string(pkg_name, action_name, action_string):
         pkg_name, action_name + ACTION_FEEDBACK_MESSAGE_SUFFIX, message_string)
     # ---------------------------------------------------------------------------------------------
 
-    return (services, feedback_msg)
+    return ActionSpecification(pkg_name, action_name, services, feedback_msg)

--- a/rosidl_parser/rosidl_parser/__init__.py
+++ b/rosidl_parser/rosidl_parser/__init__.py
@@ -700,6 +700,12 @@ def validate_field_types(spec, known_msg_types):
     elif isinstance(spec, ServiceSpecification):
         spec_type = 'Service'
         fields = spec.request.fields + spec.response.fields
+    elif isinstance(spec, ActionSpecification):
+        spec_type = 'Action'
+        fields = []
+        for service in spec.services:
+            fields += service.request.fields
+            fields += service.response.fields
     else:
         assert False, 'Unknown specification type: %s' % type(spec)
     for field in fields:
@@ -767,6 +773,7 @@ class ActionSpecification:
         self.action_name = action_name
         self.services = services
         self.feedback = feedback_message
+
 
 def parse_action_file(pkg_name, interface_filename):
     basename = os.path.basename(interface_filename)

--- a/rosidl_parser/test/test_parse_action_string.py
+++ b/rosidl_parser/test/test_parse_action_string.py
@@ -43,8 +43,9 @@ def test_valid_action_string():
 
 
 def test_valid_action_string1():
-    (services, feedback_msg) = parse_action_string(
-        'pkg', 'Foo', 'bool foo\n---\nint8 bar\n---\nbool foo')
+    spec = parse_action_string('pkg', 'Foo', 'bool foo\n---\nint8 bar\n---\nbool foo')
+    services = spec.services
+    feedback_msg = spec.feedback
     assert len(services) == 2
     goal_service, result_service = services
     # Goal service checks
@@ -79,8 +80,10 @@ def test_valid_action_string1():
 
 
 def test_valid_action_string2():
-    (services, feedback_msg) = parse_action_string(
+    spec = parse_action_string(
         'pkg', 'Foo', '#comment---\n \nbool foo\n---\n#comment\n \nint8 bar\n---\nbool foo')
+    services = spec.services
+    feedback_msg = spec.feedback
     assert len(services) == 2
     goal_service, result_service = services
     # Goal service checks
@@ -115,10 +118,12 @@ def test_valid_action_string2():
 
 
 def test_valid_action_string3():
-    (services, feedback_msg) = parse_action_string(
+    spec = parse_action_string(
         'pkg',
         'Foo',
         'bool foo\nstring status\n---\nbool FOO=1\nint8 bar\n---\nbool BAR=1\nbool foo')
+    services = spec.services
+    feedback_msg = spec.feedback
     assert len(services) == 2
     goal_service, result_service = services
     # Goal service checks


### PR DESCRIPTION
Addresses parts of #303 
Built on top of [sloretz/speficication-to-str](https://github.com/ros2/rosidl/tree/sloretz/speficication-to-str) which is in turn based on [sservulo/305-parse_action_file](https://github.com/ros2/rosidl/tree/sservulo/305-parse_action_file)
This PR:
- Defines the `action__struct.hpp.em` and `action.hpp.em` in the `rosidl_generator_cpp`'s resource directory.
- Defines the `action__struct.h.em` and `action.h.em` in the `rosidl_generator_c`'s resource directory.
- Extends the `rosidl_generator_cpp` and `rosidl_generator_c` logic to process `.action` files.
- Adds and `ActionSpecification` class to the `rosidl_parser`.

EDIT:
It wasn't possible to add a `test_action_initialization` test because of an implicit dependency to `builtin_interfaces` package in the generated c++ code which ended up in a circular dependency with the package.


Since this can't be tested in the generation pipeline yet, I've extended some of my notes in [this gist](https://gist.github.com/apojomovsky/4899b0fbeb87748abece10b1be12d730) with some instructions on how to run the generator by hand against an example package.


connects to ros2/rcl_interfaces#48