### PR TITLE
change C u16string data from uint16_t to uint_least16_t

### DIFF
--- a/rosidl_generator_c/include/rosidl_generator_c/u16string.h
+++ b/rosidl_generator_c/include/rosidl_generator_c/u16string.h
@@ -22,7 +22,8 @@
 /// U16String struct
 typedef struct rosidl_generator_c__U16String
 {
-  uint16_t * data;
+  /// The pointer to the first character.
+  uint_least16_t * data;  // using uint_least16_t to match a C++ std::u16string
   /// The length of the u16string (excluding the null byte).
   size_t size;
   /// The capacity represents the number of allocated characters (including the null byte).


### PR DESCRIPTION
In order to match how a C++ `std::u16string` is defined.

It avoids the risk of `uint16_t` and `uint_least16_t` not being the same lengths when doing stuff like this https://github.com/ros2/rosidl_typesupport_opensplice/pull/27/files#diff-eb52319d09d2b6415f95c504f6609ba7R244:

> `dds_message->@(member.name)_[i] = cv.to_bytes(reinterpret_cast<char16_t *>(str->data)).c_str();`

or the need to copy character by character to prevent the datatype mismatch on some potential platforms.

This is ready for review but I will hole this PR until ros2/rosidl#352 has landed and then update downstream code and run CI.