### PR TITLE
Add an EXCLUDE parameter to rosidl_generate_interfaces

### DIFF
--- a/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
@@ -47,13 +47,15 @@
 # :param ADD_LINTER_TESTS: if set lint the interface files using
 #   the ``ament_lint`` package
 # :type ADD_LINTER_TESTS: option
+# :param EXCLUDE: List of packages that should be skipped
+# :type EXCLUDE: list of strings
 #
 # @public
 #
 macro(rosidl_generate_interfaces target)
   cmake_parse_arguments(_ARG
     "ADD_LINTER_TESTS;SKIP_INSTALL;SKIP_GROUP_MEMBERSHIP_CHECK"
-    "LIBRARY_NAME" "DEPENDENCIES"
+    "LIBRARY_NAME" "DEPENDENCIES;EXCLUDE"
     ${ARGN})
   if(NOT _ARG_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "rosidl_generate_interfaces() called without any "
@@ -283,7 +285,7 @@ macro(rosidl_generate_interfaces target)
     list(APPEND rosidl_generate_interfaces_ABS_IDL_FILES "${_abs_idl_file}")
   endforeach()
 
-  ament_execute_extensions("rosidl_generate_idl_interfaces")
+  ament_execute_extensions("rosidl_generate_idl_interfaces" EXCLUDE ${_ARG_EXCLUDE})
 
   # check for extensions registered with the previous extension point
   set(obsolete_extension_point "rosidl_generate_interfaces")


### PR DESCRIPTION
I found a super weird issue while testing https://github.com/ros2/rmw_dds_common/pull/4 on Windows.
I later realized that the problem is when using `colcon` `--merge-install` build option.

#### Steps to reproduce the issue

In a ros2 workspace with usual ros2 packages (ros2.repos master):
```
cd /path/to/workspace/src/ros2 && git clone https://github.com/ros2/rmw_dds_common/ && git checkout ivanpauno/first-implementation
cd /path/to/workspace/
colcon build --merge-install --packages-up-to rclpy
colcon build --merge-install --packages-select --cmake-force-configure rmw_dds_common
```

First build command goes well, the second one fails:
<details>
<summary>output</summary>

```
--- stderr: rmw_dds_common                             
CMake Error at /home/ivanpauno/ros2_ws/other_ws/merge_install_rebased_ros2_node_participant_ws/install/share/rosidl_cmake/cmake/rosidl_target_interfaces.cmake:44 (message):
  rosidl_target_interfaces() the second argument 'rmw_dds_common_interfaces'
  concatenated with the third argument 'rosidl_typesupport_c' using double
  underscores must be a valid target name
Call Stack (most recent call first):
  /home/ivanpauno/ros2_ws/other_ws/merge_install_rebased_ros2_node_participant_ws/install/share/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake:220 (rosidl_target_interfaces)
  /home/ivanpauno/ros2_ws/other_ws/merge_install_rebased_ros2_node_participant_ws/install/share/ament_cmake_core/cmake/core/ament_execute_extensions.cmake:48 (include)
  /home/ivanpauno/ros2_ws/other_ws/merge_install_rebased_ros2_node_participant_ws/install/share/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake:286 (ament_execute_extensions)
  CMakeLists.txt:27 (rosidl_generate_interfaces)


---
Failed   <<< rmw_dds_common     [ Exited with code 1 ]
```

</details>

#### Explanation of the issue

In the first build, `rosidl_generator_py` is not used to generate the messages, as it's build after `rmw_dds_common`:
https://github.com/ros2/rmw_dds_common/blob/dc989e4f8f3fd2db997d6ba04aac6646b7e3acb3/rmw_dds_common_generators/package.xml#L17-L21

Second time, `rosidl_generator_py` was already build and installed.
`rosidl_generator_c` extension doesn't do nothing, because it generated the files in the previous build.
`rosidl_generator_py` depends on `rosidl_generator_c` target that is not present, and it fails.

#### Proposed workaround

Add a way to exclude a package.
`ament_execute_extensions` already supports that.
Exclude `rosidl_generator_py` in `rmw_dds_common`.

I've tried this fix, it does work well.

#### Long term fix

In general, I find strange that the second build does something different that the first one.
That's the case only when `--merge-install` is used.

It would be great if extensions are look only in the dependencies specified in the `package.xml` -- which would require a way to parse them from cmake --, or pass to `ament_execute_extensions` a list of allowed packages, instead of excluding.