### PR TITLE
use non-bool type for structure_needs_at_least_one_member field

### DIFF
--- a/rosidl_adapter/rosidl_adapter/resource/struct.idl.em
+++ b/rosidl_adapter/rosidl_adapter/resource/struct.idl.em
@@ -74,6 +74,6 @@ idl_type = get_idl_type_identifier(idl_type)
       @(idl_type) @(field.name);
 @[  end for]@
 @[else]@
-      boolean structure_needs_at_least_one_member;
+      uint8 structure_needs_at_least_one_member;
 @[end if]@
     };


### PR DESCRIPTION
Since user land code doesn't know about this field it might end up uninitialized. In case of FastRTPS it raises an exception if a boolean value is received which isn't either `0` or `1`.

Using a `uint8` instead since any uninitialized value is valid.

After this it becomes feasible to consider raising on the publish side if an uninitialized boolean value is published.