### PR TITLE
fix parsing empty string literal

### DIFF
--- a/rosidl_parser/rosidl_parser/parser.py
+++ b/rosidl_parser/rosidl_parser/parser.py
@@ -589,6 +589,8 @@ def get_floating_pt_literal_value(floating_pt_literal):
 
 
 def get_string_literal_value(string_literal, *, allow_unicode=False):
+    if len(string_literal.children) == 0:
+        return ''
     assert len(string_literal.children) == 1
     child = string_literal.children[0]
     assert isinstance(child, Token)

--- a/rosidl_parser/test/msg/MyMessage.idl
+++ b/rosidl_parser/test/msg/MyMessage.idl
@@ -20,6 +20,7 @@ module rosidl_parser {
       @key
       @range ( min=-10, max=10 )
       long long_value;
+      @verbatim (language="comment", text="")
       unsigned long unsigned_long_value;
       long long long_long_value;
       unsigned long long unsigned_long_long_value;


### PR DESCRIPTION
Fixes #405.

I am not going to run CI for this since obviously we don't have that case anywhere in the code base atm. Otherwise the following assertion would have failed.