### PR TITLE
split action services

### DIFF
--- a/rosidl_actions/rosidl_actions/__init__.py
+++ b/rosidl_actions/rosidl_actions/__init__.py
@@ -32,7 +32,7 @@ def generate_msg_and_srv(generator_arguments_file):
             os.makedirs(os.path.join(args['output_dir'], subfolder), exist_ok=True)
 
             generated_folder = os.path.join(args['output_dir'], subfolder)
-            for service in action.services:
+            for service in [action.goal_service, action.result_service]:
                 srv_file = os.path.join(generated_folder, service.srv_name + '.srv')
                 req_file = os.path.join(generated_folder, service.srv_name + '_Request.msg')
                 rsp_file = os.path.join(generated_folder, service.srv_name + '_Response.msg')

--- a/rosidl_adapter/test/test_parse_action_string.py
+++ b/rosidl_adapter/test/test_parse_action_string.py
@@ -44,10 +44,9 @@ def test_valid_action_string():
 
 def test_valid_action_string1():
     spec = parse_action_string('pkg', 'Foo', 'bool foo\n---\nint8 bar\n---\nbool foo')
-    services = spec.services
+    goal_service = spec.goal_service
+    result_service = spec.result_service
     feedback_msg = spec.feedback
-    assert len(services) == 2
-    goal_service, result_service = services
     # Goal service checks
     assert goal_service.pkg_name == 'pkg'
     assert goal_service.srv_name == 'Foo_Goal'
@@ -82,10 +81,9 @@ def test_valid_action_string1():
 def test_valid_action_string2():
     spec = parse_action_string(
         'pkg', 'Foo', '#comment---\n \nbool foo\n---\n#comment\n \nint8 bar\n---\nbool foo')
-    services = spec.services
+    goal_service = spec.goal_service
+    result_service = spec.result_service
     feedback_msg = spec.feedback
-    assert len(services) == 2
-    goal_service, result_service = services
     # Goal service checks
     assert goal_service.pkg_name == 'pkg'
     assert goal_service.srv_name == 'Foo_Goal'
@@ -122,10 +120,9 @@ def test_valid_action_string3():
         'pkg',
         'Foo',
         'bool foo\nstring status\n---\nbool FOO=1\nint8 bar\n---\nbool BAR=1\nbool foo')
-    services = spec.services
+    goal_service = spec.goal_service
+    result_service = spec.result_service
     feedback_msg = spec.feedback
-    assert len(services) == 2
-    goal_service, result_service = services
     # Goal service checks
     assert goal_service.pkg_name == 'pkg'
     assert goal_service.srv_name == 'Foo_Goal'


### PR DESCRIPTION
Since actions always contain exactly two services with a very specific semantic (the goal service and the result service) they should be stored in separate variables rather than a list which "looses" that semantic.

In support of #298.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5570)](http://ci.ros2.org/job/ci_linux/5570/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2215)](http://ci.ros2.org/job/ci_linux-aarch64/2215/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4590)](http://ci.ros2.org/job/ci_osx/4590/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5460)](http://ci.ros2.org/job/ci_windows/5460/)