### PR TITLE
add readme with link to rosidl doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# rosidl
+
+```rosidl``` is one of the ros_core packages.
+See [documentation](http://docs.ros2.org/eloquent/developer_overview.html#the-rosidl-repository) for details of this package.


### PR DESCRIPTION
Not sure what the long term plan is with `docs.ros2.org`, but since all the `rosidl` documentation is there, I figured it would be helpful to supply a link on the readme. 