### PR TITLE
Reduces action interfaces CMake target name length to please Windows.

### DIFF
--- a/rosidl_cmake/cmake/rosidl_generate_action_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_generate_action_interfaces.cmake
@@ -58,7 +58,7 @@ macro(rosidl_generate_action_interfaces target)
   set(_rgai_idl_files ${_ARG_RGAI_UNPARSED_ARGUMENTS})
 
   # Create a custom target
-  set(_rgai_sub_target "${target}+generate_action_interfaces")
+  set(_rgai_sub_target "${target}+generate_actions")
   add_custom_target(
     ${_rgai_sub_target} ALL
     DEPENDS

--- a/rosidl_generator_c/cmake/rosidl_generator_c_generate_action_interfaces.cmake
+++ b/rosidl_generator_c/cmake/rosidl_generator_c_generate_action_interfaces.cmake
@@ -66,7 +66,7 @@ foreach(dep ${target_dependencies})
   endif()
 endforeach()
 
-set(generator_arguments_file "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_c__generate_action_interfaces__arguments.json")
+set(generator_arguments_file "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_c__gen_actions__arguments.json")
 rosidl_write_generator_arguments(
   "${generator_arguments_file}"
   PACKAGE_NAME "${PROJECT_NAME}"
@@ -128,13 +128,13 @@ if(BUILD_TESTING AND rosidl_generate_action_interfaces_ADD_LINTER_TESTS)
   if(NOT _generated_files STREQUAL "")
     find_package(ament_cmake_cppcheck REQUIRED)
     ament_cppcheck(
-      TESTNAME "cppcheck_rosidl_generator_c_generate_action_interfaces"
+      TESTNAME "cppcheck_rosidl_generator_c_gen_actions"
       "${_output_path}")
 
     find_package(ament_cmake_cpplint REQUIRED)
     get_filename_component(_cpplint_root "${_output_path}" DIRECTORY)
     ament_cpplint(
-      TESTNAME "cpplint_rosidl_generator_c_generate_action_interfaces"
+      TESTNAME "cpplint_rosidl_generator_c_gen_actions"
       # the generated code might contain longer lines for templated types
       MAX_LINE_LENGTH 999
       ROOT "${_cpplint_root}"
@@ -142,7 +142,7 @@ if(BUILD_TESTING AND rosidl_generate_action_interfaces_ADD_LINTER_TESTS)
 
     find_package(ament_cmake_uncrustify REQUIRED)
     ament_uncrustify(
-      TESTNAME "uncrustify_rosidl_generator_c_generate_action_interfaces"
+      TESTNAME "uncrustify_rosidl_generator_c_gen_actions"
       # the generated code might contain longer lines for templated types
       MAX_LINE_LENGTH 999
       "${_output_path}")

--- a/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_action_interfaces.cmake
+++ b/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_action_interfaces.cmake
@@ -66,7 +66,7 @@ foreach(dep ${target_dependencies})
   endif()
 endforeach()
 
-set(generator_arguments_file "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp__generate_action_interfaces__arguments.json")
+set(generator_arguments_file "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp__generate_actions__arguments.json")
 rosidl_write_generator_arguments(
   "${generator_arguments_file}"
   PACKAGE_NAME "${PROJECT_NAME}"
@@ -117,13 +117,13 @@ if(BUILD_TESTING AND rosidl_generate_action_interfaces_ADD_LINTER_TESTS)
   if(NOT _generated_files STREQUAL "")
     find_package(ament_cmake_cppcheck REQUIRED)
     ament_cppcheck(
-      TESTNAME "cppcheck_rosidl_generator_cpp_generate_action_interfaces"
+      TESTNAME "cppcheck_rosidl_generator_cpp_generate_actions"
       "${_output_path}")
 
     find_package(ament_cmake_cpplint REQUIRED)
     get_filename_component(_cpplint_root "${_output_path}" DIRECTORY)
     ament_cpplint(
-      TESTNAME "cpplint_rosidl_generator_cpp_generate_action_interfaces"
+      TESTNAME "cpplint_rosidl_generator_cpp_generate_actions"
       # the generated code might contain longer lines for templated types
       MAX_LINE_LENGTH 999
       ROOT "${_cpplint_root}"
@@ -131,7 +131,7 @@ if(BUILD_TESTING AND rosidl_generate_action_interfaces_ADD_LINTER_TESTS)
 
     find_package(ament_cmake_uncrustify REQUIRED)
     ament_uncrustify(
-      TESTNAME "uncrustify_rosidl_generator_cpp_generate_action_interfaces"
+      TESTNAME "uncrustify_rosidl_generator_cpp_generate_actions"
       # the generated code might contain longer lines for templated types
       MAX_LINE_LENGTH 999
       "${_output_path}")


### PR DESCRIPTION
Fixes ros2/build_cop#154. Had to reduce the name length for action targets a bit. I did so everywhere for consistency.