### PR TITLE
Fix leak in test_interfaces.c

### DIFF
--- a/rosidl_generator_c/test/test_interfaces.c
+++ b/rosidl_generator_c/test/test_interfaces.c
@@ -378,6 +378,8 @@ int test_string_arrays(void)
   bool res = false;
   rosidl_generator_c__msg__StringArrays * strings = rosidl_generator_c__msg__StringArrays__create();
 
+  EXPECT_NE(strings, NULL);
+
   rosidl_generator_c__String__Sequence__init(&strings->string_dynamic_array_value, 3);
   res = rosidl_generator_c__String__assign(
     &strings->string_dynamic_array_value.data[0], TEST_STRING);

--- a/rosidl_generator_c/test/test_interfaces.c
+++ b/rosidl_generator_c/test/test_interfaces.c
@@ -378,9 +378,6 @@ int test_string_arrays(void)
   bool res = false;
   rosidl_generator_c__msg__StringArrays * strings = rosidl_generator_c__msg__StringArrays__create();
 
-  res = rosidl_generator_c__msg__StringArrays__init(strings);
-  EXPECT_EQ(res, true);
-
   rosidl_generator_c__String__Sequence__init(&strings->string_dynamic_array_value, 3);
   res = rosidl_generator_c__String__assign(
     &strings->string_dynamic_array_value.data[0], TEST_STRING);
@@ -448,9 +445,6 @@ int test_string_arrays_default_value(void)
   string_arrays = rosidl_generator_c__msg__StringArrays__create();
 
   EXPECT_NE(string_arrays, NULL);
-
-  bool res = rosidl_generator_c__msg__StringArrays__init(string_arrays);
-  EXPECT_EQ(true, res);
 
   EXPECT_EQ(0, strcmp(string_arrays->def_string_static_array_value[0].data, "Hello"));
   EXPECT_EQ(0, strcmp(string_arrays->def_string_static_array_value[1].data, "World"));


### PR DESCRIPTION
Before this fix when running test_interfaces:

```
==15142==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 120 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99d38 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded38)
    #1 0x7fd77858a0f6 in rosidl_generator_c__String__Sequence__init ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:114
    #2 0x7fd7787a85cf in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:48
    #3 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #4 0x560bf3da9991 in test_string_arrays ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:379
    #5 0x560bf3da7c00 in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:154
    #6 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 120 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99d38 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded38)
    #1 0x7fd77858a0f6 in rosidl_generator_c__String__Sequence__init ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:114
    #2 0x7fd7787a85cf in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:48
    #3 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #4 0x560bf3daa659 in test_string_arrays_default_value ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:448
    #5 0x560bf3da7c5d in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:159
    #6 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 96 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99d38 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded38)
    #1 0x7fd77858a0f6 in rosidl_generator_c__String__Sequence__init ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:114
    #2 0x7fd7787a8a66 in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:154
    #3 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #4 0x560bf3daa659 in test_string_arrays_default_value ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:448
    #5 0x560bf3da7c5d in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:159
    #6 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 96 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99d38 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded38)
    #1 0x7fd77858a0f6 in rosidl_generator_c__String__Sequence__init ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:114
    #2 0x7fd7787a8a66 in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:154
    #3 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #4 0x560bf3da9991 in test_string_arrays ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:379
    #5 0x560bf3da7c00 in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:154
    #6 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 72 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99d38 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded38)
    #1 0x7fd77858a0f6 in rosidl_generator_c__String__Sequence__init ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:114
    #2 0x7fd7787a8869 in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:110
    #3 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #4 0x560bf3da9991 in test_string_arrays ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:379
    #5 0x560bf3da7c00 in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:154
    #6 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 72 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99d38 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded38)
    #1 0x7fd77858a0f6 in rosidl_generator_c__String__Sequence__init ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:114
    #2 0x7fd7787a8869 in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:110
    #3 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #4 0x560bf3daa659 in test_string_arrays_default_value ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:448
    #5 0x560bf3da7c5d in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:159
    #6 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 48 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99d38 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded38)
    #1 0x7fd77858a0f6 in rosidl_generator_c__String__Sequence__init ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:114
    #2 0x7fd7787a8993 in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:135
    #3 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #4 0x560bf3daa659 in test_string_arrays_default_value ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:448
    #5 0x560bf3da7c5d in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:159
    #6 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 48 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99d38 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded38)
    #1 0x7fd77858a0f6 in rosidl_generator_c__String__Sequence__init ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:114
    #2 0x7fd7787a8993 in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:135
    #3 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #4 0x560bf3da9991 in test_string_arrays ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:379
    #5 0x560bf3da7c00 in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:154
    #6 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 6 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a87ea in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:91
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3da9991 in test_string_arrays ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:379
    #6 0x560bf3da7c00 in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:154
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 6 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a87ea in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:91
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3daa659 in test_string_arrays_default_value ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:448
    #6 0x560bf3da7c5d in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:159
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 6 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a8815 in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:97
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3da9991 in test_string_arrays ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:379
    #6 0x560bf3da7c00 in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:154
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 6 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a8815 in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:97
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3daa659 in test_string_arrays_default_value ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:448
    #6 0x560bf3da7c5d in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:159
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 3 byte(s) in 3 object(s) allocated from:
    #0 0x7fd778a99b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7fd778589b44 in rosidl_generator_c__String__init ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:28
    #2 0x7fd7787a855f in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:36
    #3 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #4 0x560bf3daa659 in test_string_arrays_default_value ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:448
    #5 0x560bf3da7c5d in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:159
    #6 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 3 byte(s) in 3 object(s) allocated from:
    #0 0x7fd778a99b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7fd778589b44 in rosidl_generator_c__String__init ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:28
    #2 0x7fd7787a855f in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:36
    #3 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #4 0x560bf3da9991 in test_string_arrays ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:379
    #5 0x560bf3da7c00 in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:154
    #6 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 2 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a8840 in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:103
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3daa659 in test_string_arrays_default_value ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:448
    #6 0x560bf3da7c5d in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:159
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 2 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a8840 in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:103
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3da9991 in test_string_arrays ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:379
    #6 0x560bf3da7c00 in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:154
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 10 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a86c1 in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:66
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3daa659 in test_string_arrays_default_value ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:448
    #6 0x560bf3da7c5d in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:159
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 10 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a86c1 in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:66
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3da9991 in test_string_arrays ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:379
    #6 0x560bf3da7c00 in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:154
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a8a3d in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:147
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3da9991 in test_string_arrays ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:379
    #6 0x560bf3da7c00 in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:154
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a89e6 in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:141
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3da9991 in test_string_arrays ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:379
    #6 0x560bf3da7c00 in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:154
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a89e6 in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:141
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3daa659 in test_string_arrays_default_value ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:448
    #6 0x560bf3da7c5d in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:159
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a8a3d in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:147
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3daa659 in test_string_arrays_default_value ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:448
    #6 0x560bf3da7c5d in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:159
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 7 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a8ab9 in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:160
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3da9991 in test_string_arrays ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:379
    #6 0x560bf3da7c00 in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:154
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 7 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a8b10 in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:166
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3da9991 in test_string_arrays ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:379
    #6 0x560bf3da7c00 in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:154
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 7 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a8ab9 in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:160
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3daa659 in test_string_arrays_default_value ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:448
    #6 0x560bf3da7c5d in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:159
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 7 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a8b10 in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:166
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3daa659 in test_string_arrays_default_value ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:448
    #6 0x560bf3da7c5d in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:159
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 6 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a88bc in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:116
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3daa659 in test_string_arrays_default_value ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:448
    #6 0x560bf3da7c5d in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:159
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 6 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a8913 in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:122
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3daa659 in test_string_arrays_default_value ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:448
    #6 0x560bf3da7c5d in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:159
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 6 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a8713 in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:72
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3daa659 in test_string_arrays_default_value ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:448
    #6 0x560bf3da7c5d in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:159
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 6 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a8913 in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:122
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3da9991 in test_string_arrays ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:379
    #6 0x560bf3da7c00 in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:154
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 6 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a88bc in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:116
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3da9991 in test_string_arrays ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:379
    #6 0x560bf3da7c00 in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:154
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 6 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a8713 in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:72
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3da9991 in test_string_arrays ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:379
    #6 0x560bf3da7c00 in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:154
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 5 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a861d in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:54
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3da9991 in test_string_arrays ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:379
    #6 0x560bf3da7c00 in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:154
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 5 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a861d in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:54
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3daa659 in test_string_arrays_default_value ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:448
    #6 0x560bf3da7c5d in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:159
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 5 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a8b67 in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:172
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3da9991 in test_string_arrays ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:379
    #6 0x560bf3da7c00 in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:154
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 5 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a8b67 in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:172
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3daa659 in test_string_arrays_default_value ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:448
    #6 0x560bf3da7c5d in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:159
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 3 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a8bbe in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:178
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3da9991 in test_string_arrays ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:379
    #6 0x560bf3da7c00 in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:154
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 3 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a8bbe in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:178
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3daa659 in test_string_arrays_default_value ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:448
    #6 0x560bf3da7c5d in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:159
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 2 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a896a in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:128
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3daa659 in test_string_arrays_default_value ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:448
    #6 0x560bf3da7c5d in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:159
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 2 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a8765 in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:78
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3daa659 in test_string_arrays_default_value ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:448
    #6 0x560bf3da7c5d in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:159
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 2 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a896a in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:128
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3da9991 in test_string_arrays ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:379
    #6 0x560bf3da7c00 in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:154
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 2 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a8765 in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:78
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3da9991 in test_string_arrays ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:379
    #6 0x560bf3da7c00 in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:154
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 2 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a866f in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:60
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3daa659 in test_string_arrays_default_value ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:448
    #6 0x560bf3da7c5d in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:159
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 2 byte(s) in 1 object(s) allocated from:
    #0 0x7fd778a99f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7fd778589f75 in rosidl_generator_c__String__assignn ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7fd77858a0af in rosidl_generator_c__String__assign ../../src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7fd7787a866f in rosidl_generator_c__msg__StringArrays__init rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:60
    #4 0x7fd7787a90d2 in rosidl_generator_c__msg__StringArrays__create rosidl_generator_c/rosidl_generator_c/msg/string_arrays__functions.c:264
    #5 0x560bf3da9991 in test_string_arrays ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:379
    #6 0x560bf3da7c00 in main ../../src/ros2/rosidl/rosidl_generator_c/test/test_interfaces.c:154
    #7 0x7fd7781b3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

SUMMARY: AddressSanitizer: 860 byte(s) leaked in 48 allocation(s).
```

After applying the fix:

```
Testing rosidl_generator_c message types...
Testing simple primitive message types...
Testing simple primitives with default values...
Testing string types...
Testing primitives unbounded arrays types...
Testing primitives bounded arrays types...
Testing primitives static arrays types...
Testing nested sub-messages...
Testing static_array_nested messages...
Testing bounded_array_nested messages...
Testing dynamic_array_nested messages...
Testing dynamic_array_primitives_nested messages...
Testing string arrays...
Testing string arrays with default values...
All tests were good!
```

Signed-off-by: Thomas Moulard <tmoulard@amazon.com>