### PR TITLE
Handle INT64_MIN value

### DIFF
--- a/rosidl_generator_c/rosidl_generator_c/__init__.py
+++ b/rosidl_generator_c/rosidl_generator_c/__init__.py
@@ -138,14 +138,14 @@ def basic_value_to_c(type_, value):
     if 'boolean' == type_.typename:
         return 'true' if value else 'false'
 
-    if type_.typename in [
-        'short', 'unsigned short',
-        'char', 'wchar',
-        'double',
-        'octet',
-        'int8', 'uint8',
-        'int16', 'uint16',
-    ]:
+    if type_.typename in (
+        *CHARACTER_TYPES,
+        OCTET_TYPE,
+        'int8',
+        'uint8',
+        'int16',
+        'uint16',
+    ):
         return str(value)
 
     if type_.typename == 'int32':
@@ -158,7 +158,7 @@ def basic_value_to_c(type_, value):
         # Handle edge case for INT64_MIN
         # See https://en.cppreference.com/w/cpp/language/integer_literal
         if -9223372036854775808 == value:
-            return '({0} - 1)'.format(value + 1)
+            return '({0}ll - 1)'.format(value + 1)
         return '{value}ll'.format_map(locals())
 
     if type_.typename == 'uint64':

--- a/rosidl_generator_c/rosidl_generator_c/__init__.py
+++ b/rosidl_generator_c/rosidl_generator_c/__init__.py
@@ -138,11 +138,31 @@ def basic_value_to_c(type_, value):
     if 'boolean' == type_.typename:
         return 'true' if value else 'false'
 
-    if type_.typename in (*SIGNED_INTEGER_TYPES, *CHARACTER_TYPES, OCTET_TYPE):
+    if type_.typename in [
+        'short', 'unsigned short',
+        'char', 'wchar',
+        'double',
+        'octet',
+        'int8', 'uint8',
+        'int16', 'uint16',
+    ]:
         return str(value)
 
-    if type_.typename in UNSIGNED_INTEGER_TYPES:
-        return str(value) + 'u'
+    if type_.typename == 'int32':
+        return '{value}l'.format_map(locals())
+
+    if type_.typename == 'uint32':
+        return '{value}ul'.format_map(locals())
+
+    if type_.typename == 'int64':
+        # Handle edge case for INT64_MIN
+        # See https://en.cppreference.com/w/cpp/language/integer_literal
+        if -9223372036854775808 == value:
+            return '({0} - 1)'.format(value + 1)
+        return '{value}ll'.format_map(locals())
+
+    if type_.typename == 'uint64':
+        return '{value}ull'.format_map(locals())
 
     if 'float' == type_.typename:
         return '{value}f'.format_map(locals())

--- a/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
+++ b/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
@@ -190,6 +190,10 @@ def primitive_value_to_cpp(type_, value):
         return '%sul' % value
 
     if type_.typename == 'int64':
+        # Handle edge case for INT64_MIN
+        # See https://en.cppreference.com/w/cpp/language/integer_literal
+        if -9223372036854775808 == value:
+            return '(%s - 1)' % (value + 1)
         return '%sll' % value
 
     if type_.typename == 'uint64':

--- a/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
+++ b/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
@@ -193,7 +193,7 @@ def primitive_value_to_cpp(type_, value):
         # Handle edge case for INT64_MIN
         # See https://en.cppreference.com/w/cpp/language/integer_literal
         if -9223372036854775808 == value:
-            return '(%s - 1)' % (value + 1)
+            return '(%sll - 1)' % (value + 1)
         return '%sll' % value
 
     if type_.typename == 'uint64':


### PR DESCRIPTION
Before the unary minus, the compiler first evaluates the literal, which is larger than the maximum allowed integer and results in a warning.
To correctly get the value for INT64_MIN, we substract from one number larger.
See https://en.cppreference.com/w/cpp/language/integer_literal.

Also adding missing integer suffixes for generated C code.