### PR TITLE
Group message initializations by their appropriate checks

### DIFF
--- a/rosidl_generator_cpp/resource/msg__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.em
@@ -206,30 +206,30 @@ non_defaulted_zero_initialized_members = [
     if (rosidl_generator_cpp::MessageInitialization::ALL == _init ||
       rosidl_generator_cpp::MessageInitialization::DEFAULTS_ONLY == _init)
     {
-@[for membset in default_value_members]@
-@[  for line in generate_default_string(membset)]@
-      @(line)
-@[  end for]@
-@[end for]@
-@[if zero_value_members]@
-    } else if (rosidl_generator_cpp::MessageInitialization::ZERO == _init) {
-@[  for membset in zero_value_members]@
-@[    for line in generate_zero_string(membset, '_alloc, _init')]@
+@[  for membset in default_value_members]@
+@[    for line in generate_default_string(membset)]@
       @(line)
 @[    end for]@
 @[  end for]@
-@[end if]@
+@[  if zero_value_members]@
+    } else if (rosidl_generator_cpp::MessageInitialization::ZERO == _init) {
+@[    for membset in zero_value_members]@
+@[      for line in generate_zero_string(membset, '_alloc, _init')]@
+      @(line)
+@[      end for]@
+@[    end for]@
+@[  end if]@
     }
 @[end if]@
 @[if non_defaulted_zero_initialized_members]@
     if (rosidl_generator_cpp::MessageInitialization::ALL == _init ||
       rosidl_generator_cpp::MessageInitialization::ZERO == _init)
     {
-@[for membset in non_defaulted_zero_initialized_members]@
-@[  for line in generate_zero_string(membset, '_alloc, _init')]@
+@[  for membset in non_defaulted_zero_initialized_members]@
+@[    for line in generate_zero_string(membset, '_alloc, _init')]@
       @(line)
+@[    end for]@
 @[  end for]@
-@[end for]@
     }
 @[end if]@
   }

--- a/rosidl_generator_cpp/resource/msg__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.em
@@ -150,25 +150,25 @@ def generate_zero_string(membset, fill_args):
     (void)_init;
 @[end if]@
 @{
-members_if_all_defaults = [m for m in member_list if m.members[0].default_value]
-members_else_if_zero = [m for m in member_list if m.members[0].zero_value]
-members_if_all_zero = [
-    m for m in member_list if  (m.members[0].zero_value or m.members[0].zero_need_array_override)
-    and not m.members[0].default_value
+default_value_members = [m for m in member_list if m.members[0].default_value]
+zero_value_members = [m for m in member_list if m.members[0].zero_value]
+non_defaulted_zero_initialized_members = [
+    m for m in member_list
+    if (m.members[0].zero_value or m.members[0].zero_need_array_override) and not m.members[0].default_value
 ]
 }@
-@[if members_if_all_defaults]@
+@[if default_value_members]@
     if (rosidl_generator_cpp::MessageInitialization::ALL == _init ||
       rosidl_generator_cpp::MessageInitialization::DEFAULTS_ONLY == _init)
     {
-@[  for membset in members_if_all_defaults]@
+@[  for membset in default_value_members]@
 @[    for line in generate_default_string(membset)]@
       @(line)
 @[    end for]@
 @[  end for]@
-@[  if members_else_if_zero]@
+@[  if zero_value_members]@
     } else if (rosidl_generator_cpp::MessageInitialization::ZERO == _init) {
-@[    for membset in members_else_if_zero]@
+@[    for membset in zero_value_members]@
 @[     for line in generate_zero_string(membset, '_init')]@
       @(line)
 @[     end for]@
@@ -176,11 +176,11 @@ members_if_all_zero = [
 @[  end if]@
     }
 @[  end if]@
-@[  if members_if_all_zero]@
+@[  if non_defaulted_zero_initialized_members]@
     if (rosidl_generator_cpp::MessageInitialization::ALL == _init ||
       rosidl_generator_cpp::MessageInitialization::ZERO == _init)
     {
-@[  for membset in members_if_all_zero]@
+@[  for membset in non_defaulted_zero_initialized_members]@
 @[    for line in generate_zero_string(membset, '_init')]@
 @[      if line]@
       @(line)
@@ -202,30 +202,30 @@ members_if_all_zero = [
 @[if not alloc_list]@
     (void)_alloc;
 @[end if]@
-@[if members_if_all_defaults]@
+@[if default_value_members]@
     if (rosidl_generator_cpp::MessageInitialization::ALL == _init ||
       rosidl_generator_cpp::MessageInitialization::DEFAULTS_ONLY == _init)
     {
-@[for membset in members_if_all_defaults]@
+@[for membset in default_value_members]@
 @[  for line in generate_default_string(membset)]@
       @(line)
 @[  end for]@
 @[end for]@
-@[if members_else_if_zero]@
+@[if zero_value_members]@
     } else if (rosidl_generator_cpp::MessageInitialization::ZERO == _init) {
-@[  for membset in members_else_if_zero]@
-@[   for line in generate_zero_string(membset, '_alloc, _init')]@
+@[  for membset in zero_value_members]@
+@[    for line in generate_zero_string(membset, '_alloc, _init')]@
       @(line)
-@[   end for]@
+@[    end for]@
 @[  end for]@
 @[end if]@
     }
 @[end if]@
-@[if members_if_all_zero]@
+@[if non_defaulted_zero_initialized_members]@
     if (rosidl_generator_cpp::MessageInitialization::ALL == _init ||
       rosidl_generator_cpp::MessageInitialization::ZERO == _init)
     {
-@[for membset in members_if_all_zero]@
+@[for membset in non_defaulted_zero_initialized_members]@
 @[  for line in generate_zero_string(membset, '_alloc, _init')]@
       @(line)
 @[  end for]@

--- a/rosidl_generator_cpp/resource/msg__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.em
@@ -169,9 +169,9 @@ non_defaulted_zero_initialized_members = [
 @[  if zero_value_members]@
     } else if (rosidl_generator_cpp::MessageInitialization::ZERO == _init) {
 @[    for membset in zero_value_members]@
-@[     for line in generate_zero_string(membset, '_init')]@
+@[      for line in generate_zero_string(membset, '_init')]@
       @(line)
-@[     end for]@
+@[      end for]@
 @[    end for]@
 @[  end if]@
     }

--- a/rosidl_generator_cpp/resource/msg__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.em
@@ -149,31 +149,46 @@ def generate_zero_string(membset, fill_args):
 @[if not member_list]@
     (void)_init;
 @[end if]@
-@[for membset in member_list]@
-@[ if membset.members[0].default_value is not None]@
+@{
+members_if_all_defaults = [m for m in member_list if m.members[0].default_value]
+members_else_if_zero = [m for m in member_list if m.members[0].zero_value]
+members_if_all_zero = [
+    m for m in member_list if  (m.members[0].zero_value or m.members[0].zero_need_array_override)
+    and not m.members[0].default_value
+]
+}@
+@[if members_if_all_defaults]@
     if (rosidl_generator_cpp::MessageInitialization::ALL == _init ||
       rosidl_generator_cpp::MessageInitialization::DEFAULTS_ONLY == _init)
     {
+@[for membset in members_if_all_defaults]@
 @[  for line in generate_default_string(membset)]@
       @(line)
 @[  end for]@
-@[  if membset.members[0].zero_value is not None]@
+@[end for]@
+@[if members_else_if_zero]@
     } else if (rosidl_generator_cpp::MessageInitialization::ZERO == _init) {
+@[  for membset in members_else_if_zero]@
 @[   for line in generate_zero_string(membset, '_init')]@
       @(line)
 @[   end for]@
-@[  end if]@
+@[  end for]@
+@[end if]@
     }
-@[ elif membset.members[0].zero_value is not None]@
+@[end if]@
+@[if members_if_all_zero]@
     if (rosidl_generator_cpp::MessageInitialization::ALL == _init ||
       rosidl_generator_cpp::MessageInitialization::ZERO == _init)
     {
+@[for membset in members_if_all_zero]@
 @[  for line in generate_zero_string(membset, '_init')]@
+@[    if line]@
       @(line)
+@[  end if]@
 @[  end for]@
-    }
-@[ end if]@
 @[end for]@
+    }
+@[end if]@
   }
 
   explicit @(message.structure.type.name)_(const ContainerAllocator & _alloc, rosidl_generator_cpp::MessageInitialization _init = rosidl_generator_cpp::MessageInitialization::ALL)
@@ -187,31 +202,36 @@ def generate_zero_string(membset, fill_args):
 @[if not alloc_list]@
     (void)_alloc;
 @[end if]@
-@[for membset in member_list]@
-@[ if membset.members[0].default_value is not None]@
+@[if members_if_all_defaults]@
     if (rosidl_generator_cpp::MessageInitialization::ALL == _init ||
       rosidl_generator_cpp::MessageInitialization::DEFAULTS_ONLY == _init)
     {
+@[for membset in members_if_all_defaults]@
 @[  for line in generate_default_string(membset)]@
       @(line)
 @[  end for]@
-@[  if membset.members[0].zero_value is not None]@
+@[end for]@
+@[if members_else_if_zero]@
     } else if (rosidl_generator_cpp::MessageInitialization::ZERO == _init) {
+@[  for membset in members_else_if_zero]@
 @[   for line in generate_zero_string(membset, '_alloc, _init')]@
       @(line)
 @[   end for]@
-@[  end if]@
+@[  end for]@
+@[end if]@
     }
-@[ elif membset.members[0].zero_value is not None]@
+@[end if]@
+@[if members_if_all_zero]@
     if (rosidl_generator_cpp::MessageInitialization::ALL == _init ||
       rosidl_generator_cpp::MessageInitialization::ZERO == _init)
     {
+@[for membset in members_if_all_zero]@
 @[  for line in generate_zero_string(membset, '_alloc, _init')]@
       @(line)
 @[  end for]@
-    }
-@[ end if]@
 @[end for]@
+    }
+@[end if]@
   }
 
   // field types and members

--- a/rosidl_generator_cpp/resource/msg__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.em
@@ -161,32 +161,32 @@ members_if_all_zero = [
     if (rosidl_generator_cpp::MessageInitialization::ALL == _init ||
       rosidl_generator_cpp::MessageInitialization::DEFAULTS_ONLY == _init)
     {
-@[for membset in members_if_all_defaults]@
-@[  for line in generate_default_string(membset)]@
+@[  for membset in members_if_all_defaults]@
+@[    for line in generate_default_string(membset)]@
       @(line)
+@[    end for]@
 @[  end for]@
-@[end for]@
-@[if members_else_if_zero]@
+@[  if members_else_if_zero]@
     } else if (rosidl_generator_cpp::MessageInitialization::ZERO == _init) {
-@[  for membset in members_else_if_zero]@
-@[   for line in generate_zero_string(membset, '_init')]@
+@[    for membset in members_else_if_zero]@
+@[     for line in generate_zero_string(membset, '_init')]@
       @(line)
-@[   end for]@
-@[  end for]@
-@[end if]@
+@[     end for]@
+@[    end for]@
+@[  end if]@
     }
-@[end if]@
-@[if members_if_all_zero]@
+@[  end if]@
+@[  if members_if_all_zero]@
     if (rosidl_generator_cpp::MessageInitialization::ALL == _init ||
       rosidl_generator_cpp::MessageInitialization::ZERO == _init)
     {
-@[for membset in members_if_all_zero]@
-@[  for line in generate_zero_string(membset, '_init')]@
-@[    if line]@
+@[  for membset in members_if_all_zero]@
+@[    for line in generate_zero_string(membset, '_init')]@
+@[      if line]@
       @(line)
-@[  end if]@
+@[      end if]@
+@[    end for]@
 @[  end for]@
-@[end for]@
     }
 @[end if]@
   }


### PR DESCRIPTION
I was going through message generation, and found that there were several redundant checks on message initialization.

This clears it up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ros2/rosidl/350)
<!-- Reviewable:end -->
