### PR TITLE
init and fini function for creating introspection messages

### DIFF
--- a/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/message_introspection.h
+++ b/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/message_introspection.h
@@ -47,6 +47,8 @@ typedef struct rosidl_typesupport_introspection_c__MessageMembers
   uint32_t member_count_;
   size_t size_of_;
   const rosidl_typesupport_introspection_c__MessageMember * members_;
+  void (*init_function)(void *, bool);
+  void (*fini_function)(void *);
 } rosidl_typesupport_introspection_c__MessageMembers;
 
 #endif  // ROSIDL_TYPESUPPORT_INTROSPECTION_C__MESSAGE_INTROSPECTION_H_

--- a/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/message_introspection.h
+++ b/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/message_introspection.h
@@ -48,8 +48,8 @@ typedef struct rosidl_typesupport_introspection_c__MessageMembers
   uint32_t member_count_;
   size_t size_of_;
   const rosidl_typesupport_introspection_c__MessageMember * members_;
-  void (*init_function)(void *, enum rosidl_runtime_c_message_initialization);
-  void (*fini_function)(void *);
+  void (* init_function)(void *, enum rosidl_runtime_c_message_initialization);
+  void (* fini_function)(void *);
 } rosidl_typesupport_introspection_c__MessageMembers;
 
 #endif  // ROSIDL_TYPESUPPORT_INTROSPECTION_C__MESSAGE_INTROSPECTION_H_

--- a/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/message_introspection.h
+++ b/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/message_introspection.h
@@ -19,6 +19,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "rosidl_generator_c/message_initialization.h"
 #include "rosidl_generator_c/message_type_support_struct.h"
 
 #include "rosidl_typesupport_introspection_c/visibility_control.h"
@@ -47,7 +48,7 @@ typedef struct rosidl_typesupport_introspection_c__MessageMembers
   uint32_t member_count_;
   size_t size_of_;
   const rosidl_typesupport_introspection_c__MessageMember * members_;
-  void (*init_function)(void *, bool);
+  void (*init_function)(void *, enum rosidl_runtime_c_message_initialization);
   void (*fini_function)(void *);
 } rosidl_typesupport_introspection_c__MessageMembers;
 

--- a/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
+++ b/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
@@ -113,8 +113,12 @@ extern "C"
 @#######################################################################
 @# define callback functions
 @#######################################################################
-void @(function_prefix)__@(message.structure.namespaced_type.name)_init_function(void * message_memory, bool default_initialize)
+void @(function_prefix)__@(message.structure.namespaced_type.name)_init_function(
+  void * message_memory, enum rosidl_runtime_c_message_initialization _init)
 {
+  // initializers are not yet implemented for typesupport c
+  // see https://github.com/ros2/ros2/issues/397
+  (void) _init;
   @('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))__init(message_memory);
 }
 

--- a/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
+++ b/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
@@ -116,7 +116,7 @@ extern "C"
 void @(function_prefix)__@(message.structure.namespaced_type.name)_init_function(
   void * message_memory, enum rosidl_runtime_c_message_initialization _init)
 {
-  // initializers are not yet implemented for typesupport c
+  // TODO(karsten1987): initializers are not yet implemented for typesupport c
   // see https://github.com/ros2/ros2/issues/397
   (void) _init;
   @('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))__init(message_memory);

--- a/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
+++ b/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
@@ -42,6 +42,7 @@ function_prefix = message.structure.namespaced_type.name + '__rosidl_typesupport
 #include "@(header_file)"
 @[    end if]@
 @[end for]@
+
 @#<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 @# Collect necessary include directives for all members
 @{
@@ -112,12 +113,12 @@ extern "C"
 @#######################################################################
 @# define callback functions
 @#######################################################################
-void @(function_prefix)__init_function(void * message_memory, bool default_initialize)
+void @(function_prefix)__@(message.structure.namespaced_type.name)_init_function(void * message_memory, bool default_initialize)
 {
   @('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))__init(message_memory);
 }
 
-void @(function_prefix)__fini_function(void * message_memory)
+void @(function_prefix)__@(message.structure.namespaced_type.name)_fini_function(void * message_memory)
 {
   @('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))__fini(message_memory);
 }
@@ -250,8 +251,8 @@ static const rosidl_typesupport_introspection_c__MessageMembers @(function_prefi
   @(len(message.structure.members)),  // number of fields
   sizeof(@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))),
   @(function_prefix)__@(message.structure.namespaced_type.name)_message_member_array,  // message members
-  @(function_prefix)__init_function,  // function to initialize message memory (memory has to be allocated)
-  @(function_prefix)__fini_function  // function to terminate message instance (will not free memory)
+  @(function_prefix)__@(message.structure.namespaced_type.name)_init_function,  // function to initialize message memory (memory has to be allocated)
+  @(function_prefix)__@(message.structure.namespaced_type.name)_fini_function  // function to terminate message instance (will not free memory)
 };
 
 // this is not const since it must be initialized on first access

--- a/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
+++ b/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
@@ -23,6 +23,7 @@ header_files = [
     'rosidl_typesupport_introspection_c/field_types.h',
     'rosidl_typesupport_introspection_c/identifier.h',
     'rosidl_typesupport_introspection_c/message_introspection.h',
+    include_base + '__functions.h',
     include_base + '__struct.h',
 ]
 
@@ -41,7 +42,6 @@ function_prefix = message.structure.namespaced_type.name + '__rosidl_typesupport
 #include "@(header_file)"
 @[    end if]@
 @[end for]@
-
 @#<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 @# Collect necessary include directives for all members
 @{
@@ -112,6 +112,16 @@ extern "C"
 @#######################################################################
 @# define callback functions
 @#######################################################################
+void @(function_prefix)__init_function(void * message_memory, bool default_initialize)
+{
+  @('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))__init(message_memory);
+}
+
+void @(function_prefix)__fini_function(void * message_memory)
+{
+  @('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))__fini(message_memory);
+}
+
 @[for member in message.structure.members]@
 @[  if isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, NamespacedType)]@
 size_t @(function_prefix)__size_function__@(member.type.value_type.name)__@(member.name)(
@@ -239,7 +249,9 @@ static const rosidl_typesupport_introspection_c__MessageMembers @(function_prefi
   "@(message.structure.namespaced_type.name)",  // message name
   @(len(message.structure.members)),  // number of fields
   sizeof(@('__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))),
-  @(function_prefix)__@(message.structure.namespaced_type.name)_message_member_array  // message members
+  @(function_prefix)__@(message.structure.namespaced_type.name)_message_member_array,  // message members
+  @(function_prefix)__init_function,  // function to initialize message memory (memory has to be allocated)
+  @(function_prefix)__fini_function  // function to terminate message instance (will not free memory)
 };
 
 // this is not const since it must be initialized on first access

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/message_introspection.hpp
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/message_introspection.hpp
@@ -49,6 +49,8 @@ typedef struct ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC MessageMembers
   uint32_t member_count_;
   size_t size_of_;
   const MessageMember * members_;
+  void (* init_function)(void *, bool);
+  void (* fini_function)(void *);
 } MessageMembers;
 
 }  // namespace rosidl_typesupport_introspection_cpp

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/message_introspection.hpp
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/message_introspection.hpp
@@ -20,6 +20,8 @@
 
 #include "rosidl_generator_c/message_type_support_struct.h"
 
+#include "rosidl_generator_cpp/message_initialization.hpp"
+
 #include "rosidl_typesupport_introspection_cpp/visibility_control.h"
 
 namespace rosidl_typesupport_introspection_cpp
@@ -49,7 +51,7 @@ typedef struct ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC MessageMembers
   uint32_t member_count_;
   size_t size_of_;
   const MessageMember * members_;
-  void (* init_function)(void *, bool);
+  void (* init_function)(void *, rosidl_generator_cpp::MessageInitialization);
   void (* fini_function)(void *);
 } MessageMembers;
 

--- a/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
@@ -49,12 +49,12 @@ namespace @(ns)
 namespace rosidl_typesupport_introspection_cpp
 {
 
-void init_function__@(message.structure.namespaced_type.name)(void * message_memory, bool default_initialize)
+void @(message.structure.namespaced_type.name)_init_function(void * message_memory, bool default_initialize)
 {
   new (message_memory) @('::'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]));
 }
 
-void fini_function__@(message.structure.namespaced_type.name)(void * message_memory)
+void @(message.structure.namespaced_type.name)_fini_function(void * message_memory)
 {
   auto typed_message = static_cast<@('::'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name])) *>(message_memory);
   typed_message->~@(message.structure.namespaced_type.name)();
@@ -198,8 +198,8 @@ static const ::rosidl_typesupport_introspection_cpp::MessageMembers @(message.st
   @(len(message.structure.members)),  // number of fields
   sizeof(@('::'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))),
   @(message.structure.namespaced_type.name)_message_member_array,  // message members
-  init_function__@(message.structure.namespaced_type.name),  // function to initialize message memory (memory has to be allocated)
-  fini_function__@(message.structure.namespaced_type.name)  // function to terminate message instance (will not free memory)
+  @(message.structure.namespaced_type.name)_init_function,  // function to initialize message memory (memory has to be allocated)
+  @(message.structure.namespaced_type.name)_fini_function  // function to terminate message instance (will not free memory)
 };
 
 static const rosidl_message_type_support_t @(message.structure.namespaced_type.name)_message_type_support_handle = {

--- a/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
@@ -49,9 +49,10 @@ namespace @(ns)
 namespace rosidl_typesupport_introspection_cpp
 {
 
-void @(message.structure.namespaced_type.name)_init_function(void * message_memory, bool default_initialize)
+void @(message.structure.namespaced_type.name)_init_function(
+  void * message_memory, rosidl_generator_cpp::MessageInitialization _init)
 {
-  new (message_memory) @('::'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]));
+  new (message_memory) @('::'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))(_init);
 }
 
 void @(message.structure.namespaced_type.name)_fini_function(void * message_memory)

--- a/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
@@ -49,6 +49,17 @@ namespace @(ns)
 namespace rosidl_typesupport_introspection_cpp
 {
 
+void init_function__@(message.structure.namespaced_type.name)(void * message_memory, bool default_initialize)
+{
+  new (message_memory) @('::'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]));
+}
+
+void fini_function__@(message.structure.namespaced_type.name)(void * message_memory)
+{
+  auto typed_message = static_cast<@('::'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name])) *>(message_memory);
+  typed_message->~@(message.structure.namespaced_type.name)();
+}
+
 @[for member in message.structure.members]@
 @{
 def is_vector_bool(member):
@@ -132,7 +143,7 @@ for index, member in enumerate(message.structure.members):
         # size_t string_upper_bound
         print('    0,  // upper bound of string')
         # const rosidl_generator_c::MessageTypeSupportHandle * members_
-        print('    NULL,  // members of sub message')
+        print('    nullptr,  // members of sub message')
     elif isinstance(type_, AbstractGenericString):
         # uint8_t type_id_
         if isinstance(type_, AbstractString):
@@ -144,7 +155,7 @@ for index, member in enumerate(message.structure.members):
         # size_t string_upper_bound
         print('    %u,  // upper bound of string' % (type_.maximum_size if type_.has_maximum_size() else 0))
         # const rosidl_generator_c::MessageTypeSupportHandle * members_
-        print('    NULL,  // members of sub message')
+        print('    nullptr,  // members of sub message')
     else:
         # uint8_t type_id_
         print('    ::rosidl_typesupport_introspection_cpp::ROS_TYPE_MESSAGE,  // type')
@@ -172,7 +183,7 @@ for index, member in enumerate(message.structure.members):
     # void *(void *, size_t) get_function
     print('    %s,  // get(index) function pointer' % ('get_function__%s' % function_suffix if function_suffix else 'nullptr'))
     # void(void *, size_t) resize_function
-    print('    %s  // resize(index) function pointer' % ('resize_function__%s' % function_suffix if function_suffix and isinstance(member.type, AbstractSequence) else 'NULL'))
+    print('    %s  // resize(index) function pointer' % ('resize_function__%s' % function_suffix if function_suffix and isinstance(member.type, AbstractSequence) else 'nullptr'))
 
     if index < len(message.structure.members) - 1:
         print('  },')
@@ -186,7 +197,9 @@ static const ::rosidl_typesupport_introspection_cpp::MessageMembers @(message.st
   "@(message.structure.namespaced_type.name)",  // message name
   @(len(message.structure.members)),  // number of fields
   sizeof(@('::'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))),
-  @(message.structure.namespaced_type.name)_message_member_array  // message members
+  @(message.structure.namespaced_type.name)_message_member_array,  // message members
+  init_function__@(message.structure.namespaced_type.name),  // function to initialize message memory (memory has to be allocated)
+  fini_function__@(message.structure.namespaced_type.name)  // function to terminate message instance (will not free memory)
 };
 
 static const rosidl_message_type_support_t @(message.structure.namespaced_type.name)_message_type_support_handle = {


### PR DESCRIPTION
connects to https://github.com/ros2/ros2/issues/785
fixes https://github.com/ros2/rosidl/issues/404

Signed-off-by: Karsten Knese <karsten@openrobotics.org>

With this PR, one can create a ROS message solely by providing the `rosidl_typesupport_introspection_<c|cpp>`.

depicted below for C, works analog to this in C++
```c
  auto string_typesupports =
    ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, String);
  auto string_ts_c = get_message_typesupport_handle(string_typesupports, rosidl_typesupport_introspection_c__identifier);
  auto introspection_ts = static_cast<const rosidl_typesupport_introspection_c__MessageMembers *>(string_ts_c->data);
  void * message_memory = malloc(introspection_ts->size_of_);
  introspection_ts->init_function(message_memory, true);
  std_msgs__msg__String msg = *static_cast<std_msgs__msg__String *>(message_memory);
  rosidl_generator_c__String__assign(&msg.data, "Hello world!");
  introspection_ts->fini_function(message_memory);
  free(message_memory);
  message_memory = nullptr;
```

Question: I know that in C we can specify whether the data structure should be default initialized or not. Hence the second `bool` parameter for the `init` function. However, looking at the initializer functions for the C datatype, I haven't found any way to specify that. How do I do that?