### PR TITLE
Fix resize function (#379) for C.

### DIFF
--- a/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
+++ b/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
@@ -225,7 +225,7 @@ for index, member in enumerate(message.structure.members):
     # void *(void *, size_t) get_function
     print('    %s,  // get(index) function pointer' % ('%s__get_function__%s' % (function_prefix, function_suffix) if function_suffix else 'NULL'))
     # void(void *, size_t) resize_function
-    print('    %s  // resize(index) function pointer' % ('%s__resize_function__%s' % (function_prefix, function_suffix) if function_suffix and isinstance(member.type.value_type, AbstractSequence) else 'NULL'))
+    print('    %s  // resize(index) function pointer' % ('%s__resize_function__%s' % (function_prefix, function_suffix) if function_suffix and isinstance(member.type, AbstractSequence) else 'NULL'))
 
     if index < len(message.structure.members) - 1:
         print('  },')


### PR DESCRIPTION
Commit 6f8194a673a8ec1467dc87858a1fee80b51060b5 fixed https://github.com/ros2/rosidl/pull/379 for C++.  This commit fixes the same issue for C.

Signed-off-by: Todd Malsbary <todd.malsbary@intel.com>