### PR TITLE
code style only: wrap after open parenthesis if not in one line

### DIFF
--- a/rosidl_generator_c/src/string_functions.c
+++ b/rosidl_generator_c/src/string_functions.c
@@ -44,7 +44,8 @@ rosidl_generator_c__String__fini(rosidl_generator_c__String * str)
   if (str->data) {
     /* ensure that data and capacity values are consistent */
     if (str->capacity <= 0) {
-      fprintf(stderr, "Unexpected condition: string capacity was zero for allocated data! "
+      fprintf(
+        stderr, "Unexpected condition: string capacity was zero for allocated data! "
         "Exiting.\n");
       exit(-1);
     }
@@ -55,12 +56,14 @@ rosidl_generator_c__String__fini(rosidl_generator_c__String * str)
   } else {
     /* ensure that data, size, and capacity values are consistent */
     if (0 != str->size) {
-      fprintf(stderr, "Unexpected condition: string size was non-zero for deallocated data! "
+      fprintf(
+        stderr, "Unexpected condition: string size was non-zero for deallocated data! "
         "Exiting.\n");
       exit(-1);
     }
     if (0 != str->capacity) {
-      fprintf(stderr, "Unexpected behavior: string capacity was non-zero for deallocated data! "
+      fprintf(
+        stderr, "Unexpected behavior: string capacity was non-zero for deallocated data! "
         "Exiting.\n");
       exit(-1);
     }

--- a/rosidl_generator_c/src/u16string_functions.c
+++ b/rosidl_generator_c/src/u16string_functions.c
@@ -44,7 +44,8 @@ rosidl_generator_c__U16String__fini(rosidl_generator_c__U16String * str)
   if (str->data) {
     /* ensure that data and capacity values are consistent */
     if (str->capacity <= 0) {
-      fprintf(stderr, "Unexpected condition: string capacity was zero for allocated data! "
+      fprintf(
+        stderr, "Unexpected condition: string capacity was zero for allocated data! "
         "Exiting.\n");
       exit(-1);
     }
@@ -55,12 +56,14 @@ rosidl_generator_c__U16String__fini(rosidl_generator_c__U16String * str)
   } else {
     /* ensure that data, size, and capacity values are consistent */
     if (0 != str->size) {
-      fprintf(stderr, "Unexpected condition: string size was non-zero for deallocated data! "
+      fprintf(
+        stderr, "Unexpected condition: string size was non-zero for deallocated data! "
         "Exiting.\n");
       exit(-1);
     }
     if (0 != str->capacity) {
-      fprintf(stderr, "Unexpected behavior: string capacity was non-zero for deallocated data! "
+      fprintf(
+        stderr, "Unexpected behavior: string capacity was non-zero for deallocated data! "
         "Exiting.\n");
       exit(-1);
     }

--- a/rosidl_generator_cpp/test/test_interfaces.cpp
+++ b/rosidl_generator_cpp/test/test_interfaces.cpp
@@ -195,33 +195,47 @@ void test_message_basic_types(rosidl_generator_cpp::msg::BasicTypes message)
 
 void test_message_bounded(rosidl_generator_cpp::msg::BoundedSequences message)
 {
-  TEST_BOUNDED_SEQUENCE_TYPES(message, bool_values, bool, SEQUENCE_SIZE, \
+  TEST_BOUNDED_SEQUENCE_TYPES(
+    message, bool_values, bool, SEQUENCE_SIZE, \
     false, true)
-  TEST_BOUNDED_SEQUENCE_TYPES(message, char_values, unsigned char, SEQUENCE_SIZE, \
+  TEST_BOUNDED_SEQUENCE_TYPES(
+    message, char_values, unsigned char, SEQUENCE_SIZE, \
     0, UINT8_MAX)
-  TEST_BOUNDED_SEQUENCE_TYPES(message, byte_values, uint8_t, SEQUENCE_SIZE, \
+  TEST_BOUNDED_SEQUENCE_TYPES(
+    message, byte_values, uint8_t, SEQUENCE_SIZE, \
     0, UINT8_MAX)
-  TEST_BOUNDED_SEQUENCE_TYPES(message, float32_values, float, SEQUENCE_SIZE, \
+  TEST_BOUNDED_SEQUENCE_TYPES(
+    message, float32_values, float, SEQUENCE_SIZE, \
     FLT_MIN, FLT_MAX)
-  TEST_BOUNDED_SEQUENCE_TYPES(message, float64_values, double, SEQUENCE_SIZE, \
+  TEST_BOUNDED_SEQUENCE_TYPES(
+    message, float64_values, double, SEQUENCE_SIZE, \
     DBL_MIN, DBL_MAX)
-  TEST_BOUNDED_SEQUENCE_TYPES(message, int8_values, int8_t, SEQUENCE_SIZE, \
+  TEST_BOUNDED_SEQUENCE_TYPES(
+    message, int8_values, int8_t, SEQUENCE_SIZE, \
     INT8_MIN, INT8_MAX)
-  TEST_BOUNDED_SEQUENCE_TYPES(message, uint8_values, uint8_t, SEQUENCE_SIZE, \
+  TEST_BOUNDED_SEQUENCE_TYPES(
+    message, uint8_values, uint8_t, SEQUENCE_SIZE, \
     0, UINT8_MAX)
-  TEST_BOUNDED_SEQUENCE_TYPES(message, int16_values, int16_t, SEQUENCE_SIZE, \
+  TEST_BOUNDED_SEQUENCE_TYPES(
+    message, int16_values, int16_t, SEQUENCE_SIZE, \
     INT16_MIN, INT16_MAX)
-  TEST_BOUNDED_SEQUENCE_TYPES(message, uint16_values, uint16_t, SEQUENCE_SIZE, \
+  TEST_BOUNDED_SEQUENCE_TYPES(
+    message, uint16_values, uint16_t, SEQUENCE_SIZE, \
     0, UINT16_MAX)
-  TEST_BOUNDED_SEQUENCE_TYPES(message, int32_values, int32_t, SEQUENCE_SIZE, \
+  TEST_BOUNDED_SEQUENCE_TYPES(
+    message, int32_values, int32_t, SEQUENCE_SIZE, \
     INT32_MIN, INT32_MAX)
-  TEST_BOUNDED_SEQUENCE_TYPES(message, uint32_values, uint32_t, SEQUENCE_SIZE, \
+  TEST_BOUNDED_SEQUENCE_TYPES(
+    message, uint32_values, uint32_t, SEQUENCE_SIZE, \
     0, UINT32_MAX)
-  TEST_BOUNDED_SEQUENCE_TYPES(message, int64_values, int64_t, SEQUENCE_SIZE, \
+  TEST_BOUNDED_SEQUENCE_TYPES(
+    message, int64_values, int64_t, SEQUENCE_SIZE, \
     INT64_MIN, INT64_MAX)
-  TEST_BOUNDED_SEQUENCE_TYPES(message, uint64_values, uint64_t, SEQUENCE_SIZE, \
+  TEST_BOUNDED_SEQUENCE_TYPES(
+    message, uint64_values, uint64_t, SEQUENCE_SIZE, \
     0, UINT64_MAX)
-  TEST_BOUNDED_SEQUENCE_STRING(message, string_values, std::string, SEQUENCE_SIZE, \
+  TEST_BOUNDED_SEQUENCE_STRING(
+    message, string_values, std::string, SEQUENCE_SIZE, \
     0, UINT32_MAX, 0, BOUNDED_STRING_LENGTH)
 }
 
@@ -247,33 +261,47 @@ void test_message_bounded(rosidl_generator_cpp::msg::BoundedSequences message)
 
 void test_message_unbounded(rosidl_generator_cpp::msg::UnboundedSequences message)
 {
-  TEST_UNBOUNDED_SEQUENCE_TYPES(message, bool_values, bool, SEQUENCE_SIZE, \
+  TEST_UNBOUNDED_SEQUENCE_TYPES(
+    message, bool_values, bool, SEQUENCE_SIZE, \
     false, true)
-  TEST_UNBOUNDED_SEQUENCE_TYPES(message, char_values, unsigned char, SEQUENCE_SIZE, \
+  TEST_UNBOUNDED_SEQUENCE_TYPES(
+    message, char_values, unsigned char, SEQUENCE_SIZE, \
     0, UINT8_MAX)
-  TEST_UNBOUNDED_SEQUENCE_TYPES(message, byte_values, uint8_t, SEQUENCE_SIZE, \
+  TEST_UNBOUNDED_SEQUENCE_TYPES(
+    message, byte_values, uint8_t, SEQUENCE_SIZE, \
     0, UINT8_MAX)
-  TEST_UNBOUNDED_SEQUENCE_TYPES(message, float32_values, float, SEQUENCE_SIZE, \
+  TEST_UNBOUNDED_SEQUENCE_TYPES(
+    message, float32_values, float, SEQUENCE_SIZE, \
     FLT_MIN, FLT_MAX)
-  TEST_UNBOUNDED_SEQUENCE_TYPES(message, float64_values, double, SEQUENCE_SIZE, \
+  TEST_UNBOUNDED_SEQUENCE_TYPES(
+    message, float64_values, double, SEQUENCE_SIZE, \
     DBL_MIN, DBL_MAX)
-  TEST_UNBOUNDED_SEQUENCE_TYPES(message, int8_values, int8_t, SEQUENCE_SIZE, \
+  TEST_UNBOUNDED_SEQUENCE_TYPES(
+    message, int8_values, int8_t, SEQUENCE_SIZE, \
     INT8_MIN, INT8_MAX)
-  TEST_UNBOUNDED_SEQUENCE_TYPES(message, uint8_values, uint8_t, SEQUENCE_SIZE, \
+  TEST_UNBOUNDED_SEQUENCE_TYPES(
+    message, uint8_values, uint8_t, SEQUENCE_SIZE, \
     0, UINT8_MAX)
-  TEST_UNBOUNDED_SEQUENCE_TYPES(message, int16_values, int16_t, SEQUENCE_SIZE, \
+  TEST_UNBOUNDED_SEQUENCE_TYPES(
+    message, int16_values, int16_t, SEQUENCE_SIZE, \
     INT16_MIN, INT16_MAX)
-  TEST_UNBOUNDED_SEQUENCE_TYPES(message, uint16_values, uint16_t, SEQUENCE_SIZE, \
+  TEST_UNBOUNDED_SEQUENCE_TYPES(
+    message, uint16_values, uint16_t, SEQUENCE_SIZE, \
     0, UINT16_MAX)
-  TEST_UNBOUNDED_SEQUENCE_TYPES(message, int32_values, int32_t, SEQUENCE_SIZE, \
+  TEST_UNBOUNDED_SEQUENCE_TYPES(
+    message, int32_values, int32_t, SEQUENCE_SIZE, \
     INT32_MIN, INT32_MAX)
-  TEST_UNBOUNDED_SEQUENCE_TYPES(message, uint32_values, uint32_t, SEQUENCE_SIZE, \
+  TEST_UNBOUNDED_SEQUENCE_TYPES(
+    message, uint32_values, uint32_t, SEQUENCE_SIZE, \
     0, UINT32_MAX)
-  TEST_UNBOUNDED_SEQUENCE_TYPES(message, int64_values, int64_t, SEQUENCE_SIZE, \
+  TEST_UNBOUNDED_SEQUENCE_TYPES(
+    message, int64_values, int64_t, SEQUENCE_SIZE, \
     INT64_MIN, INT64_MAX)
-  TEST_UNBOUNDED_SEQUENCE_TYPES(message, uint64_values, uint64_t, SEQUENCE_SIZE, \
+  TEST_UNBOUNDED_SEQUENCE_TYPES(
+    message, uint64_values, uint64_t, SEQUENCE_SIZE, \
     0, UINT64_MAX)
-  TEST_UNBOUNDED_SEQUENCE_STRING(message, string_values, std::string, SEQUENCE_SIZE, \
+  TEST_UNBOUNDED_SEQUENCE_STRING(
+    message, string_values, std::string, SEQUENCE_SIZE, \
     0, UINT32_MAX, 0, UINT16_MAX)
 }
 
@@ -287,31 +315,44 @@ void test_message_unbounded(rosidl_generator_cpp::msg::UnboundedSequences messag
 
 void test_message_arrays(rosidl_generator_cpp::msg::Arrays message)
 {
-  TEST_ARRAY_TYPES(message, bool_values, bool, ARRAY_SIZE, \
+  TEST_ARRAY_TYPES(
+    message, bool_values, bool, ARRAY_SIZE, \
     false, true)
-  TEST_ARRAY_TYPES(message, char_values, unsigned char, ARRAY_SIZE, \
+  TEST_ARRAY_TYPES(
+    message, char_values, unsigned char, ARRAY_SIZE, \
     0, UINT8_MAX)
-  TEST_ARRAY_TYPES(message, byte_values, uint8_t, ARRAY_SIZE, \
+  TEST_ARRAY_TYPES(
+    message, byte_values, uint8_t, ARRAY_SIZE, \
     0, UINT8_MAX)
-  TEST_ARRAY_TYPES(message, float32_values, float, ARRAY_SIZE, \
+  TEST_ARRAY_TYPES(
+    message, float32_values, float, ARRAY_SIZE, \
     FLT_MIN, FLT_MAX)
-  TEST_ARRAY_TYPES(message, float64_values, double, ARRAY_SIZE, \
+  TEST_ARRAY_TYPES(
+    message, float64_values, double, ARRAY_SIZE, \
     DBL_MIN, DBL_MAX)
-  TEST_ARRAY_TYPES(message, int8_values, int8_t, ARRAY_SIZE, \
+  TEST_ARRAY_TYPES(
+    message, int8_values, int8_t, ARRAY_SIZE, \
     INT8_MIN, INT8_MAX)
-  TEST_ARRAY_TYPES(message, uint8_values, uint8_t, ARRAY_SIZE, \
+  TEST_ARRAY_TYPES(
+    message, uint8_values, uint8_t, ARRAY_SIZE, \
     0, UINT8_MAX)
-  TEST_ARRAY_TYPES(message, int16_values, int16_t, ARRAY_SIZE, \
+  TEST_ARRAY_TYPES(
+    message, int16_values, int16_t, ARRAY_SIZE, \
     INT16_MIN, INT16_MAX)
-  TEST_ARRAY_TYPES(message, uint16_values, uint16_t, ARRAY_SIZE, \
+  TEST_ARRAY_TYPES(
+    message, uint16_values, uint16_t, ARRAY_SIZE, \
     0, UINT16_MAX)
-  TEST_ARRAY_TYPES(message, int32_values, int32_t, ARRAY_SIZE, \
+  TEST_ARRAY_TYPES(
+    message, int32_values, int32_t, ARRAY_SIZE, \
     INT32_MIN, INT32_MAX)
-  TEST_ARRAY_TYPES(message, uint32_values, uint32_t, ARRAY_SIZE, \
+  TEST_ARRAY_TYPES(
+    message, uint32_values, uint32_t, ARRAY_SIZE, \
     0, UINT32_MAX)
-  TEST_ARRAY_TYPES(message, int64_values, int64_t, ARRAY_SIZE, \
+  TEST_ARRAY_TYPES(
+    message, int64_values, int64_t, ARRAY_SIZE, \
     INT64_MIN, INT64_MAX)
-  TEST_ARRAY_TYPES(message, uint64_values, uint64_t, ARRAY_SIZE, \
+  TEST_ARRAY_TYPES(
+    message, uint64_values, uint64_t, ARRAY_SIZE, \
     0, UINT64_MAX)
 }
 
@@ -492,6 +533,7 @@ TEST(Test_messages, Test_wstring) {
 
 TEST(Test_messages, Test_string_array_static) {
   rosidl_generator_cpp::msg::Arrays message;
-  TEST_STATIC_ARRAY_STRING(message, string_values_default, std::string, ARRAY_SIZE, \
+  TEST_STATIC_ARRAY_STRING(
+    message, string_values_default, std::string, ARRAY_SIZE, \
     0, UINT32_MAX, 0, UINT16_MAX)
 }

--- a/rosidl_generator_cpp/test/test_msg_initialization.cpp
+++ b/rosidl_generator_cpp/test/test_msg_initialization.cpp
@@ -188,16 +188,20 @@ TEST(Test_msg_initialization, skip_constructor) {
   #  pragma GCC diagnostic push
   #  pragma GCC diagnostic ignored "-Wstrict-aliasing"
   #endif
-  ASSERT_TRUE(std::all_of(bounded->float32_values_default.begin(),
-    bounded->float32_values_default.end(), [](float i) {
-      uint32_t float32_bit_pattern = *reinterpret_cast<uint32_t *>(&i);
-      return 0xfefefefe == float32_bit_pattern;
-    }));
-  ASSERT_TRUE(std::all_of(bounded->float64_values_default.begin(),
-    bounded->float64_values_default.end(), [](double i) {
-      uint64_t float64_bit_pattern = *reinterpret_cast<uint64_t *>(&i);
-      return 0xfefefefefefefefe == float64_bit_pattern;
-    }));
+  ASSERT_TRUE(
+    std::all_of(
+      bounded->float32_values_default.begin(),
+      bounded->float32_values_default.end(), [](float i) {
+        uint32_t float32_bit_pattern = *reinterpret_cast<uint32_t *>(&i);
+        return 0xfefefefe == float32_bit_pattern;
+      }));
+  ASSERT_TRUE(
+    std::all_of(
+      bounded->float64_values_default.begin(),
+      bounded->float64_values_default.end(), [](double i) {
+        uint64_t float64_bit_pattern = *reinterpret_cast<uint64_t *>(&i);
+        return 0xfefefefefefefefe == float64_bit_pattern;
+      }));
 
   #ifndef _WIN32
   #  pragma GCC diagnostic pop
@@ -205,8 +209,10 @@ TEST(Test_msg_initialization, skip_constructor) {
   ASSERT_EQ(0UL, bounded->float64_values_default.size());
   ASSERT_EQ(0UL, bounded->float32_values_default.size());
   ASSERT_EQ(0UL, bounded->float32_values.size());
-  ASSERT_TRUE(std::all_of(bounded->string_values_default.begin(),
-    bounded->string_values_default.end(), [](std::string i) {
-      return "" == i;
-    }));
+  ASSERT_TRUE(
+    std::all_of(
+      bounded->string_values_default.begin(),
+      bounded->string_values_default.end(), [](std::string i) {
+        return "" == i;
+      }));
 }


### PR DESCRIPTION
Style update to match the ROS 2 development guide and pass with the updated linter configuration from ament/ament_lint#210.