### PR TITLE
enable access functions for primitive types

### DIFF
--- a/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
@@ -40,15 +40,22 @@ namespace rosidl_typesupport_introspection_cpp
 
 @[if spec.fields]@
 @[  for field in spec.fields]@
-@[    if not field.type.is_primitive_type() and field.type.is_array]@
+@[    if field.type.is_array and not field.type.type == 'bool']@
+@{
+# from rosidl_generator_cpp import msg_type_only_to_cpp
+# type = msg_type_only_to_cpp(field.type)
+default_type = str(field.type.pkg_name) + '::msg::' + field.type.type
+type = cpp_primitives.get(field.type.type, default_type)
+if field.type.type == 'string':
+    type = 'std::string'
+}@
 size_t size_function__@(spec.base_type.type)__@(field.name)(const void * untyped_member)
 {
 @[      if field.type.array_size and not field.type.is_upper_bound]@
   (void)untyped_member;
   return @(field.type.array_size);
 @[      else]@
-  const auto * member =
-    reinterpret_cast<const std::vector<@(field.type.pkg_name)::msg::@(field.type.type)> *>(untyped_member);
+  const auto * member = reinterpret_cast<const std::vector<@(type)> *>(untyped_member);
   return member->size();
 @[      end if]@
 }
@@ -57,10 +64,10 @@ const void * get_const_function__@(spec.base_type.type)__@(field.name)(const voi
 {
 @[      if field.type.array_size and not field.type.is_upper_bound]@
   const auto & member =
-    *reinterpret_cast<const std::array<@(field.type.pkg_name)::msg::@(field.type.type), @(field.type.array_size)> *>(untyped_member);
+    *reinterpret_cast<const std::array<@(type), @(field.type.array_size)> *>(untyped_member);
 @[      else]@
   const auto & member =
-    *reinterpret_cast<const std::vector<@(field.type.pkg_name)::msg::@(field.type.type)> *>(untyped_member);
+    *reinterpret_cast<const std::vector<@(type)> *>(untyped_member);
 @[      end if]@
   return &member[index];
 }
@@ -69,10 +76,10 @@ void * get_function__@(spec.base_type.type)__@(field.name)(void * untyped_member
 {
 @[      if field.type.array_size and not field.type.is_upper_bound]@
   auto & member =
-    *reinterpret_cast<std::array<@(field.type.pkg_name)::msg::@(field.type.type), @(field.type.array_size)> *>(untyped_member);
+    *reinterpret_cast<std::array<@(type), @(field.type.array_size)> *>(untyped_member);
 @[      else]@
   auto & member =
-    *reinterpret_cast<std::vector<@(field.type.pkg_name)::msg::@(field.type.type)> *>(untyped_member);
+    *reinterpret_cast<std::vector<@(type)> *>(untyped_member);
 @[      end if]@
   return &member[index];
 }
@@ -81,7 +88,7 @@ void * get_function__@(spec.base_type.type)__@(field.name)(void * untyped_member
 void resize_function__@(spec.base_type.type)__@(field.name)(void * untyped_member, size_t size)
 {
   auto * member =
-    reinterpret_cast<std::vector<@(field.type.pkg_name)::msg::@(field.type.type)> *>(untyped_member);
+    reinterpret_cast<std::vector<@(type)> *>(untyped_member);
   member->resize(size);
 }
 
@@ -120,7 +127,7 @@ for index, field in enumerate(spec.fields):
     # void * default_value_
     print('    nullptr,  // default value')  # TODO default value to be set
 
-    function_suffix = '%s__%s' % (spec.base_type.type, field.name) if not field.type.is_primitive_type() and field.type.is_array else None
+    function_suffix = '%s__%s' % (spec.base_type.type, field.name) if field.type.is_array and not field.type.type == 'bool' else None
 
     # size_t(const void *) size_function
     print('    %s,  // size() function pointer' % ('size_function__%s' % function_suffix if function_suffix else 'nullptr'))

--- a/rosidl_typesupport_introspection_cpp/rosidl_typesupport_introspection_cpp/__init__.py
+++ b/rosidl_typesupport_introspection_cpp/rosidl_typesupport_introspection_cpp/__init__.py
@@ -22,6 +22,7 @@ from rosidl_cmake import read_generator_arguments
 from rosidl_parser import parse_message_file
 from rosidl_parser import parse_service_file
 from rosidl_parser import validate_field_types
+from rosidl_generator_cpp import MSG_TYPE_TO_CPP
 
 
 def generate_cpp(generator_arguments_file):
@@ -67,7 +68,7 @@ def generate_cpp(generator_arguments_file):
                     args['output_dir'], subfolder, generated_filename %
                     convert_camel_case_to_lower_case_underscore(spec.base_type.type))
 
-                data = {'spec': spec, 'subfolder': subfolder}
+                data = {'spec': spec, 'subfolder': subfolder, 'cpp_primitives': MSG_TYPE_TO_CPP}
                 data.update(functions)
                 expand_template(
                     template_file, data, generated_file,


### PR DESCRIPTION
for visibility only. I would like to have this merged, but currently there is no nice way (that I know of) to access `std::vector<bool>` as this is a specialization of vector.
https://en.cppreference.com/w/cpp/container/vector_bool

It does not simply return a reference to it's element, `std::vector<bool>` defines a separate class `std::vector<bool>::reference` for it, which is returned by value.

In order to make this patch compile, I explicitly disable these functions for bool.