### PR TITLE
Change UUID type in action msgs

### DIFF
--- a/rosidl_adapter/rosidl_adapter/parser.py
+++ b/rosidl_adapter/rosidl_adapter/parser.py
@@ -884,7 +884,7 @@ def parse_action_string(pkg_name, action_name, action_string):
 
     # ---------------------------------------------------------------------------------------------
     # Send goal
-    implicit_input = ['UUID goal_id']
+    implicit_input = ['unique_identifier_msgs/UUID goal_id']
     request_message_string = '\n'.join(implicit_input) + '\n' + goal_service_string
     request_message = parse_message_string(
         pkg_name,
@@ -907,7 +907,7 @@ def parse_action_string(pkg_name, action_name, action_string):
 
     # ---------------------------------------------------------------------------------------------
     # Get result
-    implicit_input = ['UUID goal_id']
+    implicit_input = ['unique_identifier_msgs/UUID goal_id']
     request_message_string = '\n'.join(implicit_input)
     request_message = parse_message_string(
         pkg_name,
@@ -930,7 +930,7 @@ def parse_action_string(pkg_name, action_name, action_string):
 
     # ---------------------------------------------------------------------------------------------
     # Feedback message
-    implicit_input = ['UUID goal_id']
+    implicit_input = ['unique_identifier_msgs/UUID goal_id']
     message_string = '\n'.join(implicit_input) + '\n' + feedback_message_string
     feedback_msg = parse_message_string(
         pkg_name, action_name + ACTION_FEEDBACK_MESSAGE_SUFFIX, message_string)

--- a/rosidl_adapter/rosidl_adapter/parser.py
+++ b/rosidl_adapter/rosidl_adapter/parser.py
@@ -30,7 +30,7 @@ ACTION_REQUEST_RESPONSE_SEPARATOR = '---'
 ACTION_GOAL_SERVICE_SUFFIX = '_Goal'
 ACTION_RESULT_SERVICE_SUFFIX = '_Result'
 ACTION_FEEDBACK_MESSAGE_SUFFIX = '_Feedback'
-ACTION_IMPLICIT_FIELDS = ['goal_id', 'status']
+ACTION_IMPLICIT_FIELDS = ['action_goal_id', 'action_status']
 
 PRIMITIVE_TYPES = [
     'bool',
@@ -513,8 +513,9 @@ def parse_message_string(pkg_name, msg_name, message_string):
                 raise ImplicitFieldCollision("Duplicate parameter name '{field_name}' \
                     found processing '{line}' of '{pkg}/{msg}'. \
                     If this resulted from an action definition please \
-                    check for implicit parameter names (goal_id, status)".format(
-                    field_name=field_name, line=line, pkg=pkg_name, msg=msg_name))
+                    check for implicit parameter names {fields}".format(
+                    field_name=field_name, line=line, pkg=pkg_name, msg=msg_name,
+                    fields=repr(ACTION_IMPLICIT_FIELDS)))
             elif field_name in ACTION_IMPLICIT_FIELDS:
                 action_fields[field_name] += 1
 
@@ -884,7 +885,7 @@ def parse_action_string(pkg_name, action_name, action_string):
 
     # ---------------------------------------------------------------------------------------------
     # Send goal
-    implicit_input = ['unique_identifier_msgs/UUID goal_id']
+    implicit_input = ['unique_identifier_msgs/UUID action_goal_id']
     request_message_string = '\n'.join(implicit_input) + '\n' + goal_service_string
     request_message = parse_message_string(
         pkg_name,
@@ -907,14 +908,14 @@ def parse_action_string(pkg_name, action_name, action_string):
 
     # ---------------------------------------------------------------------------------------------
     # Get result
-    implicit_input = ['unique_identifier_msgs/UUID goal_id']
+    implicit_input = ['unique_identifier_msgs/UUID action_goal_id']
     request_message_string = '\n'.join(implicit_input)
     request_message = parse_message_string(
         pkg_name,
         action_name + ACTION_RESULT_SERVICE_SUFFIX + SERVICE_REQUEST_MESSAGE_SUFFIX,
         request_message_string)
 
-    implicit_output = ['int8 status']
+    implicit_output = ['int8 action_status']
     response_message_string = '\n'.join(implicit_output) + '\n' + result_service_string
     response_message = parse_message_string(
         pkg_name,
@@ -930,7 +931,7 @@ def parse_action_string(pkg_name, action_name, action_string):
 
     # ---------------------------------------------------------------------------------------------
     # Feedback message
-    implicit_input = ['unique_identifier_msgs/UUID goal_id']
+    implicit_input = ['unique_identifier_msgs/UUID action_goal_id']
     message_string = '\n'.join(implicit_input) + '\n' + feedback_message_string
     feedback_msg = parse_message_string(
         pkg_name, action_name + ACTION_FEEDBACK_MESSAGE_SUFFIX, message_string)

--- a/rosidl_adapter/rosidl_adapter/parser.py
+++ b/rosidl_adapter/rosidl_adapter/parser.py
@@ -30,7 +30,7 @@ ACTION_REQUEST_RESPONSE_SEPARATOR = '---'
 ACTION_GOAL_SERVICE_SUFFIX = '_Goal'
 ACTION_RESULT_SERVICE_SUFFIX = '_Result'
 ACTION_FEEDBACK_MESSAGE_SUFFIX = '_Feedback'
-ACTION_IMPLICIT_FIELDS = ['uuid', 'status']
+ACTION_IMPLICIT_FIELDS = ['goal_id', 'status']
 
 PRIMITIVE_TYPES = [
     'bool',
@@ -513,7 +513,7 @@ def parse_message_string(pkg_name, msg_name, message_string):
                 raise ImplicitFieldCollision("Duplicate parameter name '{field_name}' \
                     found processing '{line}' of '{pkg}/{msg}'. \
                     If this resulted from an action definition please \
-                    check for implicit parameter names (uuid, status)".format(
+                    check for implicit parameter names (goal_id, status)".format(
                     field_name=field_name, line=line, pkg=pkg_name, msg=msg_name))
             elif field_name in ACTION_IMPLICIT_FIELDS:
                 action_fields[field_name] += 1
@@ -884,7 +884,7 @@ def parse_action_string(pkg_name, action_name, action_string):
 
     # ---------------------------------------------------------------------------------------------
     # Send goal
-    implicit_input = ['uint8[16] uuid']
+    implicit_input = ['UUID goal_id']
     request_message_string = '\n'.join(implicit_input) + '\n' + goal_service_string
     request_message = parse_message_string(
         pkg_name,
@@ -907,7 +907,7 @@ def parse_action_string(pkg_name, action_name, action_string):
 
     # ---------------------------------------------------------------------------------------------
     # Get result
-    implicit_input = ['uint8[16] uuid']
+    implicit_input = ['UUID goal_id']
     request_message_string = '\n'.join(implicit_input)
     request_message = parse_message_string(
         pkg_name,
@@ -930,7 +930,7 @@ def parse_action_string(pkg_name, action_name, action_string):
 
     # ---------------------------------------------------------------------------------------------
     # Feedback message
-    implicit_input = ['uint8[16] uuid']
+    implicit_input = ['UUID goal_id']
     message_string = '\n'.join(implicit_input) + '\n' + feedback_message_string
     feedback_msg = parse_message_string(
         pkg_name, action_name + ACTION_FEEDBACK_MESSAGE_SUFFIX, message_string)

--- a/rosidl_adapter/test/test_parse_action_string.py
+++ b/rosidl_adapter/test/test_parse_action_string.py
@@ -31,7 +31,7 @@ def test_invalid_action_specification():
 def test_action_implicit_field_collision():
     # uuid collision on send goal service
     with pytest.raises(ImplicitFieldCollision):
-        parse_action_string('pkg', 'Foo', 'bool foo\nstring uuid\n---\nint8 bar\n---\nbool foo')
+        parse_action_string('pkg', 'Foo', 'bool foo\nstring goal_id\n---\nint8 bar\n---\nbool foo')
 
     # status collision on get result service
     with pytest.raises(ImplicitFieldCollision):
@@ -71,8 +71,8 @@ def test_valid_action_string1():
     assert len(result_service.response.constants) == 0
     # Feedback message checks
     assert len(feedback_msg.fields) == 2
-    assert feedback_msg.fields[0].type.type == 'uint8'
-    assert feedback_msg.fields[0].name == 'uuid'
+    assert feedback_msg.fields[0].type.type == 'UUID'
+    assert feedback_msg.fields[0].name == 'goal_id'
     assert feedback_msg.fields[1].type.type == 'bool'
     assert feedback_msg.fields[1].name == 'foo'
     assert len(feedback_msg.constants) == 0
@@ -108,8 +108,8 @@ def test_valid_action_string2():
     assert len(result_service.response.constants) == 0
     # Feedback message checks
     assert len(feedback_msg.fields) == 2
-    assert feedback_msg.fields[0].type.type == 'uint8'
-    assert feedback_msg.fields[0].name == 'uuid'
+    assert feedback_msg.fields[0].type.type == 'UUID'
+    assert feedback_msg.fields[0].name == 'goal_id'
     assert feedback_msg.fields[1].type.type == 'bool'
     assert feedback_msg.fields[1].name == 'foo'
     assert len(feedback_msg.constants) == 0
@@ -150,8 +150,8 @@ def test_valid_action_string3():
     assert result_service.response.constants[0].value
     # Feedback message checks
     assert len(feedback_msg.fields) == 2
-    assert feedback_msg.fields[0].type.type == 'uint8'
-    assert feedback_msg.fields[0].name == 'uuid'
+    assert feedback_msg.fields[0].type.type == 'UUID'
+    assert feedback_msg.fields[0].name == 'goal_id'
     assert feedback_msg.fields[1].type.type == 'bool'
     assert feedback_msg.fields[1].name == 'foo'
     assert len(feedback_msg.constants) == 1

--- a/rosidl_adapter/test/test_parse_action_string.py
+++ b/rosidl_adapter/test/test_parse_action_string.py
@@ -31,11 +31,13 @@ def test_invalid_action_specification():
 def test_action_implicit_field_collision():
     # uuid collision on send goal service
     with pytest.raises(ImplicitFieldCollision):
-        parse_action_string('pkg', 'Foo', 'bool foo\nstring goal_id\n---\nint8 bar\n---\nbool foo')
+        parse_action_string(
+            'pkg', 'Foo', 'bool foo\nstring action_goal_id\n---\nint8 bar\n---\nbool foo')
 
     # status collision on get result service
     with pytest.raises(ImplicitFieldCollision):
-        parse_action_string('pkg', 'Foo', 'bool foo\n---\nint8 bar\nstring status\n---\nbool foo')
+        parse_action_string(
+            'pkg', 'Foo', 'bool foo\n---\nint8 bar\nstring action_status\n---\nbool foo')
 
 
 def test_valid_action_string():
@@ -72,7 +74,7 @@ def test_valid_action_string1():
     # Feedback message checks
     assert len(feedback_msg.fields) == 2
     assert feedback_msg.fields[0].type.type == 'UUID'
-    assert feedback_msg.fields[0].name == 'goal_id'
+    assert feedback_msg.fields[0].name == 'action_goal_id'
     assert feedback_msg.fields[1].type.type == 'bool'
     assert feedback_msg.fields[1].name == 'foo'
     assert len(feedback_msg.constants) == 0
@@ -109,7 +111,7 @@ def test_valid_action_string2():
     # Feedback message checks
     assert len(feedback_msg.fields) == 2
     assert feedback_msg.fields[0].type.type == 'UUID'
-    assert feedback_msg.fields[0].name == 'goal_id'
+    assert feedback_msg.fields[0].name == 'action_goal_id'
     assert feedback_msg.fields[1].type.type == 'bool'
     assert feedback_msg.fields[1].name == 'foo'
     assert len(feedback_msg.constants) == 0
@@ -151,7 +153,7 @@ def test_valid_action_string3():
     # Feedback message checks
     assert len(feedback_msg.fields) == 2
     assert feedback_msg.fields[0].type.type == 'UUID'
-    assert feedback_msg.fields[0].name == 'goal_id'
+    assert feedback_msg.fields[0].name == 'action_goal_id'
     assert feedback_msg.fields[1].type.type == 'bool'
     assert feedback_msg.fields[1].name == 'foo'
     assert len(feedback_msg.constants) == 1

--- a/rosidl_cmake/cmake/rosidl_generate_action_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_generate_action_interfaces.cmake
@@ -72,8 +72,11 @@ macro(rosidl_generate_action_interfaces target)
   list_append_unique(_ARG_RGAI_DEPENDENCY_PACKAGE_NAMES "action_msgs")
   # downstream packages need to depend on builtin_interfaces for builtin_interfaces/Time
   list_append_unique(_ARG_RGAI_DEPENDENCY_PACKAGE_NAMES "builtin_interfaces")
+  # downstream packages need to depend on unique_identifier_msgs for unique_identifier_msgs/UUID
+  list_append_unique(_ARG_RGAI_DEPENDENCY_PACKAGE_NAMES "unique_identifier_msgs")
   ament_export_dependencies(action_msgs)
   ament_export_dependencies(builtin_interfaces)
+  ament_export_dependencies(unique_identifier_msgs)
 
   # A target name that generators may want to use to prefix their own target names
   set(rosidl_generate_action_interfaces_TARGET ${target})


### PR DESCRIPTION
This PR is part of a series of three that together close https://github.com/ros2/rcl_interfaces/issues/49
EDIT: Depends on https://github.com/ros2/ros2/pull/609
- Update rcl_action to make use of uuid field in GoalInfo.msg
- Make use of unique_identifier_msgs/uuid in parser.py
- Fixe test_parse_action_string.py test

Connects to ros2/rcl_interfaces#49
blocked by ros2/rosidl#298
requires ros2/rcl_interfaces#54