### PR TITLE
fix CMake warning installing generated .idl files on Windows

### DIFF
--- a/rosidl_adapter/rosidl_adapter/main.py
+++ b/rosidl_adapter/rosidl_adapter/main.py
@@ -14,6 +14,7 @@
 
 import argparse
 import json
+import os
 import pathlib
 import sys
 
@@ -57,4 +58,7 @@ def main(argv=sys.argv[1:]):
     output_file.parent.mkdir(exist_ok=True)
     with output_file.open('w') as h:
         for basepath, relative_path in idl_tuples:
-            h.write('{basepath}:{relative_path}\n'.format_map(locals()))
+            line = '{basepath}:{relative_path}\n'.format_map(locals())
+            # use CMake friendly separator
+            line = line.replace(os.sep, '/')
+            h.write(line)


### PR DESCRIPTION
On Windows the paths of the generated `.idl` files will contain backslashes which are not CMake friendly if not escaped. An example warning without this patch (from https://ci.ros2.org/job/ci_windows/5585/):

```
CMake Warning (dev) at cmake_install.cmake:451 (file):
  Syntax error in cmake code at

    C:/J/workspace/ci_windows/ws/build/builtin_interfaces/cmake_install.cmake:451

  when parsing string

    C:\J\workspace\ci_windows\ws\build\builtin_interfaces\rosidl_adapter\builtin_interfaces/msg\Duration.idl

  Invalid escape sequence \J

  Policy CMP0010 is not set: Bad variable reference syntax is an error.  Run
  "cmake --help-policy CMP0010" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
```

With this patch the warning is gone: https://ci.ros2.org/job/ci_windows/5588/