### PR TITLE
Add dependency to action_msgs when generating action interfaces

### DIFF
--- a/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
@@ -133,6 +133,17 @@ macro(rosidl_generate_interfaces target)
   # afterwards all remaining interface files are .idl files
   list(APPEND _idl_tuples ${_idl_adapter_tuples})
 
+  # to generate .action interfaces, we need to depend on "action_msgs"
+  foreach(_tuple ${_interface_tuples})
+    get_filename_component(_extension "${_tuple}" EXT)
+    if("${_extension}" STREQUAL ".action")
+      find_package(action_msgs REQUIRED)
+      list_append_unique(_ARG_DEPENDENCIES "action_msgs")
+      ament_export_dependencies(action_msgs)
+      break()
+    endif()
+  endforeach()
+
   # collect all interface files from dependencies
   set(_dep_files)
   foreach(_dep ${_ARG_DEPENDENCIES})

--- a/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
@@ -133,10 +133,11 @@ macro(rosidl_generate_interfaces target)
   # afterwards all remaining interface files are .idl files
   list(APPEND _idl_tuples ${_idl_adapter_tuples})
 
-  # to generate .action interfaces, we need to depend on "action_msgs"
+  # to generate action interfaces, we need to depend on "action_msgs"
   foreach(_tuple ${_interface_tuples})
-    get_filename_component(_extension "${_tuple}" EXT)
-    if("${_extension}" STREQUAL ".action")
+    string(REGEX REPLACE ".*:([^:]*)$" "\\1" _tuple_file "${_tuple}")
+    get_filename_component(_parent_dir "${_tuple_file}" DIRECTORY)
+    if("${_parent_dir}" STREQUAL "action")
       find_package(action_msgs REQUIRED)
       list_append_unique(_ARG_DEPENDENCIES "action_msgs")
       ament_export_dependencies(action_msgs)

--- a/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
@@ -138,7 +138,12 @@ macro(rosidl_generate_interfaces target)
     string(REGEX REPLACE ".*:([^:]*)$" "\\1" _tuple_file "${_tuple}")
     get_filename_component(_parent_dir "${_tuple_file}" DIRECTORY)
     if("${_parent_dir}" STREQUAL "action")
-      find_package(action_msgs REQUIRED)
+      find_package(action_msgs QUIET)
+      if(NOT ${action_msgs_FOUND})
+        message(FATAL_ERROR "Unable to generate action interface for '${_tuple_file}'. "
+          "In order to generate action interfaces, you must add a build dependency to 'action_msgs' "
+          "in your package.xml.")
+      endif()
       list_append_unique(_ARG_DEPENDENCIES "action_msgs")
       ament_export_dependencies(action_msgs)
       break()

--- a/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
@@ -21,10 +21,14 @@
 #   specific generators might use the _name as a prefix for their own
 #   generation step
 # :type target: string
-# :param ARGN: the interface file containing message and service definitions
-#   where each value might be either a path relative to the
+# :param ARGN: the interface file containing message, service, and action
+#   definitions where each value might be either a path relative to the
 #   CMAKE_CURRENT_SOURCE_DIR or a tuple separated by a colon with an absolute
 #   base path and a path relative to that base path.
+#   If the interface file's parent directory is 'action', is is assumed to be
+#   an action definition.
+#   If an action interface is passed then you must add a depend tag for
+#   'action_msgs' to your package.xml, otherwise this macro will error.
 #   For backward compatibility if an interface file doesn't end in ``.idl`` it
 #   is being passed to ``rosidl_adapter`` (if available) to be transformed into
 #   an ``.idl`` file.
@@ -141,7 +145,7 @@ macro(rosidl_generate_interfaces target)
       find_package(action_msgs QUIET)
       if(NOT ${action_msgs_FOUND})
         message(FATAL_ERROR "Unable to generate action interface for '${_tuple_file}'. "
-          "In order to generate action interfaces, you must add a build dependency to 'action_msgs' "
+          "In order to generate action interfaces you must add a depend tag for 'action_msgs' "
           "in your package.xml.")
       endif()
       list_append_unique(_ARG_DEPENDENCIES "action_msgs")


### PR DESCRIPTION
Fixes https://github.com/ros2/rcl_interfaces/issues/75

I'm not sure if this is the correct thing to do. @dirk-thomas, maybe you can tell me otherwise.