### PR TITLE
Added rosidl_generator_c as a member of group rosidl_runtime_packages

### DIFF
--- a/rosidl_generator_c/package.xml
+++ b/rosidl_generator_c/package.xml
@@ -25,6 +25,7 @@
   <test_depend>test_interface_files</test_depend>
 
   <member_of_group>rosidl_generator_packages</member_of_group>
+  <member_of_group>rosidl_runtime_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
As discussed in this issue https://github.com/ros2/rosidl/issues/437, for consistency `rosidl_generator_c` is added as a member of group `rosidl_runtime_packages`