### PR TITLE
fix comment regex in grammar to not be greedy

### DIFF
--- a/rosidl_parser/rosidl_parser/grammar.lark
+++ b/rosidl_parser/rosidl_parser/grammar.lark
@@ -17,7 +17,7 @@
 
 // 7.2.2 Comments
 COMMENT: "//" /[^\n]/*
-  | "/*" /(.|\n)+/ "*/"
+  | "/*" /(.|\n)+?/ "*/"
 %ignore COMMENT
 
 


### PR DESCRIPTION
Otherwise the content between multiple multi line comments is being ignored.