### PR TITLE
fix cpp generator and introspection ts for long double

### DIFF
--- a/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
+++ b/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
@@ -181,7 +181,7 @@ def primitive_value_to_cpp(type_, value):
     if type_.typename in [
         'short', 'unsigned short',
         'char', 'wchar',
-        'double',
+        'double', 'long double',
         'octet',
         'int8', 'uint8',
         'int16', 'uint16',

--- a/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
+++ b/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
@@ -181,7 +181,7 @@ for index, member in enumerate(message.structure.members):
     print('    "%s",  // name' % member.name)
     if isinstance(type_, BasicType):
         # uint8_t type_id_
-        print('    rosidl_typesupport_introspection_c__ROS_TYPE_%s,  // type' % type_.typename.upper())
+        print('    rosidl_typesupport_introspection_c__ROS_TYPE_%s,  // type' % type_.typename.replace(' ', '_').upper())
         # size_t string_upper_bound
         print('    0,  // upper bound of string')
         # const rosidl_generator_c::MessageTypeSupportHandle * members_

--- a/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
@@ -128,7 +128,7 @@ for index, member in enumerate(message.structure.members):
     print('    "%s",  // name' % member.name)
     if isinstance(type_, BasicType):
         # uint8_t type_id_
-        print('    ::rosidl_typesupport_introspection_cpp::ROS_TYPE_%s,  // type' % type_.typename.upper())
+        print('    ::rosidl_typesupport_introspection_cpp::ROS_TYPE_%s,  // type' % type_.typename.replace(' ', '_').upper())
         # size_t string_upper_bound
         print('    0,  // upper bound of string')
         # const rosidl_generator_c::MessageTypeSupportHandle * members_


### PR DESCRIPTION
As reported in http://answers.ros.org/question/324586/ros2-messages-from-idl-files/

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7293)](http://ci.ros2.org/job/ci_linux/7293/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=3468)](http://ci.ros2.org/job/ci_linux-aarch64/3468/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=5968)](http://ci.ros2.org/job/ci_osx/5968/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7112)](http://ci.ros2.org/job/ci_windows/7112/)