### PR TITLE
conversion functions from .msg / .srv to .idl

### DIFF
--- a/rosidl_adapter/CMakeLists.txt
+++ b/rosidl_adapter/CMakeLists.txt
@@ -14,6 +14,11 @@ endif()
 
 ament_package()
 
+install(PROGRAMS
+  scripts/msg2idl.py
+  scripts/srv2idl.py
+  DESTINATION lib/${PROJECT_NAME})
+
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
   ament_add_pytest_test(pytest test)

--- a/rosidl_adapter/rosidl_adapter/__init__.py
+++ b/rosidl_adapter/rosidl_adapter/__init__.py
@@ -1,0 +1,30 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def convert_to_idl(package_dir, package_name, interface_file, output_dir):
+    if interface_file.suffix == '.msg':
+        from rosidl_adapter.msg import convert_msg_to_idl
+        return convert_msg_to_idl(
+            package_dir, package_name, interface_file,
+            output_dir / package_name / 'msg')
+
+    if interface_file.suffix == '.srv':
+        from rosidl_adapter.srv import convert_srv_to_idl
+        return convert_srv_to_idl(
+            package_dir, package_name, interface_file,
+            output_dir / package_name / 'srv')
+
+    assert False, "Unsupported interface type '{interface_file.suffix}'" \
+        .format_map(locals())

--- a/rosidl_adapter/rosidl_adapter/cli.py
+++ b/rosidl_adapter/rosidl_adapter/cli.py
@@ -45,4 +45,6 @@ def convert_files_to_idl(extension, conversion_function, argv=sys.argv[1:]):
         pkg = parse_package(package_dir, warnings=warnings)
 
         conversion_function(
-            package_dir, pkg.name, interface_file, interface_file.parent)
+            package_dir, pkg.name,
+            interface_file.absolute().relative_to(package_dir),
+            interface_file.parent)

--- a/rosidl_adapter/rosidl_adapter/cli.py
+++ b/rosidl_adapter/rosidl_adapter/cli.py
@@ -1,0 +1,48 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import pathlib
+import sys
+
+from catkin_pkg.package import package_exists_at
+from catkin_pkg.package import parse_package
+
+
+def convert_files_to_idl(extension, conversion_function, argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description='Convert {extension} files to .idl'.format_map(locals()))
+    parser.add_argument(
+        'interface_files', nargs='+',
+        help='The interface files to convert')
+    args = parser.parse_args(argv)
+
+    for interface_file in args.interface_files:
+        interface_file = pathlib.Path(interface_file)
+        package_dir = interface_file.parent.absolute()
+        while (
+            len(package_dir.parents) and
+            not package_exists_at(str(package_dir))
+        ):
+            package_dir = package_dir.parent
+        if not package_dir.parents:
+            print(
+                "Could not find package for '{interface_file}'"
+                .format_map(locals()), file=sys.stderr)
+            continue
+        warnings = []
+        pkg = parse_package(package_dir, warnings=warnings)
+
+        conversion_function(
+            package_dir, pkg.name, interface_file, interface_file.parent)

--- a/rosidl_adapter/rosidl_adapter/msg/__init__.py
+++ b/rosidl_adapter/rosidl_adapter/msg/__init__.py
@@ -21,13 +21,15 @@ def convert_msg_to_idl(package_dir, package_name, input_file, output_dir):
     assert not input_file.is_absolute()
     assert input_file.suffix == '.msg'
 
-    print('Reading input file: {input_file}'.format_map(locals()))
+    abs_input_file = package_dir / input_file
+    print('Reading input file: {abs_input_file}'.format_map(locals()))
     abs_input_file = package_dir / input_file
     content = abs_input_file.read_text(encoding='utf-8')
     msg = parse_message_string(package_name, input_file.stem, content)
 
     output_file = output_dir / input_file.with_suffix('.idl').name
-    print('Writing output file: {output_file}'.format_map(locals()))
+    abs_output_file = output_file.absolute()
+    print('Writing output file: {abs_output_file}'.format_map(locals()))
     data = {
         'pkg_name': package_name,
         'relative_input_file': input_file,

--- a/rosidl_adapter/rosidl_adapter/msg/__init__.py
+++ b/rosidl_adapter/rosidl_adapter/msg/__init__.py
@@ -1,0 +1,104 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rosidl_adapter.parser import parse_message_string
+from rosidl_adapter.resource import expand_template
+
+
+def convert_msg_to_idl(package_dir, package_name, input_file, output_dir):
+    assert package_dir.is_absolute()
+    assert not input_file.is_absolute()
+    assert input_file.suffix == '.msg'
+
+    print('Reading input file: {input_file}'.format_map(locals()))
+    abs_input_file = package_dir / input_file
+    content = abs_input_file.read_text(encoding='utf-8')
+    msg = parse_message_string(package_name, input_file.stem, content)
+
+    output_file = output_dir / input_file.with_suffix('.idl').name
+    print('Writing output file: {output_file}'.format_map(locals()))
+    data = {
+        'pkg_name': package_name,
+        'relative_input_file': input_file,
+        'msg': msg,
+    }
+
+    expand_template('msg.idl.em', data, output_file)
+    return output_file
+
+
+MSG_TYPE_TO_IDL = {
+    'bool': 'boolean',
+    'byte': 'octet',
+    'char': 'uint8',
+    'int8': 'int8',
+    'uint8': 'uint8',
+    'int16': 'int16',
+    'uint16': 'uint16',
+    'int32': 'int32',
+    'uint32': 'uint32',
+    'int64': 'int64',
+    'uint64': 'uint64',
+    'float32': 'float',
+    'float64': 'double',
+    'string': 'string',
+}
+
+
+def to_idl_literal(idl_type, value):
+    if idl_type[-1] in (']', '>'):
+        elements = [repr(v) for v in value]
+        while len(elements) < 2:
+            elements.append('')
+        return '"(%s)"' % ', '.join(e.replace('"', r'\"') for e in elements)
+
+    if 'boolean' == idl_type:
+        return 'TRUE' if value else 'FALSE'
+    if 'string' == idl_type:
+        return string_to_idl_string_literal(value)
+    return value
+
+
+def string_to_idl_string_literal(string):
+    """Convert string to character literal as described in IDL 4.2 section  7.2.6.3 ."""
+    estr = string.encode().decode('unicode_escape')
+    estr = estr.replace('"', r'\"')
+    return '"{0}"'.format(estr)
+
+
+def get_include_file(base_type):
+    if base_type.is_primitive_type():
+        return None
+    return '{base_type.pkg_name}/msg/{base_type.type}.idl'.format_map(locals())
+
+
+def get_idl_type(type_):
+    if isinstance(type_, str):
+        identifier = MSG_TYPE_TO_IDL[type_]
+    elif type_.is_primitive_type():
+        identifier = MSG_TYPE_TO_IDL[type_.type]
+    else:
+        identifier = '{type_.pkg_name}::msg::{type_.type}' \
+            .format_map(locals())
+
+    if isinstance(type_, str) or not type_.is_array:
+        return identifier
+
+    if type_.is_fixed_size_array():
+        return '{identifier}[{type_.array_size}]'.format_map(locals())
+
+    if not type_.is_upper_bound:
+        return 'sequence<{identifier}>'.format_map(locals())
+
+    return 'sequence<{identifier}, {type_.array_size}>'.format_map(locals())

--- a/rosidl_adapter/rosidl_adapter/resource/__init__.py
+++ b/rosidl_adapter/rosidl_adapter/resource/__init__.py
@@ -1,0 +1,87 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from io import StringIO
+import os
+import sys
+
+import em
+
+
+def expand_template(template_name, data, output_file):
+    content = evaluate_template(template_name, data)
+
+    if output_file.exists():
+        existing_content = output_file.read_text()
+        if existing_content == content:
+            return
+    elif output_file.parent:
+        os.makedirs(str(output_file.parent), exist_ok=True)
+
+    output_file.write_text(content)
+
+
+_interpreter = None
+
+
+def evaluate_template(template_name, data):
+    global _interpreter
+    # create copy before manipulating
+    data = dict(data)
+    data['TEMPLATE'] = _evaluate_template
+
+    template_path = os.path.join(os.path.dirname(__file__), template_name)
+
+    output = StringIO()
+    try:
+        _interpreter = em.Interpreter(
+            output=output,
+            options={
+                em.BUFFERED_OPT: True,
+                em.RAW_OPT: True,
+            })
+
+        with open(template_path, 'r') as h:
+            content = h.read()
+        _interpreter.invoke(
+            'beforeFile', name=template_name, file=h, locals=data)
+        _interpreter.string(content, template_path, locals=data)
+        _interpreter.invoke('afterFile')
+
+        return output.getvalue()
+    except Exception as e:  # noqa: F841
+        print(
+            "{e.__class__.__name__} processing template '{template_name}'"
+            .format_map(locals()), file=sys.stderr)
+        raise
+    finally:
+        _interpreter.shutdown()
+        _interpreter = None
+
+
+def _evaluate_template(template_name, **kwargs):
+    global _interpreter
+    template_path = os.path.join(os.path.dirname(__file__), template_name)
+    with open(template_path, 'r') as h:
+        _interpreter.invoke(
+            'beforeInclude', name=template_path, file=h, locals=kwargs)
+        content = h.read()
+    try:
+        _interpreter.string(content, template_path, kwargs)
+    except Exception as e:  # noqa: F841
+        print(
+            "{e.__class__.__name__} processing template '{template_name}': {e}"
+            .format_map(locals()), file=sys.stderr)
+        sys.exit(1)
+    _interpreter.invoke('afterInclude')

--- a/rosidl_adapter/rosidl_adapter/resource/msg.idl.em
+++ b/rosidl_adapter/rosidl_adapter/resource/msg.idl.em
@@ -1,0 +1,25 @@
+// generated from rosidl_adapter/resource/msg.idl.em
+// with input from @(pkg_name)/@(relative_input_file)
+
+@{
+from rosidl_adapter.msg import get_include_file
+include_files = set()
+for field in msg.fields:
+    include_file = get_include_file(field.type)
+    if include_file is not None:
+        include_files.add(include_file)
+}@
+@[for include_file in sorted(include_files)]@
+#include "@(include_file)"
+@[end for]@
+
+module @(pkg_name) {
+  module msg {
+@{
+TEMPLATE(
+    'struct.idl.em',
+    msg=msg,
+)
+}@
+  };
+};

--- a/rosidl_adapter/rosidl_adapter/resource/srv.idl.em
+++ b/rosidl_adapter/rosidl_adapter/resource/srv.idl.em
@@ -1,0 +1,31 @@
+// generated from rosidl_adapter/resource/srv.idl.em
+// with input from @(pkg_name)/@(relative_input_file)
+
+@{
+from rosidl_adapter.msg import get_include_file
+include_files = set()
+for field in srv.request.fields + srv.response.fields:
+    include_file = get_include_file(field.type)
+    if include_file is not None:
+        include_files.add(include_file)
+}@
+@[for include_file in sorted(include_files)]@
+#include "@(include_file)"
+@[end for]@
+
+module @(pkg_name) {
+  module srv {
+@{
+TEMPLATE(
+    'struct.idl.em',
+    msg=srv.request,
+)
+}@
+@{
+TEMPLATE(
+    'struct.idl.em',
+    msg=srv.response,
+)
+}@
+  };
+};

--- a/rosidl_adapter/rosidl_adapter/resource/struct.idl.em
+++ b/rosidl_adapter/rosidl_adapter/resource/struct.idl.em
@@ -1,0 +1,86 @@
+@#typedefs for arrays need to be defined outside of the struct
+@{
+from collections import OrderedDict
+
+from rosidl_adapter.msg import get_idl_type
+from rosidl_adapter.msg import to_idl_literal
+from rosidl_adapter.msg import string_to_idl_string_literal
+
+typedefs = OrderedDict()
+def get_idl_type_identifier(idl_type):
+    return idl_type.replace('::', '__').replace('[', '__').replace(']', '')
+}@
+@[for field in msg.fields]@
+@{
+idl_type = get_idl_type(field.type)
+}@
+@[  if field.type.is_fixed_size_array()]@
+@{
+idl_base_type = idl_type.split('[', 1)[0]
+idl_base_type_identifier = idl_base_type.replace('::', '__')
+# only necessary for complex types
+if idl_base_type_identifier != idl_base_type:
+    if idl_base_type_identifier not in typedefs:
+        typedefs[idl_base_type_identifier] = idl_base_type
+    else:
+        assert typedefs[idl_base_type_identifier] == idl_base_type
+idl_type_identifier = get_idl_type_identifier(idl_type) + '[' + str(field.type.array_size) + ']'
+if idl_type_identifier not in typedefs:
+    typedefs[idl_type_identifier] = idl_base_type_identifier
+else:
+    assert typedefs[idl_type_identifier] == idl_base_type_identifier
+}@
+@[  end if]@
+@[end for]@
+@[for k, v in typedefs.items()]@
+    typedef @(v) @(k);
+@[end for]@
+@[if msg.constants]@
+    module @(msg.msg_name)_Constants {
+@[  for constant in msg.constants]@
+      const @(get_idl_type(constant.type)) @(constant.name) = @(to_idl_literal(get_idl_type(constant.type), constant.value));
+@[  end for]@
+    };
+@[end if]@
+@#
+@[if msg.annotations.get('comment', [])]@
+    /*
+@[  for comment in msg.annotations['comment']]@
+     *@(comment)
+@[  end for]@
+     */
+@[end if]@
+    struct @(msg.msg_name) {
+@# use comments as docblocks once they are available
+@[if msg.fields]@
+@[  for i, field in enumerate(msg.fields)]@
+@[if i > 0]@
+
+@[end if]@
+@[    if field.annotations.get('comment', [])]@
+      /*
+@[      for comment in field.annotations['comment']]@
+       *@(comment)
+@[      end for]@
+       */
+@[    end if]@
+@[    if field.default_value is not None]@
+      @@default (value=@(to_idl_literal(get_idl_type(field.type), field.default_value)))
+@[    end if]@
+@[    if 'unit' in field.annotations]@
+      @@unit (value=@(string_to_idl_string_literal(field.annotations['unit'])))
+@[    end if]@
+@{
+idl_type = get_idl_type(field.type)
+}@
+@[    if field.type.is_fixed_size_array()]@
+@{
+idl_type = get_idl_type_identifier(idl_type)
+}@
+@[    end if]@
+      @(idl_type) @(field.name);
+@[  end for]@
+@[else]@
+      boolean structure_needs_at_least_one_member;
+@[end if]@
+    };

--- a/rosidl_adapter/rosidl_adapter/srv/__init__.py
+++ b/rosidl_adapter/rosidl_adapter/srv/__init__.py
@@ -1,0 +1,38 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rosidl_adapter.parser import parse_service_string
+from rosidl_adapter.resource import expand_template
+
+
+def convert_srv_to_idl(package_dir, package_name, input_file, output_dir):
+    assert package_dir.is_absolute()
+    assert not input_file.is_absolute()
+    assert input_file.suffix == '.srv'
+
+    print('Reading input file: {input_file}'.format_map(locals()))
+    abs_input_file = package_dir / input_file
+    content = abs_input_file.read_text(encoding='utf-8')
+    srv = parse_service_string(package_name, input_file.stem, content)
+
+    output_file = output_dir / input_file.with_suffix('.idl').name
+    print('Writing output file: {output_file}'.format_map(locals()))
+    data = {
+        'pkg_name': package_name,
+        'relative_input_file': input_file,
+        'srv': srv,
+    }
+
+    expand_template('srv.idl.em', data, output_file)
+    return output_file

--- a/rosidl_adapter/rosidl_adapter/srv/__init__.py
+++ b/rosidl_adapter/rosidl_adapter/srv/__init__.py
@@ -21,13 +21,15 @@ def convert_srv_to_idl(package_dir, package_name, input_file, output_dir):
     assert not input_file.is_absolute()
     assert input_file.suffix == '.srv'
 
-    print('Reading input file: {input_file}'.format_map(locals()))
+    abs_input_file = package_dir / input_file
+    print('Reading input file: {abs_input_file}'.format_map(locals()))
     abs_input_file = package_dir / input_file
     content = abs_input_file.read_text(encoding='utf-8')
     srv = parse_service_string(package_name, input_file.stem, content)
 
     output_file = output_dir / input_file.with_suffix('.idl').name
-    print('Writing output file: {output_file}'.format_map(locals()))
+    abs_output_file = output_file.absolute()
+    print('Writing output file: {abs_output_file}'.format_map(locals()))
     data = {
         'pkg_name': package_name,
         'relative_input_file': input_file,

--- a/rosidl_adapter/scripts/msg2idl.py
+++ b/rosidl_adapter/scripts/msg2idl.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rosidl_adapter.cli import convert_files_to_idl
+from rosidl_adapter.msg import convert_msg_to_idl
+
+
+if __name__ == '__main__':
+    convert_files_to_idl('.msg', convert_msg_to_idl)

--- a/rosidl_adapter/scripts/srv2idl.py
+++ b/rosidl_adapter/scripts/srv2idl.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rosidl_adapter.cli import convert_files_to_idl
+from rosidl_adapter.srv import convert_srv_to_idl
+
+
+if __name__ == '__main__':
+    convert_files_to_idl('.srv', convert_srv_to_idl)


### PR DESCRIPTION
This is the third PR integrating #298 step-by-step.

Builds on top of #323.

Since the functionality provided by this patch isn't actively being used yet there isn't a point in running CI.

The command line script `msg2idl.py` and `srv2idl.py` can be used to manually convert `.msg` / `.srv` files.