### PR TITLE
rosidl_adapter: struct.idl template: generate a verbatim for each comment line instead of joining the comments with nl

### DIFF
--- a/rosidl_adapter/rosidl_adapter/resource/struct.idl.em
+++ b/rosidl_adapter/rosidl_adapter/resource/struct.idl.em
@@ -46,7 +46,9 @@ else:
 @[end if]@
 @#
 @[if msg.annotations.get('comment', [])]@
-    @@verbatim (language="comment", text=@(string_to_idl_string_literal('\n'.join(msg.annotations['comment']))))
+@[    for comment in msg.annotations['comment']]@
+    @@verbatim (language="comment", text=@(string_to_idl_string_literal(comment)))
+@[    end for]@
 @[end if]@
     struct @(msg.msg_name) {
 @[if msg.fields]@
@@ -55,7 +57,9 @@ else:
 
 @[end if]@
 @[    if field.annotations.get('comment', [])]@
-      @@verbatim (language="comment", text=@(string_to_idl_string_literal('\n'.join(field.annotations['comment']))))
+@[        for comment in field.annotations['comment']]@
+      @@verbatim (language="comment", text=@(string_to_idl_string_literal(comment)))
+@[        end for]@
 @[    end if]@
 @[    if field.default_value is not None]@
       @@default (value=@(to_idl_literal(get_idl_type(field.type), field.default_value)))


### PR DESCRIPTION
This aims to fix https://github.com/eProsima/IDL-Parser/issues/33, where the parser was breaking when finding a new line on the verbatim but without a backlash signalling.

The proposed solution adds a `@verbatim` line for each comment line, instead of joining each comment by new line. I did try another solution by joining the lines using ` \\ \n`, but that was resulting in a warning on the IDL Parser, which I avoided.

@LuisGP @dirk-thomas looking for your feedback and review. Thanks!