### PR TITLE
simplify code using updated definition API

### DIFF
--- a/rosidl_generator_c/resource/action__type_support.h.em
+++ b/rosidl_generator_c/resource/action__type_support.h.em
@@ -13,7 +13,7 @@ ROSIDL_GENERATOR_C_PUBLIC_@(package_name)
 const rosidl_action_type_support_t *
   ROSIDL_TYPESUPPORT_INTERFACE__ACTION_SYMBOL_NAME(
   rosidl_typesupport_c,
-  @(',\n  '.join(action.namespaced_type.namespaces + [action.namespaced_type.name]))
+  @(',\n  '.join(action.namespaced_type.namespaced_name()))
 )();
 
 @{

--- a/rosidl_generator_c/resource/msg__functions.c.em
+++ b/rosidl_generator_c/resource/msg__functions.c.em
@@ -101,7 +101,7 @@ for member in message.structure.members:
                 # set default value for each array element
                 for i, default_value in enumerate(literal_eval(member.get_annotation_value('default')['value'])):
                     lines.append('msg->%s[%d] = %s;' % (member.name, i, value_to_c(member.type.value_type, default_value)))
-        elif isinstance(member.type.value_type, AbstractGenericString) or isinstance(member.type.value_type, NamespacedType): 
+        elif isinstance(member.type.value_type, (AbstractGenericString, NamespacedType)):
             # initialize each array element
             lines.append('for (size_t i = 0; i < %d; ++i) {' % member.type.size)
             lines.append('  if (!%s__init(&msg->%s[i])) {' % (basetype_to_c(member.type.value_type), member.name))
@@ -225,7 +225,7 @@ lines = []
 for member in message.structure.members:
     lines.append('// ' + member.name)
     if isinstance(member.type, Array):
-        if isinstance(member.type.value_type, AbstractGenericString) or isinstance(member.type.value_type, NamespacedType):
+        if isinstance(member.type.value_type, (AbstractGenericString, NamespacedType)):
             lines.append('for (size_t i = 0; i < %d; ++i) {' % member.type.size)
             # initialize each array element
             lines.append('  %s__fini(&msg->%s[i]);' % (basetype_to_c(member.type.value_type), member.name))

--- a/rosidl_generator_c/resource/msg__struct.h.em
+++ b/rosidl_generator_c/resource/msg__struct.h.em
@@ -6,8 +6,13 @@ from rosidl_parser.definition import AbstractSequence
 from rosidl_parser.definition import AbstractString
 from rosidl_parser.definition import AbstractWString
 from rosidl_parser.definition import BasicType
+from rosidl_parser.definition import BOOLEAN_TYPE
 from rosidl_parser.definition import BoundedSequence
+from rosidl_parser.definition import CHARACTER_TYPES
+from rosidl_parser.definition import FLOATING_POINT_TYPES
+from rosidl_parser.definition import INTEGER_TYPES
 from rosidl_parser.definition import NamespacedType
+from rosidl_parser.definition import OCTET_TYPE
 from rosidl_generator_c import basetype_to_c
 from rosidl_generator_c import idl_declaration_to_c
 from rosidl_generator_c import idl_structure_type_sequence_to_c_typename
@@ -62,15 +67,13 @@ for member in message.structure.members:
 /// Constant '@(constant.name)'.
 @[    if isinstance(constant.type, BasicType)]@
 @[        if constant.type.typename in (
-              'short', 'unsigned short', 'long', 'unsigned long', 'long long', 'unsigned long long',
-              'char', 'wchar', 'octet',
-              'int8', 'uint8', 'int16', 'uint16', 'int32', 'uint32', 'int64', 'uint64',
-          )]@
+                *INTEGER_TYPES, *CHARACTER_TYPES, OCTET_TYPE
+        )]@
 enum
 {
   @(idl_structure_type_to_c_typename(message.structure.namespaced_type))__@(constant.name) = @(value_to_c(constant.type, constant.value))
 };
-@[        elif constant.type.typename in ('float', 'double', 'long double', 'boolean')]@
+@[        elif constant.type.typename in (*FLOATING_POINT_TYPES, BOOLEAN_TYPE)]@
 static const @(basetype_to_c(constant.type)) @(idl_structure_type_to_c_typename(message.structure.namespaced_type))__@(constant.name) = @(value_to_c(constant.type, constant.value));
 @[        else]@
 @{assert False, 'Unhandled basic type: ' + str(constant.type)}@

--- a/rosidl_generator_c/resource/msg__type_support.h.em
+++ b/rosidl_generator_c/resource/msg__type_support.h.em
@@ -13,5 +13,5 @@ ROSIDL_GENERATOR_C_PUBLIC_@(package_name)
 const rosidl_message_type_support_t *
   ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
   rosidl_typesupport_c,
-  @(',\n  '.join(message.structure.namespaced_type.namespaces + [message.structure.namespaced_type.name]))
+  @(',\n  '.join(message.structure.namespaced_type.namespaced_name()))
 )();

--- a/rosidl_generator_c/resource/srv__type_support.h.em
+++ b/rosidl_generator_c/resource/srv__type_support.h.em
@@ -27,5 +27,5 @@ ROSIDL_GENERATOR_C_PUBLIC_@(package_name)
 const rosidl_service_type_support_t *
   ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(
   rosidl_typesupport_c,
-  @(',\n  '.join(service.namespaced_type.namespaces + [service.namespaced_type.name]))
+  @(',\n  '.join(service.namespaced_type.namespaced_name()))
 )();

--- a/rosidl_generator_c/rosidl_generator_c/__init__.py
+++ b/rosidl_generator_c/rosidl_generator_c/__init__.py
@@ -21,7 +21,11 @@ from rosidl_parser.definition import AbstractType
 from rosidl_parser.definition import AbstractWString
 from rosidl_parser.definition import Array
 from rosidl_parser.definition import BasicType
+from rosidl_parser.definition import CHARACTER_TYPES
 from rosidl_parser.definition import NamespacedType
+from rosidl_parser.definition import OCTET_TYPE
+from rosidl_parser.definition import SIGNED_INTEGER_TYPES
+from rosidl_parser.definition import UNSIGNED_INTEGER_TYPES
 
 
 def generate_c(generator_arguments_file):
@@ -57,11 +61,11 @@ BASIC_IDL_TYPES_TO_C = {
 def idl_structure_type_to_c_include_prefix(namespaced_type):
     return '/'.join(
         convert_camel_case_to_lower_case_underscore(x)
-        for x in (namespaced_type.namespaces + [namespaced_type.name]))
+        for x in (namespaced_type.namespaced_name()))
 
 
 def idl_structure_type_to_c_typename(namespaced_type):
-    return '__'.join(namespaced_type.namespaces + [namespaced_type.name])
+    return '__'.join(namespaced_type.namespaced_name())
 
 
 def idl_structure_type_sequence_to_c_typename(namespaced_type):
@@ -134,17 +138,10 @@ def basic_value_to_c(type_, value):
     if 'boolean' == type_.typename:
         return 'true' if value else 'false'
 
-    if type_.typename in (
-        'short', 'long', 'long long',
-        'char', 'wchar', 'octet',
-        'int8', 'int16', 'int32', 'int64',
-    ):
+    if type_.typename in (*SIGNED_INTEGER_TYPES, *CHARACTER_TYPES, OCTET_TYPE):
         return str(value)
 
-    if type_.typename in (
-        'unsigned short', 'unsigned long', 'unsigned long long',
-        'uint8', 'uint16', 'uint32', 'uint64',
-    ):
+    if type_.typename in UNSIGNED_INTEGER_TYPES:
         return str(value) + 'u'
 
     if 'float' == type_.typename:

--- a/rosidl_generator_cpp/resource/action__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/action__struct.hpp.em
@@ -11,7 +11,7 @@ action_includes = (
     'action_msgs/msg/goal_info.hpp',
     'action_msgs/msg/goal_status_array.hpp',
 )
-action_name = '::'.join(action.namespaced_type.namespaces + [action.namespaced_type.name])
+action_name = '::'.join(action.namespaced_type.namespaced_name())
 }@
 @{
 TEMPLATE(

--- a/rosidl_generator_cpp/resource/msg__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.em
@@ -21,9 +21,14 @@ from rosidl_parser.definition import ACTION_FEEDBACK_SUFFIX
 from rosidl_parser.definition import ACTION_GOAL_SUFFIX
 from rosidl_parser.definition import ACTION_RESULT_SUFFIX
 from rosidl_parser.definition import BasicType
+from rosidl_parser.definition import BOOLEAN_TYPE
+from rosidl_parser.definition import CHARACTER_TYPES
+from rosidl_parser.definition import INTEGER_TYPES
 from rosidl_parser.definition import NamespacedType
+from rosidl_parser.definition import OCTET_TYPE
+from rosidl_parser.definition import UNSIGNED_INTEGER_TYPES
 
-message_typename = '::'.join(message.structure.namespaced_type.namespaces + [message.structure.namespaced_type.name])
+message_typename = '::'.join(message.structure.namespaced_type.namespaced_name())
 }@
 @
 @#<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
@@ -257,9 +262,9 @@ non_defaulted_zero_initialized_members = [
   static const @(MSG_TYPE_TO_CPP['string']) @(constant.name);
 @[ else]@
   static constexpr @(MSG_TYPE_TO_CPP[constant.type.typename]) @(constant.name) =
-@[  if isinstance(constant.type, BasicType) and constant.type.typename in ['short', 'unsigned short', 'long', 'unsigned long', 'long long', 'unsigned long long', 'char', 'wchar', 'boolean', 'octet', 'int8', 'uint8', 'int16', 'uint16', 'int32', 'uint32', 'int64', 'uint64']]@
+@[  if isinstance(constant.type, BasicType) and constant.type.typename in (*INTEGER_TYPES, *CHARACTER_TYPES, BOOLEAN_TYPE, OCTET_TYPE)]@
     @(int(constant.value))@
-@[   if constant.type.typename.startswith('u')]@
+@[   if constant.type.typename in UNSIGNED_INTEGER_TYPES]@
 u@
 @[   end if];
 @[  else]@

--- a/rosidl_generator_cpp/resource/msg__traits.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__traits.hpp.em
@@ -10,7 +10,7 @@ from rosidl_parser.definition import NamespacedType
 from rosidl_parser.definition import AbstractSequence
 from rosidl_parser.definition import UnboundedSequence
 
-message_typename = '::'.join(message.structure.namespaced_type.namespaces + [message.structure.namespaced_type.name])
+message_typename = '::'.join(message.structure.namespaced_type.namespaced_name())
 }@
 @
 @#<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
@@ -21,7 +21,7 @@ from rosidl_cmake import convert_camel_case_to_lower_case_underscore
 includes = OrderedDict()
 for member in message.structure.members:
     type_ = member.type
-    if isinstance(type_, Array) or isinstance(type_, BoundedSequence):
+    if isinstance(type_, (Array, BoundedSequence)):
         type_ = type_.value_type
     if isinstance(type_, NamespacedType):
         if (
@@ -80,7 +80,7 @@ for member in message.structure.members:
         fixed_template_string = 'false'
         break
     if isinstance(type_, NamespacedType):
-        typename = '::'.join(type_.namespaces + [type_.name])
+        typename = '::'.join(type_.namespaced_name())
         fixed_template_strings.add('has_fixed_size<{typename}>::value'.format_map(locals()))
 else:
     if fixed_template_strings:
@@ -98,13 +98,13 @@ for member in message.structure.members:
     if isinstance(type_, UnboundedSequence):
         bounded_template_string = 'false'
         break
-    if isinstance(type_, Array) or isinstance(type_, BoundedSequence):
+    if isinstance(type_, (Array, BoundedSequence)):
         type_ = type_.value_type
     if isinstance(type_, AbstractGenericString) and not type_.has_maximum_size():
         bounded_template_string = 'false'
         break
     if isinstance(type_, NamespacedType):
-        typename = '::'.join(type_.namespaces + [type_.name])
+        typename = '::'.join(type_.namespaced_name())
         bounded_template_strings.add('has_bounded_size<{typename}>::value'.format_map(locals()))
 else:
     if bounded_template_strings:

--- a/rosidl_generator_cpp/resource/srv__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/srv__struct.hpp.em
@@ -22,7 +22,7 @@ namespace @(ns)
 struct @(service.namespaced_type.name)
 {
 @{
-service_typename = '::'.join(service.namespaced_type.namespaces + [service.namespaced_type.name])
+service_typename = '::'.join(service.namespaced_type.namespaced_name())
 }@
   using Request = @(service_typename)_Request;
   using Response = @(service_typename)_Response;

--- a/rosidl_generator_cpp/resource/srv__traits.hpp.em
+++ b/rosidl_generator_cpp/resource/srv__traits.hpp.em
@@ -14,7 +14,7 @@ TEMPLATE(
 }@
 
 @{
-service_typename = '::'.join(service.namespaced_type.namespaces + [service.namespaced_type.name])
+service_typename = '::'.join(service.namespaced_type.namespaced_name())
 }@
 @
 namespace rosidl_generator_traits

--- a/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
+++ b/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
@@ -23,6 +23,7 @@ from rosidl_parser.definition import AbstractWString
 from rosidl_parser.definition import Array
 from rosidl_parser.definition import BasicType
 from rosidl_parser.definition import BoundedSequence
+from rosidl_parser.definition import FLOATING_POINT_TYPES
 from rosidl_parser.definition import NamespacedType
 from rosidl_parser.definition import UnboundedSequence
 
@@ -76,7 +77,7 @@ def msg_type_only_to_cpp(type_):
     elif isinstance(type_, AbstractWString):
         assert False, 'TBD'
     elif isinstance(type_, NamespacedType):
-        typename = '::'.join(type_.namespaces + [type_.name])
+        typename = '::'.join(type_.namespaced_name())
         cpp_type = typename + '_<ContainerAllocator>'
     else:
         assert False, type_
@@ -162,7 +163,7 @@ def primitive_value_to_cpp(type_, value):
     @type value: python builtin (bool, int, float or str)
     @returns: a string containing the C++ representation of the value
     """
-    assert isinstance(type_, BasicType) or isinstance(type_, AbstractGenericString), \
+    assert isinstance(type_, (BasicType, AbstractGenericString)), \
         "Could not convert non-primitive type '%s' to CPP" % (type_)
     assert value is not None, "Value for type '%s' must not be None" % (type_)
 
@@ -203,7 +204,7 @@ def primitive_value_to_cpp(type_, value):
 def default_value_from_type(type_):
     if isinstance(type_, AbstractGenericString):
         return ''
-    elif isinstance(type_, BasicType) and type_.typename in ['float', 'double']:
+    elif isinstance(type_, BasicType) and type_.typename in FLOATING_POINT_TYPES:
         return 0.0
     elif isinstance(type_, BasicType) and type_.typename == 'boolean':
         return False

--- a/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
+++ b/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
@@ -121,8 +121,8 @@ size_t @(function_prefix)__size_function__@(member.type.value_type.name)__@(memb
   (void)untyped_member;
   return @(member.type.size);
 @[    else]@
-  const @('__'.join(member.type.value_type.namespaces + [member.type.value_type.name]))__Sequence * member =
-    (const @('__'.join(member.type.value_type.namespaces + [member.type.value_type.name]))__Sequence *)(untyped_member);
+  const @('__'.join(member.type.value_type.namespaced_name()))__Sequence * member =
+    (const @('__'.join(member.type.value_type.namespaced_name()))__Sequence *)(untyped_member);
   return member->size;
 @[    end if]@
 }
@@ -131,12 +131,12 @@ const void * @(function_prefix)__get_const_function__@(member.type.value_type.na
   const void * untyped_member, size_t index)
 {
 @[    if isinstance(member.type, Array)]@
-  const @('__'.join(member.type.value_type.namespaces + [member.type.value_type.name])) ** member =
-    (const @('__'.join(member.type.value_type.namespaces + [member.type.value_type.name])) **)(untyped_member);
+  const @('__'.join(member.type.value_type.namespaced_name())) ** member =
+    (const @('__'.join(member.type.value_type.namespaced_name())) **)(untyped_member);
   return &(*member)[index];
 @[    else]@
-  const @('__'.join(member.type.value_type.namespaces + [member.type.value_type.name]))__Sequence * member =
-    (const @('__'.join(member.type.value_type.namespaces + [member.type.value_type.name]))__Sequence *)(untyped_member);
+  const @('__'.join(member.type.value_type.namespaced_name()))__Sequence * member =
+    (const @('__'.join(member.type.value_type.namespaced_name()))__Sequence *)(untyped_member);
   return &member->data[index];
 @[    end if]@
 }
@@ -145,12 +145,12 @@ void * @(function_prefix)__get_function__@(member.type.value_type.name)__@(membe
   void * untyped_member, size_t index)
 {
 @[    if isinstance(member.type, Array)]@
-  @('__'.join(member.type.value_type.namespaces + [member.type.value_type.name])) ** member =
-    (@('__'.join(member.type.value_type.namespaces + [member.type.value_type.name])) **)(untyped_member);
+  @('__'.join(member.type.value_type.namespaced_name())) ** member =
+    (@('__'.join(member.type.value_type.namespaced_name())) **)(untyped_member);
   return &(*member)[index];
 @[    else]@
-  @('__'.join(member.type.value_type.namespaces + [member.type.value_type.name]))__Sequence * member =
-    (@('__'.join(member.type.value_type.namespaces + [member.type.value_type.name]))__Sequence *)(untyped_member);
+  @('__'.join(member.type.value_type.namespaced_name()))__Sequence * member =
+    (@('__'.join(member.type.value_type.namespaced_name()))__Sequence *)(untyped_member);
   return &member->data[index];
 @[    end if]@
 }
@@ -159,10 +159,10 @@ void * @(function_prefix)__get_function__@(member.type.value_type.name)__@(membe
 bool @(function_prefix)__resize_function__@(member.type.value_type.name)__@(member.name)(
   void * untyped_member, size_t size)
 {
-  @('__'.join(member.type.value_type.namespaces + [member.type.value_type.name]))__Sequence * member =
-    (@('__'.join(member.type.value_type.namespaces + [member.type.value_type.name]))__Sequence *)(untyped_member);
-  @('__'.join(member.type.value_type.namespaces + [member.type.value_type.name]))__Sequence__fini(member);
-  return @('__'.join(member.type.value_type.namespaces + [member.type.value_type.name]))__Sequence__init(member, size);
+  @('__'.join(member.type.value_type.namespaced_name()))__Sequence * member =
+    (@('__'.join(member.type.value_type.namespaced_name()))__Sequence *)(untyped_member);
+  @('__'.join(member.type.value_type.namespaced_name()))__Sequence__fini(member);
+  return @('__'.join(member.type.value_type.namespaced_name()))__Sequence__init(member, size);
 }
 
 @[    end if]@
@@ -261,7 +261,7 @@ if isinstance(type_, AbstractNestedType):
 }@
 @[    if isinstance(type_, NamespacedType)]@
   @(function_prefix)__@(message.structure.namespaced_type.name)_message_member_array[@(i)].members_ =
-    ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_c, @(', '.join(type_.namespaces + [type_.name])))();
+    ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_c, @(', '.join(type_.namespaced_name())))();
 @[    end if]@
 @[end for]@
   if (!@(function_prefix)__@(message.structure.namespaced_type.name)_message_type_support_handle.typesupport_identifier) {

--- a/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
@@ -67,7 +67,7 @@ elif isinstance(member.type.value_type, AbstractString):
 elif isinstance(member.type.value_type, AbstractWString):
     assert False, 'Unknown type: ' + str(member.type.value_type)
 elif isinstance(member.type.value_type, NamespacedType):
-    type_ = '::'.join(member.type.value_type.namespaces + [member.type.value_type.name])
+    type_ = '::'.join(member.type.value_type.namespaced_name())
 }@
 size_t size_function__@(message.structure.namespaced_type.name)__@(member.name)(const void * untyped_member)
 {
@@ -151,7 +151,7 @@ for index, member in enumerate(message.structure.members):
         # size_t string_upper_bound
         print('    0,  // upper bound of string')
         # const rosidl_message_type_support_t * members_
-        print('    ::rosidl_typesupport_introspection_cpp::get_message_type_support_handle<%s>(),  // members of sub message' % '::'.join(type_.namespaces + [type_.name]))
+        print('    ::rosidl_typesupport_introspection_cpp::get_message_type_support_handle<%s>(),  // members of sub message' % '::'.join(type_.namespaced_name()))
     # bool is_array_
     print('    %s,  // is array' % ('true' if isinstance(member.type, AbstractNestedType) else 'false'))
     # size_t array_size_


### PR DESCRIPTION
Follow up of #360 to simplify the code using the updated definition API.

Another round of lengthy builds with all three RMW impl.:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=6755)](http://ci.ros2.org/job/ci_linux/6755/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=3057)](http://ci.ros2.org/job/ci_linux-aarch64/3057/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=5551)](http://ci.ros2.org/job/ci_osx/5551/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=6580)](http://ci.ros2.org/job/ci_windows/6580/)