### PR TITLE
support adjacent string literals, use them for multi-line comments

### DIFF
--- a/rosidl_adapter/rosidl_adapter/resource/struct.idl.em
+++ b/rosidl_adapter/rosidl_adapter/resource/struct.idl.em
@@ -46,7 +46,14 @@ else:
 @[end if]@
 @#
 @[if msg.annotations.get('comment', [])]@
-    @@verbatim (language="comment", text=@(string_to_idl_string_literal('\n'.join(msg.annotations['comment']))))
+    @@verbatim (language="comment", text=@
+@[  for i, line in enumerate(msg.annotations['comment'])]
+      @(string_to_idl_string_literal(line))@
+@[    if i < len(msg.annotations.get('comment')) - 1]@
+ "\n"@
+@[    end if]@
+@[  end for]@
+)
 @[end if]@
     struct @(msg.msg_name) {
 @[if msg.fields]@
@@ -55,7 +62,14 @@ else:
 
 @[end if]@
 @[    if field.annotations.get('comment', [])]@
-      @@verbatim (language="comment", text=@(string_to_idl_string_literal('\n'.join(field.annotations['comment']))))
+      @@verbatim (language="comment", text=@
+@[      for i, line in enumerate(field.annotations['comment'])]
+        @(string_to_idl_string_literal(line))@
+@[        if i < len(field.annotations.get('comment')) - 1]@
+ "\n"@
+@[        end if]@
+@[      end for]@
+)
 @[    end if]@
 @[    if field.default_value is not None]@
       @@default (value=@(to_idl_literal(get_idl_type(field.type), field.default_value)))

--- a/rosidl_parser/rosidl_parser/grammar.lark
+++ b/rosidl_parser/rosidl_parser/grammar.lark
@@ -65,6 +65,9 @@ _FORMATTING_CHARACTERS: "\t" | "\n" | "\r"
 _ESCAPE_SEQUENCES: "\\n" | "\\t" | "\\v" | "\\b" | "\\r" | "\\f" | "\\a" | "\\\\" | "\\?" | "\\'" | "\\\"" | "\\" "0".."7" "0".."7" | "\\x" HEXDIGIT HEXDIGIT | "\\" HEXDIGIT HEXDIGIT HEXDIGIT HEXDIGIT
 
 // 7.2.6.3 String Literals
+// adjacent string literals are concatenated
+string_literals: string_literal+
+wide_string_literals: wide_string_literal+
 // string_literal: "\"" CHAR* "\""
 // wide_string_literal:  "L\"" CHAR* "\""
 // replace precise rules based on the spec with regex for parsing performance
@@ -186,8 +189,8 @@ literal.2: integer_literal
   | character_literal
   | wide_character_literal
   | boolean_literal
-  | string_literal
-  | wide_string_literal
+  | string_literals
+  | wide_string_literals
 
 // (18)
 boolean_literal: boolean_literal_true

--- a/rosidl_parser/rosidl_parser/parser.py
+++ b/rosidl_parser/rosidl_parser/parser.py
@@ -556,13 +556,13 @@ def get_const_expr_value(const_expr):
         assert child.data in ('boolean_literal_true', 'boolean_literal_false')
         return child.data == 'boolean_literal_true'
 
-    if child.data == 'string_literal':
+    if child.data == 'string_literals':
         assert not negate_value
-        return get_string_literal_value(child, allow_unicode=False)
+        return get_string_literals_value(child, allow_unicode=False)
 
-    if child.data == 'wide_string_literal':
+    if child.data == 'wide_string_literals':
         assert not negate_value
-        return get_string_literal_value(child, allow_unicode=True)
+        return get_string_literals_value(child, allow_unicode=True)
 
     assert False, 'Unsupported tree: ' + str(const_expr)
 
@@ -586,6 +586,15 @@ def get_floating_pt_literal_value(floating_pt_literal):
         else:
             assert False, 'Unsupported tree: ' + str(floating_pt_literal)
     return float(value)
+
+
+def get_string_literals_value(string_literals, *, allow_unicode=False):
+    assert len(string_literals.children) > 0
+    value = ''
+    for string_literal in string_literals.children:
+        value += get_string_literal_value(
+            string_literal, allow_unicode=allow_unicode)
+    return value
 
 
 def get_string_literal_value(string_literal, *, allow_unicode=False):

--- a/rosidl_parser/test/msg/MyMessage.idl
+++ b/rosidl_parser/test/msg/MyMessage.idl
@@ -12,7 +12,7 @@ module rosidl_parser {
       const wstring WSTRING_CONSTANT = "wstring_value_\u2122";
     };
 
-    @verbatim ( language="comment", text="Documentation of MyMessage." )
+    @verbatim ( language="comment", text="Documentation of MyMessage." "Adjacent string literal." )
     struct MyMessage {
       short short_value, short_value2;
       @default ( value=123 )

--- a/rosidl_parser/test/test_parser.py
+++ b/rosidl_parser/test/test_parser.py
@@ -159,7 +159,7 @@ def test_message_parser_annotations(message_idl_file):
     assert structure.annotations[0].value['language'] == 'comment'
     assert 'text' in structure.annotations[0].value
     assert structure.annotations[0].value['text'] == \
-        'Documentation of MyMessage.'
+        'Documentation of MyMessage.Adjacent string literal.'
 
     assert len(structure.members[2].annotations) == 1
 


### PR DESCRIPTION
Replaces #406.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8101)](http://ci.ros2.org/job/ci_linux/8101/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=4100)](http://ci.ros2.org/job/ci_linux-aarch64/4100/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6602)](http://ci.ros2.org/job/ci_osx/6602/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7979)](http://ci.ros2.org/job/ci_windows/7979/)