### PR TITLE
only export ament_cmake_core instead of ament_cmake

### DIFF
--- a/rosidl_generator_c/package.xml
+++ b/rosidl_generator_c/package.xml
@@ -10,7 +10,7 @@
   <buildtool_depend>ament_cmake_python</buildtool_depend>
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
-  <buildtool_export_depend>ament_cmake</buildtool_export_depend>
+  <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
 
   <build_export_depend>rosidl_typesupport_interface</build_export_depend>

--- a/rosidl_generator_cpp/package.xml
+++ b/rosidl_generator_cpp/package.xml
@@ -10,7 +10,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <buildtool_export_depend>ament_cmake</buildtool_export_depend>
+  <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
 
   <!-- This is needed for the rosidl_message_type_support_t struct and visibility macros -->


### PR DESCRIPTION
Based on the API reviews #446 and #447.

Only `ament_cmake_core` is used downstream by the exported CMake logic:
* https://github.com/ros2/rosidl/blob/0b938b05bec0a2a5196e136b83ed29a04c1765af/rosidl_generator_c/cmake/register_c.cmake#L16
* https://github.com/ros2/rosidl/blob/0b938b05bec0a2a5196e136b83ed29a04c1765af/rosidl_generator_cpp/cmake/register_cpp.cmake#L16

[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10113)](https://ci.ros2.org/job/ci_linux/10113/)