### PR TITLE
[backport dashing] Allow 'get_const_expr_value' to parse either literals or scoped_names

### DIFF
--- a/rosidl_parser/test/msg/MyMessage.idl
+++ b/rosidl_parser/test/msg/MyMessage.idl
@@ -13,6 +13,7 @@ module rosidl_parser {
     };
 
     @verbatim ( language="comment", text="Documentation of MyMessage." "Adjacent string literal." )
+    @transfer_mode(SHMEM_REF)
     struct MyMessage {
       short short_value, short_value2;
       @default ( value=123 )

--- a/rosidl_parser/test/test_parser.py
+++ b/rosidl_parser/test/test_parser.py
@@ -152,7 +152,7 @@ def test_message_parser_annotations(message_idl_file):
     assert len(messages) == 1
     structure = messages[0].structure
 
-    assert len(structure.annotations) == 1
+    assert len(structure.annotations) == 2
     assert structure.annotations[0].name == 'verbatim'
     assert len(structure.annotations[0].value) == 2
     assert 'language' in structure.annotations[0].value
@@ -160,6 +160,9 @@ def test_message_parser_annotations(message_idl_file):
     assert 'text' in structure.annotations[0].value
     assert structure.annotations[0].value['text'] == \
         'Documentation of MyMessage.Adjacent string literal.'
+
+    assert structure.annotations[1].name == 'transfer_mode'
+    assert structure.annotations[1].value == 'SHMEM_REF'
 
     assert len(structure.members[2].annotations) == 1
 


### PR DESCRIPTION
Backport of #430.