### PR TITLE
Fix bug inserting bounded_vector in reverse order

### DIFF
--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/bounded_vector.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/bounded_vector.hpp
@@ -629,7 +629,8 @@ public:
     InputIterator first,
     InputIterator last)
   {
-    if (size() + std::distance(first, last) > UpperBound) {
+    auto dist = std::distance(first, last);
+    if ((dist < 0) || (size() + static_cast<size_t>(dist) > UpperBound)) {
       throw std::length_error("Exceeded upper bound");
     }
     return Base::insert(position, first, last);

--- a/rosidl_runtime_cpp/test/test_bounded_vector.cpp
+++ b/rosidl_runtime_cpp/test/test_bounded_vector.cpp
@@ -50,3 +50,19 @@ TEST(rosidl_generator_cpp, bounded_vector_rvalue) {
   ASSERT_EQ(vv[0], 1);
   ASSERT_EQ(vv[1], 2);
 }
+
+TEST(rosidl_generator_cpp, bounded_vector_insert) {
+  rosidl_runtime_cpp::BoundedVector<int, 6> v1;
+  v1.push_back(1);
+  auto it = v1.begin();
+  rosidl_runtime_cpp::BoundedVector<int, 3> v2;
+  v2.push_back(2);
+  v2.push_back(3);
+  v2.push_back(4);
+  // insert v2 after the first position in reverse order
+  ASSERT_THROW(v1.insert(it + 1, v2.end(), v2.begin()), std::length_error);
+  // insert v2 after the 1st position
+  ASSERT_NO_THROW(v1.insert(it + 1, v2.begin(), v2.end()));
+  // insert v2 after the 4th position
+  ASSERT_THROW(v1.insert(it + 4, v2.begin(), v2.end()), std::length_error);
+}


### PR DESCRIPTION
This PR fixes a bug which allowed to insert `bounded_vector` in reverse order. 

This fix was originally implemented by @sumanth-nirmal.