### PR TITLE
Allow 'get_const_expr_value' to parse either literals or scoped_names…

### DIFF
--- a/rosidl_parser/rosidl_parser/parser.py
+++ b/rosidl_parser/rosidl_parser/parser.py
@@ -522,7 +522,6 @@ def get_annotations(tree):
 
 
 def get_const_expr_value(const_expr):
-    # the const_expr could either be a literal or a name
     # TODO support arbitrary expressions
     expr = list(const_expr.find_data('primary_expr'))
     assert len(expr) == 1, str(expr)
@@ -573,7 +572,7 @@ def get_const_expr_value(const_expr):
 
         assert False, 'Unsupported tree: ' + str(const_expr)
     else:
-        assert False, 'Unknown type: ' + str(child.data)
+        assert False, 'Unsupported tree: ' + str(const_expr)
 
 
 def get_decimal_literal_value(decimal_literal):

--- a/rosidl_parser/rosidl_parser/parser.py
+++ b/rosidl_parser/rosidl_parser/parser.py
@@ -528,9 +528,9 @@ def get_const_expr_value(const_expr):
     primary_expr = expr[0]
     assert len(primary_expr.children) == 1
     child = primary_expr.children[0]
-    if child.data == 'scoped_name':
+    if 'scoped_name' == child.data:
         return str(child.children[0])
-    elif child.data == 'literal':
+    elif 'literal' == child.data:
         literals = list(const_expr.find_data('literal'))
         # TODO support arbitrary expressions
         assert len(literals) == 1, str(const_expr)

--- a/rosidl_parser/rosidl_parser/parser.py
+++ b/rosidl_parser/rosidl_parser/parser.py
@@ -523,6 +523,7 @@ def get_annotations(tree):
 
 def get_const_expr_value(const_expr):
     # the const_expr could either be a literal or a name
+    # TODO support arbitrary expressions
     expr = list(const_expr.find_data('primary_expr'))
     assert len(expr) == 1, str(expr)
     primary_expr = expr[0]
@@ -531,15 +532,12 @@ def get_const_expr_value(const_expr):
     if 'scoped_name' == child.data:
         return str(child.children[0])
     elif 'literal' == child.data:
-        literals = list(const_expr.find_data('literal'))
-        # TODO support arbitrary expressions
-        assert len(literals) == 1, str(const_expr)
-
+        literal = child
         unary_operator_minuses = list(const_expr.find_data('unary_operator_minus'))
         negate_value = len(unary_operator_minuses) % 2
 
-        assert len(literals[0].children) == 1
-        child = literals[0].children[0]
+        assert len(literal.children) == 1
+        child = literal.children[0]
 
         if child.data == 'integer_literal':
             assert len(child.children) == 1

--- a/rosidl_parser/rosidl_parser/parser.py
+++ b/rosidl_parser/rosidl_parser/parser.py
@@ -522,49 +522,58 @@ def get_annotations(tree):
 
 
 def get_const_expr_value(const_expr):
-    literals = list(const_expr.find_data('literal'))
-    # TODO support arbitrary expressions
-    assert len(literals) == 1, str(const_expr)
+    # the const_expr could either be a literal or a name
+    expr = list(const_expr.find_data('primary_expr'))
+    assert len(expr) == 1, str(expr)
+    child = expr[0].children[0]
+    if child.data == 'scoped_name':
+        return str(child.children[0])
+    elif child.data == 'literal':
+        literals = list(const_expr.find_data('literal'))
+        # TODO support arbitrary expressions
+        assert len(literals) == 1, str(const_expr)
 
-    unary_operator_minuses = list(const_expr.find_data('unary_operator_minus'))
-    negate_value = len(unary_operator_minuses) % 2
+        unary_operator_minuses = list(const_expr.find_data('unary_operator_minus'))
+        negate_value = len(unary_operator_minuses) % 2
 
-    assert len(literals[0].children) == 1
-    child = literals[0].children[0]
+        assert len(literals[0].children) == 1
+        child = literals[0].children[0]
 
-    if child.data == 'integer_literal':
-        assert len(child.children) == 1
-        child = child.children[0]
+        if child.data == 'integer_literal':
+            assert len(child.children) == 1
+            child = child.children[0]
 
-        if child.data == 'decimal_literal':
-            value = get_decimal_literal_value(child)
+            if child.data == 'decimal_literal':
+                value = get_decimal_literal_value(child)
+                if negate_value:
+                    value = -value
+                return value
+
+            assert False, 'Unsupported tree: ' + str(child)
+
+        if child.data == 'floating_pt_literal':
+            value = get_floating_pt_literal_value(child)
             if negate_value:
                 value = -value
             return value
 
-        assert False, 'Unsupported tree: ' + str(child)
+        if child.data == 'boolean_literal':
+            assert len(child.children) == 1
+            child = child.children[0]
+            assert child.data in ('boolean_literal_true', 'boolean_literal_false')
+            return child.data == 'boolean_literal_true'
 
-    if child.data == 'floating_pt_literal':
-        value = get_floating_pt_literal_value(child)
-        if negate_value:
-            value = -value
-        return value
+        if child.data == 'string_literals':
+            assert not negate_value
+            return get_string_literals_value(child, allow_unicode=False)
 
-    if child.data == 'boolean_literal':
-        assert len(child.children) == 1
-        child = child.children[0]
-        assert child.data in ('boolean_literal_true', 'boolean_literal_false')
-        return child.data == 'boolean_literal_true'
+        if child.data == 'wide_string_literals':
+            assert not negate_value
+            return get_string_literals_value(child, allow_unicode=True)
 
-    if child.data == 'string_literals':
-        assert not negate_value
-        return get_string_literals_value(child, allow_unicode=False)
-
-    if child.data == 'wide_string_literals':
-        assert not negate_value
-        return get_string_literals_value(child, allow_unicode=True)
-
-    assert False, 'Unsupported tree: ' + str(const_expr)
+        assert False, 'Unsupported tree: ' + str(const_expr)
+    else:
+        assert False, 'Unknown type: ' + str(child.data)
 
 
 def get_decimal_literal_value(decimal_literal):

--- a/rosidl_parser/rosidl_parser/parser.py
+++ b/rosidl_parser/rosidl_parser/parser.py
@@ -525,7 +525,9 @@ def get_const_expr_value(const_expr):
     # the const_expr could either be a literal or a name
     expr = list(const_expr.find_data('primary_expr'))
     assert len(expr) == 1, str(expr)
-    child = expr[0].children[0]
+    primary_expr = expr[0]
+    assert len(primary_expr.children) == 1
+    child = primary_expr.children[0]
     if child.data == 'scoped_name':
         return str(child.children[0])
     elif child.data == 'literal':

--- a/rosidl_parser/test/msg/MyMessage.idl
+++ b/rosidl_parser/test/msg/MyMessage.idl
@@ -13,6 +13,7 @@ module rosidl_parser {
     };
 
     @verbatim ( language="comment", text="Documentation of MyMessage." "Adjacent string literal." )
+    @transfer_mode(SHMEM_REF)
     struct MyMessage {
       short short_value, short_value2;
       @default ( value=123 )

--- a/rosidl_parser/test/test_parser.py
+++ b/rosidl_parser/test/test_parser.py
@@ -160,7 +160,7 @@ def test_message_parser_annotations(message_idl_file):
     assert 'text' in structure.annotations[0].value
     assert structure.annotations[0].value['text'] == \
         'Documentation of MyMessage.Adjacent string literal.'
-        
+
     assert structure.annotations[1].name == 'transfer_mode'
     assert structure.annotations[1].value == 'SHMEM_REF'
 

--- a/rosidl_parser/test/test_parser.py
+++ b/rosidl_parser/test/test_parser.py
@@ -152,7 +152,7 @@ def test_message_parser_annotations(message_idl_file):
     assert len(messages) == 1
     structure = messages[0].structure
 
-    assert len(structure.annotations) == 1
+    assert len(structure.annotations) == 2
     assert structure.annotations[0].name == 'verbatim'
     assert len(structure.annotations[0].value) == 2
     assert 'language' in structure.annotations[0].value
@@ -160,6 +160,9 @@ def test_message_parser_annotations(message_idl_file):
     assert 'text' in structure.annotations[0].value
     assert structure.annotations[0].value['text'] == \
         'Documentation of MyMessage.Adjacent string literal.'
+        
+    assert structure.annotations[1].name == 'transfer_mode'
+    assert structure.annotations[1].value == 'SHMEM_REF'
 
     assert len(structure.members[2].annotations) == 1
 


### PR DESCRIPTION
- Changed the function `get_const_expr_value` in `parser.py` to work when the const expr is a scoped_name as well as when it is a literal

Fixes #429.