### PR TITLE
[backport dashing] [rosidl_typesupport_introspection_c] Use message namespaced type name as function prefix

### DIFF
--- a/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
+++ b/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
@@ -26,7 +26,7 @@ header_files = [
     include_base + '__struct.h',
 ]
 
-function_prefix = '__'.join(include_parts) + '__rosidl_typesupport_introspection_c'
+function_prefix = message.structure.namespaced_type.name + '__rosidl_typesupport_introspection_c'
 }@
 @[for header_file in header_files]@
 @[    if header_file in include_directives]@


### PR DESCRIPTION
Backport #387 

Fixes https://github.com/ros2/rosidl/issues/386

This is the same prefix that is already applied to C++ typesupport functions.