### PR TITLE
Add missing return statement to bounded_vector emplace call

### DIFF
--- a/rosidl_generator_cpp/include/rosidl_generator_cpp/bounded_vector.hpp
+++ b/rosidl_generator_cpp/include/rosidl_generator_cpp/bounded_vector.hpp
@@ -475,7 +475,7 @@ public:
     if (size() >= _UpperBound) {
       throw std::length_error("Exceeded upper bound");
     }
-    _Base::emplace(__position, std::forward<_Args>(__args) ...);
+    return _Base::emplace(__position, std::forward<_Args>(__args) ...);
   }
 
   /// Insert given value into %BoundedVector before specified iterator.


### PR DESCRIPTION
Really trivial change. Found this with PVS studio.

Signed-off-by: Hunter L. Allen <hallen@kns.com>