### PR TITLE
better memory handling for sequences

### DIFF
--- a/rosidl_generator_c/src/primitives_sequence_functions.c
+++ b/rosidl_generator_c/src/primitives_sequence_functions.c
@@ -25,12 +25,9 @@
     if (!sequence) { \
       return false; \
     } \
-    TYPE_NAME * data = NULL; \
-    if (size) { \
-      data = malloc(sizeof(TYPE_NAME) * size); \
-      if (!data) { \
-        return false; \
-      } \
+    TYPE_NAME * data = realloc(sequence->data, sizeof(TYPE_NAME) * size); \
+    if (size && !data) { \
+      return false; \
     } \
     sequence->data = data; \
     sequence->size = size; \

--- a/rosidl_generator_c/src/primitives_sequence_functions.c
+++ b/rosidl_generator_c/src/primitives_sequence_functions.c
@@ -41,18 +41,10 @@
     if (!sequence) { \
       return; \
     } \
-    if (sequence->data) { \
-      /* ensure that data and capacity values are consistent */ \
-      assert(sequence->capacity > 0); \
-      free(sequence->data); \
-      sequence->data = NULL; \
-      sequence->size = 0; \
-      sequence->capacity = 0; \
-    } else { \
-      /* ensure that data, size, and capacity values are consistent */ \
-      assert(0 == sequence->size); \
-      assert(0 == sequence->capacity); \
-    } \
+    free(sequence->data); \
+    sequence->data = NULL; \
+    sequence->size = 0; \
+    sequence->capacity = 0; \
   }
 
 // array functions for all basic types

--- a/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
+++ b/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
@@ -176,7 +176,6 @@ bool @(function_prefix)__resize_function__@(member.type.value_type.name)__@(memb
 {
   @('__'.join(member.type.value_type.namespaced_name()))__Sequence * member =
     (@('__'.join(member.type.value_type.namespaced_name()))__Sequence *)(untyped_member);
-  @('__'.join(member.type.value_type.namespaced_name()))__Sequence__fini(member);
   return @('__'.join(member.type.value_type.namespaced_name()))__Sequence__init(member, size);
 }
 


### PR DESCRIPTION
1) don't leak memory if resized to 0
2) realloc instead of dealloc/malloc
