### PR TITLE
Expose subfolder argument for ROSIDL_GET_SRV_TYPE_SUPPORT macro

### DIFF
--- a/rosidl_generator_c/include/rosidl_generator_c/service_type_support_struct.h
+++ b/rosidl_generator_c/include/rosidl_generator_c/service_type_support_struct.h
@@ -45,7 +45,8 @@ const rosidl_service_type_support_t * get_service_typesupport_handle_function(
   const rosidl_service_type_support_t * handle, const char * identifier);
 
 #define ROSIDL_GET_SRV_TYPE_SUPPORT(PkgName, SrvSubfolder, SrvName) \
-  ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(rosidl_typesupport_c, PkgName, SrvSubfolder, SrvName)()
+  ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME( \
+    rosidl_typesupport_c, PkgName, SrvSubfolder, SrvName)()
 
 #ifdef __cplusplus
 }

--- a/rosidl_generator_c/include/rosidl_generator_c/service_type_support_struct.h
+++ b/rosidl_generator_c/include/rosidl_generator_c/service_type_support_struct.h
@@ -44,8 +44,8 @@ ROSIDL_GENERATOR_C_PUBLIC
 const rosidl_service_type_support_t * get_service_typesupport_handle_function(
   const rosidl_service_type_support_t * handle, const char * identifier);
 
-#define ROSIDL_GET_SRV_TYPE_SUPPORT(PkgName, SrvName) \
-  ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(rosidl_typesupport_c, PkgName, srv, SrvName)()
+#define ROSIDL_GET_SRV_TYPE_SUPPORT(PkgName, SrvSubfolder, SrvName) \
+  ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(rosidl_typesupport_c, PkgName, SrvSubfolder, SrvName)()
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This allows getting type support for services defined in an 'action' namespace; analogous to how ROSIDL_GET_MSG_TYPE_SUPPORT exposes the subfolder argument to support services.