### PR TITLE
Fix move assignment of bounded vector

### DIFF
--- a/rosidl_generator_cpp/include/rosidl_generator_cpp/bounded_vector.hpp
+++ b/rosidl_generator_cpp/include/rosidl_generator_cpp/bounded_vector.hpp
@@ -218,7 +218,7 @@ public:
   BoundedVector &
   operator=(BoundedVector && __x)
   {
-    (void)_Base::operator=(std::forward<_Base &&>(__x));
+    (void)_Base::operator=(std::move(__x));
     return *this;
   }
 


### PR DESCRIPTION
This PR fixes the move assignment of bounded vector. `std::move` should be used instead of `std::forward` because the parameter it's not a forwarding reference but a rvalue reference of the template class `BoundedVector`.
 
This fix was originally implemented by Andreas Pasternak.