### PR TITLE
Export typesupport library in a separate cmake variable

### DIFF
--- a/rosidl_typesupport_introspection_c/cmake/rosidl_typesupport_introspection_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_introspection_c/cmake/rosidl_typesupport_introspection_c_generate_interfaces.cmake
@@ -116,6 +116,9 @@ foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
   ament_target_dependencies(
     ${rosidl_generate_interfaces_TARGET}${_target_suffix}
     ${_pkg_name})
+  target_link_libraries(
+    ${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    ${${_pkg_name}_LIBRARIES${_target_suffix}})
 endforeach()
 
 add_dependencies(
@@ -137,7 +140,8 @@ if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin
   )
-  ament_export_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix})
+  rosidl_export_typesupport_libraries(${_target_suffix}
+    ${rosidl_generate_interfaces_TARGET}${_target_suffix})
 endif()
 
 if(BUILD_TESTING AND rosidl_generate_interfaces_ADD_LINTER_TESTS)

--- a/rosidl_typesupport_introspection_cpp/cmake/rosidl_typesupport_introspection_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_introspection_cpp/cmake/rosidl_typesupport_introspection_cpp_generate_interfaces.cmake
@@ -104,6 +104,9 @@ foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
   ament_target_dependencies(
     ${rosidl_generate_interfaces_TARGET}${_target_suffix}
     ${_pkg_name})
+  target_link_libraries(
+    ${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    ${${_pkg_name}_LIBRARIES${_target_suffix}})
 endforeach()
 
 add_dependencies(
@@ -129,7 +132,8 @@ if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin
   )
-  ament_export_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix})
+  rosidl_export_typesupport_libraries(${_target_suffix}
+    ${rosidl_generate_interfaces_TARGET}${_target_suffix})
 endif()
 
 if(BUILD_TESTING AND rosidl_generate_interfaces_ADD_LINTER_TESTS)


### PR DESCRIPTION
#### TL;DR

Same as https://github.com/ros2/rosidl_typesupport_connext/commit/56e609d09b1eee0abce9095f7322528b8ca9024b.
See https://github.com/ros2/rosidl/pull/284 and https://github.com/ros2/ros2/issues/437 for further reference.

#### Long story

Generated interfaces' typesupports shouldn't be exported in `${PROJECT_NAME}_LIBRARIES` cmake variable.
`rosidl_typesupport_connext_*` is already handling this correctly.

These generated typesupport libraries are only needed when linking by:
- Dependent messages. This PR is already adding the `target_link_libraries` needed to consider the new variable.
- When only one typesupport is available, the generated `rosidl_typesupport_c` or `rosidl_typesupport_cpp` will need to link against the specific typesupport generated here. Preexisting code was already considering the existence of the variable used here https://github.com/ros2/rosidl_typesupport/blob/4847322f6a03e5a2ec5cf0498ec8d93d0be8f7b4/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_interfaces.cmake#L119-L120, so there's nothing else to fix. In case multiple typesupports are available, POCO is used and there's no need to link against the libraries generated here.

Why now?

When testing https://github.com/ros2/rmw_fastrtps/pull/312, I find two new regressions in the `os X` job https://ci.ros2.org/job/ci_osx/7989/:

- https://ci.ros2.org/job/ci_osx/7989/testReport/junit/(root)/projectroot/test_gid_message/
- https://ci.ros2.org/job/ci_osx/7989/testReport/junit/projectroot/test/test_dds_attributes_to_rmw_qos/

Those tests where failing when loading `librmw_dds_common_interfaces__rosidl_typesupport_introspection_cpp.so` because `librosidl_typesupport_introspection_c.dylib` wasn't found.
That library isn't needed at all by the package, and shouldn't be linked against in the first place.

This PR together with https://github.com/ros2/rmw_fastrtps/pull/312/commits/8b6f5567d659c869ffa30bc43df66661333b8b1b fix that bug, and I'm only linking against the typesupport I need now.