### PR TITLE
Add message namespace to MessageMembers struct

### DIFF
--- a/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/message_introspection.h
+++ b/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/message_introspection.h
@@ -43,6 +43,7 @@ typedef struct rosidl_typesupport_introspection_c__MessageMember
 typedef struct rosidl_typesupport_introspection_c__MessageMembers
 {
   const char * package_name_;
+  const char * message_namespace_;
   const char * message_name_;
   uint32_t member_count_;
   size_t size_of_;

--- a/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/message_introspection.h
+++ b/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/message_introspection.h
@@ -42,7 +42,6 @@ typedef struct rosidl_typesupport_introspection_c__MessageMember
 
 typedef struct rosidl_typesupport_introspection_c__MessageMembers
 {
-  const char * package_name_;
   const char * message_namespace_;
   const char * message_name_;
   uint32_t member_count_;

--- a/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/service_introspection.h
+++ b/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/service_introspection.h
@@ -25,7 +25,7 @@
 
 typedef struct rosidl_typesupport_introspection_c__ServiceMembers
 {
-  const char * package_name_;
+  const char * service_namespace_;
   const char * service_name_;
   const rosidl_typesupport_introspection_c__MessageMembers * request_members_;
   const rosidl_typesupport_introspection_c__MessageMembers * response_members_;

--- a/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
+++ b/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
@@ -235,8 +235,7 @@ for index, member in enumerate(message.structure.members):
 };
 
 static const rosidl_typesupport_introspection_c__MessageMembers @(function_prefix)__@(message.structure.namespaced_type.name)_message_members = {
-  "@(package_name)",  // package name
-  "@('__'.join(list(interface_path.parents[0].parts)))",  // message namespace
+  "@('__'.join([package_name] + list(interface_path.parents[0].parts)))",  // message namespace
   "@(message.structure.namespaced_type.name)",  // message name
   @(len(message.structure.members)),  // number of fields
   sizeof(@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))),

--- a/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
+++ b/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
@@ -236,6 +236,7 @@ for index, member in enumerate(message.structure.members):
 
 static const rosidl_typesupport_introspection_c__MessageMembers @(function_prefix)__@(message.structure.namespaced_type.name)_message_members = {
   "@(package_name)",  // package name
+  "@('__'.join(list(interface_path.parents[0].parts)))",  // message namespace
   "@(message.structure.namespaced_type.name)",  // message name
   @(len(message.structure.members)),  // number of fields
   sizeof(@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))),

--- a/rosidl_typesupport_introspection_c/resource/srv__type_support.c.em
+++ b/rosidl_typesupport_introspection_c/resource/srv__type_support.c.em
@@ -41,7 +41,7 @@ function_prefix = '__'.join(include_parts) + '__rosidl_typesupport_introspection
 
 // this is intentionally not const to allow initialization later to prevent an initialization race
 static rosidl_typesupport_introspection_c__ServiceMembers @(function_prefix)__@(service.namespaced_type.name)_service_members = {
-  "@(package_name)",  // package name
+  "@('__'.join([package_name] + list(interface_path.parents[0].parts)))",  // service namespace
   "@(service.namespaced_type.name)",  // service name
   // these two fields are initialized below on the first access
   NULL,  // request message

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/message_introspection.hpp
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/message_introspection.hpp
@@ -45,6 +45,7 @@ typedef struct ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC MessageMember
 typedef struct ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC MessageMembers
 {
   const char * package_name_;
+  const char * message_namespace_;
   const char * message_name_;
   uint32_t member_count_;
   size_t size_of_;

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/message_introspection.hpp
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/message_introspection.hpp
@@ -44,7 +44,6 @@ typedef struct ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC MessageMember
 
 typedef struct ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC MessageMembers
 {
-  const char * package_name_;
   const char * message_namespace_;
   const char * message_name_;
   uint32_t member_count_;

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/service_introspection.hpp
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/service_introspection.hpp
@@ -28,7 +28,7 @@ namespace rosidl_typesupport_introspection_cpp
 
 typedef struct ServiceMembers
 {
-  const char * package_name_;
+  const char * service_namespace_;
   const char * service_name_;
   const MessageMembers * request_members_;
   const MessageMembers * response_members_;

--- a/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
@@ -183,6 +183,7 @@ for index, member in enumerate(message.structure.members):
 
 static const ::rosidl_typesupport_introspection_cpp::MessageMembers @(message.structure.namespaced_type.name)_message_members = {
   "@(package_name)",  // package name
+  "@('::'.join(list(interface_path.parents[0].parts)))",  // message namespace
   "@(message.structure.namespaced_type.name)",  // message name
   @(len(message.structure.members)),  // number of fields
   sizeof(@('::'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))),

--- a/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
@@ -182,8 +182,7 @@ for index, member in enumerate(message.structure.members):
 };
 
 static const ::rosidl_typesupport_introspection_cpp::MessageMembers @(message.structure.namespaced_type.name)_message_members = {
-  "@(package_name)",  // package name
-  "@('::'.join(list(interface_path.parents[0].parts)))",  // message namespace
+  "@('::'.join([package_name] + list(interface_path.parents[0].parts)))",  // message namespace
   "@(message.structure.namespaced_type.name)",  // message name
   @(len(message.structure.members)),  // number of fields
   sizeof(@('::'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))),

--- a/rosidl_typesupport_introspection_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_introspection_cpp/resource/srv__type_support.cpp.em
@@ -52,7 +52,7 @@ namespace rosidl_typesupport_introspection_cpp
 
 // this is intentionally not const to allow initialization later to prevent an initialization race
 static ::rosidl_typesupport_introspection_cpp::ServiceMembers @(service.namespaced_type.name)_service_members = {
-  "@(package_name)",  // package name
+  "@('::'.join([package_name] + list(interface_path.parents[0].parts)))",  // service namespace
   "@(service.namespaced_type.name)",  // service name
   // these two fields are initialized below on the first access
   // see get_service_type_support_handle<@('::'.join([package_name] + list(interface_path.parents[0].parts) + [service.namespaced_type.name]))>()


### PR DESCRIPTION
The message namespace is useful in rmw implementations for reconstructing the full name of message types.

Connects to ros2/ros2#677