### PR TITLE
cast to std::array

### DIFF
--- a/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
@@ -13,6 +13,7 @@
 @#  - get_header_filename_from_msg_name (function)
 @#######################################################################
 @
+#include <array>
 // providing offsetof()
 #include <cstddef>
 #include <vector>
@@ -55,8 +56,8 @@ size_t size_function__@(spec.base_type.type)__@(field.name)(const void * untyped
 const void * get_const_function__@(spec.base_type.type)__@(field.name)(const void * untyped_member, size_t index)
 {
 @[      if field.type.array_size and not field.type.is_upper_bound]@
-  const @(field.type.pkg_name)::msg::@(field.type.type) * member =
-    reinterpret_cast<const @(field.type.pkg_name)::msg::@(field.type.type) *>(untyped_member);
+  const auto member =
+    *reinterpret_cast<const std::array<@(field.type.pkg_name)::msg::@(field.type.type), @(field.type.array_size)> *>(untyped_member);
 @[      else]@
   const std::vector<@(field.type.pkg_name)::msg::@(field.type.type)> & member =
     *reinterpret_cast<const std::vector<@(field.type.pkg_name)::msg::@(field.type.type)> *>(untyped_member);
@@ -67,8 +68,8 @@ const void * get_const_function__@(spec.base_type.type)__@(field.name)(const voi
 void * get_function__@(spec.base_type.type)__@(field.name)(void * untyped_member, size_t index)
 {
 @[      if field.type.array_size and not field.type.is_upper_bound]@
-  @(field.type.pkg_name)::msg::@(field.type.type) * member =
-    reinterpret_cast<@(field.type.pkg_name)::msg::@(field.type.type) *>(untyped_member);
+  auto member =
+    *reinterpret_cast<std::array<@(field.type.pkg_name)::msg::@(field.type.type), @(field.type.array_size)> *>(untyped_member);
 @[      else]@
   std::vector<@(field.type.pkg_name)::msg::@(field.type.type)> & member =
     *reinterpret_cast<std::vector<@(field.type.pkg_name)::msg::@(field.type.type)> *>(untyped_member);

--- a/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
@@ -47,7 +47,7 @@ size_t size_function__@(spec.base_type.type)__@(field.name)(const void * untyped
   (void)untyped_member;
   return @(field.type.array_size);
 @[      else]@
-  const std::vector<@(field.type.pkg_name)::msg::@(field.type.type)> * member =
+  const auto * member =
     reinterpret_cast<const std::vector<@(field.type.pkg_name)::msg::@(field.type.type)> *>(untyped_member);
   return member->size();
 @[      end if]@
@@ -59,7 +59,7 @@ const void * get_const_function__@(spec.base_type.type)__@(field.name)(const voi
   const auto & member =
     *reinterpret_cast<const std::array<@(field.type.pkg_name)::msg::@(field.type.type), @(field.type.array_size)> *>(untyped_member);
 @[      else]@
-  const std::vector<@(field.type.pkg_name)::msg::@(field.type.type)> & member =
+  const auto & member =
     *reinterpret_cast<const std::vector<@(field.type.pkg_name)::msg::@(field.type.type)> *>(untyped_member);
 @[      end if]@
   return &member[index];
@@ -71,7 +71,7 @@ void * get_function__@(spec.base_type.type)__@(field.name)(void * untyped_member
   auto & member =
     *reinterpret_cast<std::array<@(field.type.pkg_name)::msg::@(field.type.type), @(field.type.array_size)> *>(untyped_member);
 @[      else]@
-  std::vector<@(field.type.pkg_name)::msg::@(field.type.type)> & member =
+  auto & member =
     *reinterpret_cast<std::vector<@(field.type.pkg_name)::msg::@(field.type.type)> *>(untyped_member);
 @[      end if]@
   return &member[index];
@@ -80,7 +80,7 @@ void * get_function__@(spec.base_type.type)__@(field.name)(void * untyped_member
 @[      if not field.type.array_size or field.type.is_upper_bound]@
 void resize_function__@(spec.base_type.type)__@(field.name)(void * untyped_member, size_t size)
 {
-  std::vector<@(field.type.pkg_name)::msg::@(field.type.type)> * member =
+  auto * member =
     reinterpret_cast<std::vector<@(field.type.pkg_name)::msg::@(field.type.type)> *>(untyped_member);
   member->resize(size);
 }

--- a/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
@@ -56,7 +56,7 @@ size_t size_function__@(spec.base_type.type)__@(field.name)(const void * untyped
 const void * get_const_function__@(spec.base_type.type)__@(field.name)(const void * untyped_member, size_t index)
 {
 @[      if field.type.array_size and not field.type.is_upper_bound]@
-  const auto member =
+  const auto & member =
     *reinterpret_cast<const std::array<@(field.type.pkg_name)::msg::@(field.type.type), @(field.type.array_size)> *>(untyped_member);
 @[      else]@
   const std::vector<@(field.type.pkg_name)::msg::@(field.type.type)> & member =
@@ -68,7 +68,7 @@ const void * get_const_function__@(spec.base_type.type)__@(field.name)(const voi
 void * get_function__@(spec.base_type.type)__@(field.name)(void * untyped_member, size_t index)
 {
 @[      if field.type.array_size and not field.type.is_upper_bound]@
-  auto member =
+  auto & member =
     *reinterpret_cast<std::array<@(field.type.pkg_name)::msg::@(field.type.type), @(field.type.array_size)> *>(untyped_member);
 @[      else]@
   std::vector<@(field.type.pkg_name)::msg::@(field.type.type)> & member =


### PR DESCRIPTION
fixes ros2/rosidl#320

I wanted to apply the same style as for the vector in the line below, but `cpplint` did not like it. It complains something like `(error: returnLocalVariable) Pointer to local array variable returned.`
Don't know why this doesn't occur with the vector.