### PR TITLE
change setters to return reference

### DIFF
--- a/rosidl_generator_cpp/resource/msg__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.em
@@ -223,11 +223,11 @@ def generate_zero_string(membset, fill_args):
 
   // setters for named parameter idiom
 @[for member in message.structure.members]@
-  Type * set__@(member.name)(
+  Type & set__@(member.name)(
     const @(msg_type_to_cpp(member.type)) & _arg)
   {
     this->@(member.name) = _arg;
-    return this;
+    return *this;
   }
 @[end for]@
 


### PR DESCRIPTION
Implements #349.

Looking at the named parameter idiom and how it is commonly implemented I only found cases where a reference is returned:

* https://isocpp.org/wiki/faq/ctors#named-parameter-idiom
* https://en.wikibooks.org/wiki/More_C%2B%2B_Idioms/Named_Parameter

Another advantage over returning a pointer is that it clarifies that the returned value is never a `nullptr`.

* Linux with FastRTPS: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=6395)](https://ci.ros2.org/job/ci_linux/6395/)