### PR TITLE
avoid mangling of typesupport introspection symbols

### DIFF
--- a/rosidl_typesupport_introspection_cpp/resource/msg__rosidl_typesupport_introspection_cpp.hpp.em
+++ b/rosidl_typesupport_introspection_cpp/resource/msg__rosidl_typesupport_introspection_cpp.hpp.em
@@ -16,7 +16,16 @@ header_files = [
 #include "@(header_file)"
 @[end for]@
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 // TODO(dirk-thomas) these visibility macros should be message package specific
 ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC
 const rosidl_message_type_support_t *
   ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_cpp, @(', '.join([package_name] + list(interface_path.parents[0].parts))), @(message.structure.type.name))();
+
+#ifdef __cplusplus
+}
+#endif

--- a/rosidl_typesupport_introspection_cpp/resource/srv__rosidl_typesupport_introspection_cpp.hpp.em
+++ b/rosidl_typesupport_introspection_cpp/resource/srv__rosidl_typesupport_introspection_cpp.hpp.em
@@ -30,6 +30,15 @@ header_files = [
 #include "@(header_file)"
 @[end for]@
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC
 const rosidl_service_type_support_t *
   ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(rosidl_typesupport_introspection_cpp, @(', '.join([package_name] + list(interface_path.parents[0].parts))), @(service.structure_type.name))();
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Fixes ros2/rcl_interfaces#69.

[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=6732)](https://ci.ros2.org/job/ci_linux/6732/)