### PR TITLE
Move repeated logic for C include prefix into common function

### DIFF
--- a/rosidl_generator_c/resource/msg__functions.c.em
+++ b/rosidl_generator_c/resource/msg__functions.c.em
@@ -44,16 +44,6 @@ for member in message.structure.members:
         member_names.append(member.name)
     elif isinstance(type_, NamespacedType):
         include_prefix = idl_structure_type_to_c_include_prefix(type_)
-        if include_prefix.endswith('__request'):
-            include_prefix = include_prefix[:-9]
-        elif include_prefix.endswith('__response'):
-            include_prefix = include_prefix[:-10]
-        if include_prefix.endswith('__goal'):
-            include_prefix = include_prefix[:-6]
-        elif include_prefix.endswith('__result'):
-            include_prefix = include_prefix[:-8]
-        elif include_prefix.endswith('__feedback'):
-            include_prefix = include_prefix[:-10]
         member_names = includes.setdefault(
             include_prefix + '__functions.h', [])
         member_names.append(member.name)

--- a/rosidl_generator_c/resource/msg__struct.h.em
+++ b/rosidl_generator_c/resource/msg__struct.h.em
@@ -44,16 +44,6 @@ for member in message.structure.members:
         member_names.append(member.name)
     elif isinstance(type_, NamespacedType):
         include_prefix = idl_structure_type_to_c_include_prefix(type_)
-        if include_prefix.endswith('__request'):
-            include_prefix = include_prefix[:-9]
-        elif include_prefix.endswith('__response'):
-            include_prefix = include_prefix[:-10]
-        if include_prefix.endswith('__goal'):
-            include_prefix = include_prefix[:-6]
-        elif include_prefix.endswith('__result'):
-            include_prefix = include_prefix[:-8]
-        elif include_prefix.endswith('__feedback'):
-            include_prefix = include_prefix[:-10]
         member_names = includes.setdefault(
             include_prefix + '__struct.h', [])
         member_names.append(member.name)

--- a/rosidl_generator_c/rosidl_generator_c/__init__.py
+++ b/rosidl_generator_c/rosidl_generator_c/__init__.py
@@ -70,9 +70,21 @@ BASIC_IDL_TYPES_TO_C = {
 
 
 def idl_structure_type_to_c_include_prefix(namespaced_type):
-    return '/'.join(
+    include_prefix = '/'.join(
         convert_camel_case_to_lower_case_underscore(x)
         for x in (namespaced_type.namespaced_name()))
+    # Strip service or action suffixes
+    if include_prefix.endswith('__request'):
+        include_prefix = include_prefix[:-9]
+    elif include_prefix.endswith('__response'):
+        include_prefix = include_prefix[:-10]
+    if include_prefix.endswith('__goal'):
+        include_prefix = include_prefix[:-6]
+    elif include_prefix.endswith('__result'):
+        include_prefix = include_prefix[:-8]
+    elif include_prefix.endswith('__feedback'):
+        include_prefix = include_prefix[:-10]
+    return include_prefix
 
 
 def idl_structure_type_to_c_typename(namespaced_type):

--- a/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
+++ b/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
@@ -66,16 +66,6 @@ for member in message.structure.members:
         member_names.append(member.name)
     elif isinstance(type_, NamespacedType):
         include_prefix = idl_structure_type_to_c_include_prefix(type_)
-        if include_prefix.endswith('__request'):
-            include_prefix = include_prefix[:-9]
-        elif include_prefix.endswith('__response'):
-            include_prefix = include_prefix[:-10]
-        if include_prefix.endswith('__goal'):
-            include_prefix = include_prefix[:-6]
-        elif include_prefix.endswith('__result'):
-            include_prefix = include_prefix[:-8]
-        elif include_prefix.endswith('__feedback'):
-            include_prefix = include_prefix[:-10]
         member_names = includes.setdefault(
             include_prefix + '.h', [])
         member_names.append(member.name)


### PR DESCRIPTION
The same logic for stripping the end of the include prefix for services and actions was repeated in several places.
This is a minor refactor moving the logic to a common place.