### PR TITLE
Generate action type supports

### DIFF
--- a/rosidl_actions/rosidl_actions/__init__.py
+++ b/rosidl_actions/rosidl_actions/__init__.py
@@ -43,6 +43,7 @@ def generate_msg_and_srv(generator_arguments_file):
                 with open(rsp_file, 'w+') as fout:
                     fout.write(str(service.response))
 
-            generated_file = os.path.join(args['output_dir'], subfolder, action.feedback.msg_name + '.msg')
+            generated_file = os.path.join(
+                args['output_dir'], subfolder, action.feedback.msg_name + '.msg')
             with open(generated_file, 'w+') as fout:
                 fout.write(str(action.feedback))

--- a/rosidl_cmake/cmake/rosidl_generate_action_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_generate_action_interfaces.cmake
@@ -55,7 +55,7 @@ function(rosidl_generate_action_interfaces target)
   set(_idl_files ${_ARG_UNPARSED_ARGUMENTS})
 
   # Create a custom target
-  set(_sub_target "${target}+convert_action_to_msg_and_srv")
+  set(_sub_target "${target}+generate_action_interfaces")
   add_custom_target(
     ${_sub_target} ALL
     DEPENDS

--- a/rosidl_cmake/cmake/rosidl_generate_action_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_generate_action_interfaces.cmake
@@ -68,6 +68,10 @@ function(rosidl_generate_action_interfaces target)
     ${_idl_files}
   )
 
+  # downstream packages need to depend on action_msgs if they have actions
+  list_append_unique(_ARG_DEPENDENCY_PACKAGE_NAMES "action_msgs")
+  ament_export_dependencies(action_msgs)
+
   # A target name that generators may want to use to prefix their own target names
   set(rosidl_generate_action_interfaces_TARGET ${target})
   # Give extensions a list of .action files to generate interfaces from

--- a/rosidl_cmake/cmake/rosidl_generate_action_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_generate_action_interfaces.cmake
@@ -28,6 +28,9 @@
 #   be either an absolute path or path relative to the
 #   CMAKE_INSTALL_PREFIX.
 # :type ARGN: list of strings
+# :param DEPENDENCY_PACKAGE_NAMES: Packages with interface files generation
+# should depend on
+# :type DEPENDENCY_PACKAGE_NAMES: list of strings
 # :param TARGET_DEPENDENCIES: cmake targets or files the generated target
 #   should depend on
 # :type TARGET_DEPENDENCIES: list of strings
@@ -75,6 +78,8 @@ function(rosidl_generate_action_interfaces target)
   set(rosidl_generate_action_interfaces_SKIP_INSTALL ${_ARG_SKIP_INSTALL})
   # If true the extension should create tests for language specific linters
   set(rosidl_generate_action_interfaces_ADD_LINTER_TESTS ${_ARG_ADD_LINTER_TESTS})
+  # Packages that generated code should depend on
+  set(rosidl_generate_action_interfaces_DEPENDENCY_PACKAGE_NAMES ${_ARG_DEPENDENCY_PACKAGE_NAMES})
   ament_execute_extensions("rosidl_generate_action_interfaces")
 
   add_dependencies(${target} ${_sub_target})

--- a/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
@@ -207,6 +207,28 @@ macro(rosidl_generate_interfaces target)
   set(rosidl_generate_interfaces_ADD_LINTER_TESTS ${_ARG_ADD_LINTER_TESTS})
   ament_execute_extensions("rosidl_generate_interfaces")
 
+  if(_action_files)
+    # Invoke generation for `.action` files
+    set(_skip_install "")
+    if(_ARG_SKIP_INSTALL)
+      set(_skip_install "SKIP_INSTALL")
+    endif()
+    set(_add_linter_tests "")
+    if(_ARG_ADD_LINTER_TESTS)
+      set(_add_linter_tests "ADD_LINTER_TESTS")
+    endif()
+    set(_library_name "")
+    if(_ARG_LIBRARY_NAME)
+      set(_library_name "LIBRARY ${_ARG_LIBRARY_NAME}")
+    endif()
+    rosidl_generate_action_interfaces(${target}
+      ${_skip_install}
+      ${_add_linter_tests}
+      ${_library_name}
+      ${_action_files}
+    )
+  endif()
+
   if(NOT _ARG_SKIP_INSTALL)
     # install interface files to subfolders based on their extension
     foreach(_idl_file ${_idl_files})

--- a/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
@@ -221,6 +221,10 @@ macro(rosidl_generate_interfaces target)
     if(_ARG_LIBRARY_NAME)
       set(_library_name "LIBRARY ${_ARG_LIBRARY_NAME}")
     endif()
+    set(_pkg_depends "")
+    if(_recursive_dependencies)
+      set(_pkg_depends "DEPENDENCY_PACKAGE_NAMES ${_recursive_dependencies}")
+    endif()
     rosidl_generate_action_interfaces(${target}
       ${_skip_install}
       ${_add_linter_tests}

--- a/rosidl_generator_c/cmake/register_c.cmake
+++ b/rosidl_generator_c/cmake/register_c.cmake
@@ -19,6 +19,11 @@ macro(rosidl_generator_c_extras BIN GENERATOR_FILES TEMPLATE_DIR)
     "rosidl_generator_c"
     "rosidl_generator_c_generate_interfaces.cmake")
 
+  ament_register_extension(
+    "rosidl_generate_action_interfaces"
+    "rosidl_generator_c"
+    "rosidl_generator_c_generate_action_interfaces.cmake")
+
   normalize_path(BIN "${BIN}")
   set(rosidl_generator_c_BIN "${BIN}")
 

--- a/rosidl_generator_c/cmake/rosidl_generator_c_generate_action_interfaces.cmake
+++ b/rosidl_generator_c/cmake/rosidl_generator_c_generate_action_interfaces.cmake
@@ -1,0 +1,169 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(_output_path
+  "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_c/${PROJECT_NAME}")
+set(_generated_files "")
+
+foreach(_idl_file ${rosidl_generate_action_interfaces_IDL_FILES})
+  get_filename_component(_extension "${_idl_file}" EXT)
+  get_filename_component(_parent_folder "${_idl_file}" DIRECTORY)
+  get_filename_component(_parent_folder "${_parent_folder}" NAME)
+  if(_extension STREQUAL ".action")
+    set(_allowed_parent_folders "action")
+    if(NOT _parent_folder IN_LIST _allowed_parent_folders)
+      message(FATAL_ERROR "Interface file with unknown parent folder: ${_idl_file}")
+    endif()
+  else()
+    message(FATAL_ERROR "Interface file with unknown extension: ${_idl_file}")
+  endif()
+  get_filename_component(_msg_name "${_idl_file}" NAME_WE)
+  string_camel_case_to_lower_case_underscore("${_msg_name}" _header_name)
+  list(APPEND _generated_files
+    "${_output_path}/${_parent_folder}/${_header_name}.h"
+  )
+endforeach()
+
+set(_dependency_files "")
+set(_dependencies "")
+foreach(_pkg_name ${rosidl_generate_action_interfaces_DEPENDENCY_PACKAGE_NAMES})
+  foreach(_idl_file ${${_pkg_name}_INTERFACE_FILES})
+  get_filename_component(_extension "${_idl_file}" EXT)
+  if(_extension STREQUAL ".msg")
+    set(_abs_idl_file "${${_pkg_name}_DIR}/../${_idl_file}")
+    normalize_path(_abs_idl_file "${_abs_idl_file}")
+    list(APPEND _dependency_files "${_abs_idl_file}")
+    list(APPEND _dependencies "${_pkg_name}:${_abs_idl_file}")
+  endif()
+  endforeach()
+endforeach()
+
+set(target_dependencies
+  "${rosidl_generator_c_BIN}"
+  ${rosidl_generator_c_GENERATOR_FILES}
+  "${rosidl_generator_c_TEMPLATE_DIR}/action.h.em"
+  "${rosidl_generator_c_TEMPLATE_DIR}/action__type_support.h.em"
+  ${rosidl_generate_action_interfaces_IDL_FILES}
+  ${_dependency_files})
+foreach(dep ${target_dependencies})
+  if(NOT EXISTS "${dep}")
+    get_property(is_generated SOURCE "${dep}" PROPERTY GENERATED)
+    if(NOT ${_is_generated})
+      message(FATAL_ERROR "Target dependency '${dep}' does not exist")
+    endif()
+  endif()
+endforeach()
+
+set(generator_arguments_file "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_c__generate_action_interfaces__arguments.json")
+rosidl_write_generator_arguments(
+  "${generator_arguments_file}"
+  PACKAGE_NAME "${PROJECT_NAME}"
+  ROS_INTERFACE_FILES "${rosidl_generate_action_interfaces_IDL_FILES}"
+  ROS_INTERFACE_DEPENDENCIES "${_dependencies}"
+  OUTPUT_DIR "${_output_path}"
+  TEMPLATE_DIR "${rosidl_generator_c_TEMPLATE_DIR}"
+  TARGET_DEPENDENCIES ${target_dependencies}
+)
+
+add_custom_command(
+  OUTPUT ${_generated_files}
+  COMMAND ${PYTHON_EXECUTABLE} ${rosidl_generator_c_BIN}
+  --generator-arguments-file "${generator_arguments_file}"
+  DEPENDS ${target_dependencies}
+  COMMENT "Generating C++ type support dispatch for ROS interfaces"
+  VERBATIM
+)
+
+# generate header to switch between export and import for a specific package
+set(_visibility_control_file
+  "${_output_path}/action/rosidl_generator_c__visibility_control.h")
+string(TOUPPER "${PROJECT_NAME}" PROJECT_NAME_UPPER)
+configure_file(
+  "${rosidl_generator_c_TEMPLATE_DIR}/rosidl_generator_c__action_visibility_control.h.in"
+  "${_visibility_control_file}"
+  @ONLY
+)
+
+set(_target_suffix "__generate_action_interfaces__rosidl_generator_c")
+
+add_library(${rosidl_generate_action_interfaces_TARGET}${_target_suffix} ${rosidl_generator_c_LIBRARY_TYPE} ${_generated_files})
+set_target_properties(${rosidl_generate_action_interfaces_TARGET}${_target_suffix} PROPERTIES LINKER_LANGUAGE CXX)
+if(rosidl_generate_action_interfaces_LIBRARY_NAME)
+  set_target_properties(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+    PROPERTIES OUTPUT_NAME "${rosidl_generate_action_interfaces_LIBRARY_NAME}${_target_suffix}")
+endif()
+if(WIN32)
+  target_compile_definitions(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+    PRIVATE "ROSIDL_GENERATOR_c_BUILDING_DLL")
+endif()
+set_target_properties(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+  PROPERTIES CXX_STANDARD 14)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set_target_properties(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+    PROPERTIES COMPILE_OPTIONS -Wall -Wextra -Wpedantic)
+endif()
+target_include_directories(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+  PUBLIC
+  ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_c
+)
+
+ament_target_dependencies(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+  "rosidl_generator_c"
+  "rosidl_typesupport_interface")
+foreach(_pkg_name ${rosidl_generate_action_interfaces_DEPENDENCY_PACKAGE_NAMES})
+  ament_target_dependencies(
+    ${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+    ${_pkg_name})
+endforeach()
+
+add_dependencies(
+  ${rosidl_generate_action_interfaces_TARGET}
+  ${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+)
+
+if(NOT rosidl_generate_action_interfaces_SKIP_INSTALL)
+  install(
+    TARGETS ${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+  )
+  ament_export_libraries(${rosidl_generate_action_interfaces_TARGET}${_target_suffix})
+endif()
+
+if(BUILD_TESTING AND rosidl_generate_action_interfaces_ADD_LINTER_TESTS)
+  if(NOT _generated_files STREQUAL "")
+    find_package(ament_cmake_cppcheck REQUIRED)
+    ament_cppcheck(
+      TESTNAME "cppcheck_rosidl_generator_c_generate_action_interfaces"
+      "${_output_path}")
+
+    find_package(ament_cmake_cpplint REQUIRED)
+    get_filename_component(_cpplint_root "${_output_path}" DIRECTORY)
+    ament_cpplint(
+      TESTNAME "cpplint_rosidl_generator_c_generate_action_interfaces"
+      # the generated code might contain longer lines for templated types
+      MAX_LINE_LENGTH 999
+      ROOT "${_cpplint_root}"
+      "${_output_path}")
+
+    find_package(ament_cmake_uncrustify REQUIRED)
+    ament_uncrustify(
+      TESTNAME "uncrustify_rosidl_generator_c_generate_action_interfaces"
+      # the generated code might contain longer lines for templated types
+      MAX_LINE_LENGTH 999
+      "${_output_path}")
+  endif()
+endif()

--- a/rosidl_generator_c/resource/action__type_support.h.em
+++ b/rosidl_generator_c/resource/action__type_support.h.em
@@ -1,8 +1,8 @@
-// generated from rosidl_generator_c/resource/action.h.em
+// generated from rosidl_generator_c/resource/action__type_support.h.em
 // generated code does not contain a copyright notice
 
 @#######################################################################
-@# EmPy template for generating <action>.hp files
+@# EmPy template for generating <action>__type_support.h files
 @#
 @# Context:
 @#  - spec (rosidl_parser.ActionSpecification)
@@ -15,7 +15,7 @@
 @{
 header_guard_parts = [
     spec.pkg_name, subfolder,
-    get_header_filename_from_msg_name(spec.action_name) + '_h']
+    get_header_filename_from_msg_name(spec.action_name) + '__type_support_h']
 header_guard_variable = '__'.join([x.upper() for x in header_guard_parts]) + '_'
 }@
 
@@ -27,14 +27,18 @@ extern "C"
 {
 #endif
 
-#include <action_msgs/msg/goal_info.h>
-#include <action_msgs/msg/goal_status_array.h>
-#include <action_msgs/srv/cancel_goal.h>
+#include "rosidl_generator_c/action_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
 
-#include <@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.action_name))__feedback.h>
-#include <@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.action_name))__goal.h>
-#include <@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.action_name))__result.h>
-#include "@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.action_name))__type_support.h"
+#include "test_msgs/action/rosidl_generator_c__visibility_control.h"
+
+/* *INDENT-OFF* */
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_@(spec.pkg_name)_ACTION
+const rosidl_action_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__ACTION_SYMBOL_NAME(
+  rosidl_typesupport_c, @(spec.pkg_name), @(subfolder), @(spec.action_name))();
+/* *INDENT-ON* */
 
 #ifdef __cplusplus
 }

--- a/rosidl_generator_c/resource/rosidl_generator_c__action_visibility_control.h.in
+++ b/rosidl_generator_c/resource/rosidl_generator_c__action_visibility_control.h.in
@@ -1,0 +1,43 @@
+// generated from
+// rosidl_generator_c/resource/rosidl_generator_c__action_visibility_control.h.in
+// generated code does not contain a copyright notice
+
+#ifndef @PROJECT_NAME_UPPER@__ACTION__ROSIDL_GENERATOR_C__VISIBILITY_CONTROL_H_
+#define @PROJECT_NAME_UPPER@__ACTION__ROSIDL_GENERATOR_C__VISIBILITY_CONTROL_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define ROSIDL_GENERATOR_C_EXPORT_@PROJECT_NAME@_ACTION __attribute__ ((dllexport))
+    #define ROSIDL_GENERATOR_C_IMPORT_@PROJECT_NAME@_ACTION __attribute__ ((dllimport))
+  #else
+    #define ROSIDL_GENERATOR_C_EXPORT_@PROJECT_NAME@_ACTION __declspec(dllexport)
+    #define ROSIDL_GENERATOR_C_IMPORT_@PROJECT_NAME@_ACTION __declspec(dllimport)
+  #endif
+  #ifdef ROSIDL_GENERATOR_C_BUILDING_DLL_@PROJECT_NAME@_ACTION
+    #define ROSIDL_GENERATOR_C_PUBLIC_@PROJECT_NAME@_ACTION ROSIDL_GENERATOR_C_EXPORT_@PROJECT_NAME@_ACTION
+  #else
+    #define ROSIDL_GENERATOR_C_PUBLIC_@PROJECT_NAME@_ACTION ROSIDL_GENERATOR_C_IMPORT_@PROJECT_NAME@_ACTION
+  #endif
+#else
+  #define ROSIDL_GENERATOR_C_EXPORT_@PROJECT_NAME@_ACTION __attribute__ ((visibility("default")))
+  #define ROSIDL_GENERATOR_C_IMPORT_@PROJECT_NAME@_ACTION
+  #if __GNUC__ >= 4
+    #define ROSIDL_GENERATOR_C_PUBLIC_@PROJECT_NAME@_ACTION __attribute__ ((visibility("default")))
+  #else
+    #define ROSIDL_GENERATOR_C_PUBLIC_@PROJECT_NAME@_ACTION
+  #endif
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // @PROJECT_NAME_UPPER@__ACTION__ROSIDL_GENERATOR_C__VISIBILITY_CONTROL_H_

--- a/rosidl_generator_c/rosidl_generator_c/__init__.py
+++ b/rosidl_generator_c/rosidl_generator_c/__init__.py
@@ -39,6 +39,7 @@ def generate_c(generator_arguments_file):
     }
     mapping_action = {
         os.path.join(template_dir, 'action.h.em'): '%s.h',
+        os.path.join(template_dir, 'action__type_support.h.em'): '%s__type_support.h',
     }
     for template_file in list(mapping_msgs.keys()) + list(mapping_srvs.keys()):
         assert os.path.exists(template_file), 'Could not find template: ' + template_file

--- a/rosidl_generator_cpp/cmake/register_cpp.cmake
+++ b/rosidl_generator_cpp/cmake/register_cpp.cmake
@@ -19,6 +19,11 @@ macro(rosidl_generator_cpp_extras BIN GENERATOR_FILES TEMPLATE_DIR)
     "rosidl_generator_cpp"
     "rosidl_generator_cpp_generate_interfaces.cmake")
 
+ament_register_extension(
+  "rosidl_generate_action_interfaces"
+  "rosidl_generator_cpp"
+  "rosidl_generator_cpp_generate_action_interfaces.cmake")
+
   normalize_path(BIN "${BIN}")
   set(rosidl_generator_cpp_BIN "${BIN}")
 

--- a/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_action_interfaces.cmake
+++ b/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_action_interfaces.cmake
@@ -1,0 +1,165 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(_output_path
+  "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp/${PROJECT_NAME}")
+set(_generated_files "")
+
+foreach(_idl_file ${rosidl_generate_action_interfaces_IDL_FILES})
+  get_filename_component(_extension "${_idl_file}" EXT)
+  get_filename_component(_parent_folder "${_idl_file}" DIRECTORY)
+  get_filename_component(_parent_folder "${_parent_folder}" NAME)
+  if(_extension STREQUAL ".action")
+    set(_allowed_parent_folders "action")
+    if(NOT _parent_folder IN_LIST _allowed_parent_folders)
+      message(FATAL_ERROR "Interface file with unknown parent folder: ${_idl_file}")
+    endif()
+  else()
+    message(FATAL_ERROR "Interface file with unknown extension: ${_idl_file}")
+  endif()
+  get_filename_component(_msg_name "${_idl_file}" NAME_WE)
+  string_camel_case_to_lower_case_underscore("${_msg_name}" _header_name)
+  list(APPEND _generated_files
+    "${_output_path}/${_parent_folder}/${_header_name}__struct.hpp"
+    "${_output_path}/${_parent_folder}/${_header_name}.hpp"
+  )
+endforeach()
+
+set(_dependency_files "")
+set(_dependencies "")
+foreach(_pkg_name ${rosidl_generate_action_interfaces_DEPENDENCY_PACKAGE_NAMES})
+  foreach(_idl_file ${${_pkg_name}_INTERFACE_FILES})
+  get_filename_component(_extension "${_idl_file}" EXT)
+  if(_extension STREQUAL ".msg")
+    set(_abs_idl_file "${${_pkg_name}_DIR}/../${_idl_file}")
+    normalize_path(_abs_idl_file "${_abs_idl_file}")
+    list(APPEND _dependency_files "${_abs_idl_file}")
+    list(APPEND _dependencies "${_pkg_name}:${_abs_idl_file}")
+  endif()
+  endforeach()
+endforeach()
+
+set(target_dependencies
+  "${rosidl_generator_cpp_BIN}"
+  ${rosidl_generator_cpp_GENERATOR_FILES}
+  "${rosidl_generator_cpp_TEMPLATE_DIR}/action__struct.hpp.em"
+  "${rosidl_generator_cpp_TEMPLATE_DIR}/action.hpp.em"
+  ${rosidl_generate_action_interfaces_IDL_FILES}
+  ${_dependency_files})
+foreach(dep ${target_dependencies})
+  if(NOT EXISTS "${dep}")
+    get_property(is_generated SOURCE "${dep}" PROPERTY GENERATED)
+    if(NOT ${_is_generated})
+      message(FATAL_ERROR "Target dependency '${dep}' does not exist")
+    endif()
+  endif()
+endforeach()
+
+set(generator_arguments_file "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp__generate_action_interfaces__arguments.json")
+rosidl_write_generator_arguments(
+  "${generator_arguments_file}"
+  PACKAGE_NAME "${PROJECT_NAME}"
+  ROS_INTERFACE_FILES "${rosidl_generate_action_interfaces_IDL_FILES}"
+  ROS_INTERFACE_DEPENDENCIES "${_dependencies}"
+  OUTPUT_DIR "${_output_path}"
+  TEMPLATE_DIR "${rosidl_generator_cpp_TEMPLATE_DIR}"
+  TARGET_DEPENDENCIES ${target_dependencies}
+)
+
+add_custom_command(
+  OUTPUT ${_generated_files}
+  COMMAND ${PYTHON_EXECUTABLE} ${rosidl_generator_cpp_BIN}
+  --generator-arguments-file "${generator_arguments_file}"
+  DEPENDS ${target_dependencies}
+  COMMENT "Generating C++ type support dispatch for ROS interfaces"
+  VERBATIM
+)
+
+set(_target_suffix "__generate_action_interfaces__rosidl_generator_cpp")
+
+add_library(${rosidl_generate_action_interfaces_TARGET}${_target_suffix} ${rosidl_generator_cpp_LIBRARY_TYPE} ${_generated_files})
+set_target_properties(${rosidl_generate_action_interfaces_TARGET}${_target_suffix} PROPERTIES LINKER_LANGUAGE CXX)
+if(rosidl_generate_action_interfaces_LIBRARY_NAME)
+  set_target_properties(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+    PROPERTIES OUTPUT_NAME "${rosidl_generate_action_interfaces_LIBRARY_NAME}${_target_suffix}")
+endif()
+if(WIN32)
+  target_compile_definitions(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+    PRIVATE "ROSIDL_GENERATOR_CPP_BUILDING_DLL")
+endif()
+set_target_properties(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+  PROPERTIES CXX_STANDARD 14)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set_target_properties(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+    PROPERTIES COMPILE_OPTIONS -Wall -Wextra -Wpedantic)
+endif()
+target_include_directories(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+  PUBLIC
+  ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp
+)
+
+ament_target_dependencies(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+  "rosidl_generator_c"
+  "rosidl_generator_cpp"
+  "rosidl_typesupport_interface")
+foreach(_pkg_name ${rosidl_generate_action_interfaces_DEPENDENCY_PACKAGE_NAMES})
+  ament_target_dependencies(
+    ${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+    ${_pkg_name})
+endforeach()
+
+add_dependencies(
+  ${rosidl_generate_action_interfaces_TARGET}
+  ${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+)
+add_dependencies(
+  ${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+  ${rosidl_generate_action_interfaces_TARGET}__cpp
+)
+
+if(NOT rosidl_generate_action_interfaces_SKIP_INSTALL)
+  install(
+    TARGETS ${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+  )
+  ament_export_libraries(${rosidl_generate_action_interfaces_TARGET}${_target_suffix})
+endif()
+
+if(BUILD_TESTING AND rosidl_generate_action_interfaces_ADD_LINTER_TESTS)
+  if(NOT _generated_files STREQUAL "")
+    find_package(ament_cmake_cppcheck REQUIRED)
+    ament_cppcheck(
+      TESTNAME "cppcheck_rosidl_generator_cpp_generate_action_interfaces"
+      "${_output_path}")
+
+    find_package(ament_cmake_cpplint REQUIRED)
+    get_filename_component(_cpplint_root "${_output_path}" DIRECTORY)
+    ament_cpplint(
+      TESTNAME "cpplint_rosidl_generator_cpp_generate_action_interfaces"
+      # the generated code might contain longer lines for templated types
+      MAX_LINE_LENGTH 999
+      ROOT "${_cpplint_root}"
+      "${_output_path}")
+
+    find_package(ament_cmake_uncrustify REQUIRED)
+    ament_uncrustify(
+      TESTNAME "uncrustify_rosidl_generator_cpp_generate_action_interfaces"
+      # the generated code might contain longer lines for templated types
+      MAX_LINE_LENGTH 999
+      "${_output_path}")
+  endif()
+endif()

--- a/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_action_interfaces.cmake
+++ b/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_action_interfaces.cmake
@@ -86,57 +86,31 @@ add_custom_command(
   VERBATIM
 )
 
-set(_target_suffix "__generate_action_interfaces__rosidl_generator_cpp")
+set(_target_suffix "__cpp__actions")
 
-add_library(${rosidl_generate_action_interfaces_TARGET}${_target_suffix} ${rosidl_generator_cpp_LIBRARY_TYPE} ${_generated_files})
-set_target_properties(${rosidl_generate_action_interfaces_TARGET}${_target_suffix} PROPERTIES LINKER_LANGUAGE CXX)
-if(rosidl_generate_action_interfaces_LIBRARY_NAME)
-  set_target_properties(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
-    PROPERTIES OUTPUT_NAME "${rosidl_generate_action_interfaces_LIBRARY_NAME}${_target_suffix}")
+if(TARGET ${rosidl_generate_action_interfaces_TARGET}${_target_suffix})
+  message(WARNING "Custom target ${rosidl_generate_interfaces_TARGET}${_target_suffix} already exists")
+else()
+  add_custom_target(
+    ${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    DEPENDS
+    ${_generated_files}
+  )
 endif()
-if(WIN32)
-  target_compile_definitions(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
-    PRIVATE "ROSIDL_GENERATOR_CPP_BUILDING_DLL")
-endif()
-set_target_properties(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
-  PROPERTIES CXX_STANDARD 14)
-
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  set_target_properties(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
-    PROPERTIES COMPILE_OPTIONS -Wall -Wextra -Wpedantic)
-endif()
-target_include_directories(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
-  PUBLIC
-  ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp
-)
-
-ament_target_dependencies(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
-  "rosidl_generator_c"
-  "rosidl_generator_cpp"
-  "rosidl_typesupport_interface")
-foreach(_pkg_name ${rosidl_generate_action_interfaces_DEPENDENCY_PACKAGE_NAMES})
-  ament_target_dependencies(
-    ${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
-    ${_pkg_name})
-endforeach()
 
 add_dependencies(
-  ${rosidl_generate_action_interfaces_TARGET}
-  ${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
-)
-add_dependencies(
-  ${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
-  ${rosidl_generate_action_interfaces_TARGET}__cpp
+  ${rosidl_generate_interfaces_TARGET}
+  ${rosidl_generate_interfaces_TARGET}${_target_suffix}
 )
 
 if(NOT rosidl_generate_action_interfaces_SKIP_INSTALL)
-  install(
-    TARGETS ${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION bin
-  )
-  ament_export_libraries(${rosidl_generate_action_interfaces_TARGET}${_target_suffix})
+  if(NOT _generated_files STREQUAL "")
+    install(
+      FILES ${_generated_files}
+      DESTINATION "include/${PROJECT_NAME}/action"
+    )
+  endif()
+  ament_export_include_directories(include)
 endif()
 
 if(BUILD_TESTING AND rosidl_generate_action_interfaces_ADD_LINTER_TESTS)

--- a/rosidl_generator_cpp/resource/action__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/action__struct.hpp.em
@@ -21,7 +21,7 @@ header_guard_variable = '__'.join([x.upper() for x in header_guard_parts]) + '_'
 #ifndef @(header_guard_variable)
 #define @(header_guard_variable)
 
-#include <action_msgs/msg/cancel_goal.hpp>
+#include <action_msgs/srv/cancel_goal.hpp>
 #include <action_msgs/msg/goal_info.hpp>
 #include <action_msgs/msg/goal_status_array.hpp>
 #include <@(spec.pkg_name)/action/@(get_header_filename_from_msg_name(spec.action_name))__feedback.hpp>

--- a/rosidl_parser/rosidl_parser/__init__.py
+++ b/rosidl_parser/rosidl_parser/__init__.py
@@ -766,6 +766,7 @@ def parse_service_string(pkg_name, srv_name, message_string):
 
     return ServiceSpecification(pkg_name, srv_name, request_message, response_message)
 
+
 class ActionSpecification:
 
     def __init__(self, pkg_name, action_name, services, feedback_message):

--- a/rosidl_parser/test/test_parse_action_string.py
+++ b/rosidl_parser/test/test_parse_action_string.py
@@ -43,8 +43,9 @@ def test_valid_action_string():
 
 
 def test_valid_action_string1():
-    (services, feedback_msg) = parse_action_string(
-        'pkg', 'Foo', 'bool foo\n---\nint8 bar\n---\nbool foo')
+    spec = parse_action_string('pkg', 'Foo', 'bool foo\n---\nint8 bar\n---\nbool foo')
+    services = spec.services
+    feedback_msg = spec.feedback
     assert len(services) == 2
     goal_service, result_service = services
     # Goal service checks
@@ -79,8 +80,10 @@ def test_valid_action_string1():
 
 
 def test_valid_action_string2():
-    (services, feedback_msg) = parse_action_string(
+    spec = parse_action_string(
         'pkg', 'Foo', '#comment---\n \nbool foo\n---\n#comment\n \nint8 bar\n---\nbool foo')
+    services = spec.services
+    feedback_msg = spec.feedback
     assert len(services) == 2
     goal_service, result_service = services
     # Goal service checks
@@ -115,10 +118,12 @@ def test_valid_action_string2():
 
 
 def test_valid_action_string3():
-    (services, feedback_msg) = parse_action_string(
+    spec = parse_action_string(
         'pkg',
         'Foo',
         'bool foo\nstring status\n---\nbool FOO=1\nint8 bar\n---\nbool BAR=1\nbool foo')
+    services = spec.services
+    feedback_msg = spec.feedback
     assert len(services) == 2
     goal_service, result_service = services
     # Goal service checks


### PR DESCRIPTION
FYI @sservulo here's a PR targeted at your branch with some additions to make `rosidl_generate_interfaces()` try to generate the action type supports.

connects to ros2/rcl_interfaces#48