### PR TITLE
move non-entry point headers into detail subdir

### DIFF
--- a/rosidl_generator_c/cmake/rosidl_generator_c_generate_interfaces.cmake
+++ b/rosidl_generator_c/cmake/rosidl_generator_c_generate_interfaces.cmake
@@ -24,12 +24,12 @@ foreach(_abs_idl_file ${rosidl_generate_interfaces_ABS_IDL_FILES})
   string_camel_case_to_lower_case_underscore("${_idl_name}" _header_name)
   list(APPEND _generated_headers
     "${_output_path}/${_parent_folder}/${_header_name}.h"
-    "${_output_path}/${_parent_folder}/${_header_name}__functions.h"
-    "${_output_path}/${_parent_folder}/${_header_name}__struct.h"
-    "${_output_path}/${_parent_folder}/${_header_name}__type_support.h"
+    "${_output_path}/${_parent_folder}/detail/${_header_name}__functions.h"
+    "${_output_path}/${_parent_folder}/detail/${_header_name}__struct.h"
+    "${_output_path}/${_parent_folder}/detail/${_header_name}__type_support.h"
   )
   list(APPEND _generated_sources
-    "${_output_path}/${_parent_folder}/${_header_name}__functions.c"
+    "${_output_path}/${_parent_folder}/detail/${_header_name}__functions.c"
   )
 endforeach()
 

--- a/rosidl_generator_c/resource/idl.h.em
+++ b/rosidl_generator_c/resource/idl.h.em
@@ -15,8 +15,10 @@
 from rosidl_cmake import convert_camel_case_to_lower_case_underscore
 include_parts = [package_name] + list(interface_path.parents[0].parts) + \
     [convert_camel_case_to_lower_case_underscore(interface_path.stem)]
+include_parts_detail = [package_name] + list(interface_path.parents[0].parts) + [
+    'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
 header_guard_variable = '__'.join([x.upper() for x in include_parts]) + '_H_'
-include_base = '/'.join(include_parts)
+include_base = '/'.join(include_parts_detail)
 }@
 #ifndef @(header_guard_variable)
 #define @(header_guard_variable)

--- a/rosidl_generator_c/resource/idl__functions.c.em
+++ b/rosidl_generator_c/resource/idl__functions.c.em
@@ -12,8 +12,8 @@
 @#######################################################################
 @{
 from rosidl_cmake import convert_camel_case_to_lower_case_underscore
-include_parts = [package_name] + list(interface_path.parents[0].parts) + \
-    [convert_camel_case_to_lower_case_underscore(interface_path.stem)]
+include_parts = [package_name] + list(interface_path.parents[0].parts) + [
+    'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
 include_base = '/'.join(include_parts)
 
 include_directives = {include_base + '__functions.h'}

--- a/rosidl_generator_c/resource/idl__functions.h.em
+++ b/rosidl_generator_c/resource/idl__functions.h.em
@@ -1,4 +1,4 @@
-// generated from rosidl_generator_c/resource/idl__struct.h.em
+// generated from rosidl_generator_c/resource/idl__functions.h.em
 // with input from @(package_name):@(interface_path)
 // generated code does not contain a copyright notice
 @
@@ -12,8 +12,8 @@
 @#######################################################################
 @{
 from rosidl_cmake import convert_camel_case_to_lower_case_underscore
-include_parts = [package_name] + list(interface_path.parents[0].parts) + \
-    [convert_camel_case_to_lower_case_underscore(interface_path.stem)]
+include_parts = [package_name] + list(interface_path.parents[0].parts) + [
+    'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
 header_guard_variable = '__'.join([x.upper() for x in include_parts]) + \
     '__FUNCTIONS_H_'
 include_base = '/'.join(include_parts)

--- a/rosidl_generator_c/resource/idl__struct.h.em
+++ b/rosidl_generator_c/resource/idl__struct.h.em
@@ -12,8 +12,8 @@
 @#######################################################################
 @{
 from rosidl_cmake import convert_camel_case_to_lower_case_underscore
-include_parts = [package_name] + list(interface_path.parents[0].parts) + \
-    [convert_camel_case_to_lower_case_underscore(interface_path.stem)]
+include_parts = [package_name] + list(interface_path.parents[0].parts) + [
+    'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
 header_guard_variable = '__'.join([x.upper() for x in include_parts]) + \
     '__STRUCT_H_'
 

--- a/rosidl_generator_c/resource/idl__type_support.h.em
+++ b/rosidl_generator_c/resource/idl__type_support.h.em
@@ -12,8 +12,8 @@
 @#######################################################################
 @{
 from rosidl_cmake import convert_camel_case_to_lower_case_underscore
-include_parts = [package_name] + list(interface_path.parents[0].parts) + \
-    [convert_camel_case_to_lower_case_underscore(interface_path.stem)]
+include_parts = [package_name] + list(interface_path.parents[0].parts) + [
+    'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
 header_guard_variable = '__'.join([x.upper() for x in include_parts]) + \
     '__TYPE_SUPPORT_H_'
 

--- a/rosidl_generator_c/resource/msg__functions.c.em
+++ b/rosidl_generator_c/resource/msg__functions.c.em
@@ -43,7 +43,8 @@ for member in message.structure.members:
             'rosidl_runtime_c/u16string_functions.h', [])
         member_names.append(member.name)
     elif isinstance(type_, NamespacedType):
-        include_prefix = idl_structure_type_to_c_include_prefix(type_)
+        include_prefix = idl_structure_type_to_c_include_prefix(
+          type_, 'detail')
         member_names = includes.setdefault(
             include_prefix + '__functions.h', [])
         member_names.append(member.name)

--- a/rosidl_generator_c/resource/msg__struct.h.em
+++ b/rosidl_generator_c/resource/msg__struct.h.em
@@ -43,7 +43,8 @@ for member in message.structure.members:
             'rosidl_runtime_c/u16string.h', [])
         member_names.append(member.name)
     elif isinstance(type_, NamespacedType):
-        include_prefix = idl_structure_type_to_c_include_prefix(type_)
+        include_prefix = idl_structure_type_to_c_include_prefix(
+            type_, 'detail')
         member_names = includes.setdefault(
             include_prefix + '__struct.h', [])
         member_names.append(member.name)

--- a/rosidl_generator_c/rosidl_generator_c/__init__.py
+++ b/rosidl_generator_c/rosidl_generator_c/__init__.py
@@ -29,10 +29,10 @@ from rosidl_parser.definition import OCTET_TYPE
 def generate_c(generator_arguments_file):
     mapping = {
         'idl.h.em': '%s.h',
-        'idl__functions.c.em': '%s__functions.c',
-        'idl__functions.h.em': '%s__functions.h',
-        'idl__struct.h.em': '%s__struct.h',
-        'idl__type_support.h.em': '%s__type_support.h',
+        'idl__functions.c.em': 'detail/%s__functions.c',
+        'idl__functions.h.em': 'detail/%s__functions.h',
+        'idl__struct.h.em': 'detail/%s__struct.h',
+        'idl__type_support.h.em': 'detail/%s__type_support.h',
     }
     generate_files(
         generator_arguments_file, mapping,
@@ -69,10 +69,13 @@ BASIC_IDL_TYPES_TO_C = {
 }
 
 
-def idl_structure_type_to_c_include_prefix(namespaced_type):
-    include_prefix = '/'.join(
+def idl_structure_type_to_c_include_prefix(namespaced_type, subdirectory=None):
+    parts = [
         convert_camel_case_to_lower_case_underscore(x)
-        for x in (namespaced_type.namespaced_name()))
+        for x in (namespaced_type.namespaced_name())]
+    if subdirectory is not None:
+        parts[-1:-1] = [subdirectory]
+    include_prefix = '/'.join(parts)
     # Strip service or action suffixes
     if include_prefix.endswith('__request'):
         include_prefix = include_prefix[:-9]

--- a/rosidl_generator_c/test/separate_compilation.c
+++ b/rosidl_generator_c/test/separate_compilation.c
@@ -18,8 +18,8 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "rosidl_generator_c/msg/defaults__struct.h"
-#include "rosidl_generator_c/msg/defaults__functions.h"
+#include "rosidl_generator_c/msg/detail/defaults__struct.h"
+#include "rosidl_generator_c/msg/detail/defaults__functions.h"
 
 int func()
 {

--- a/rosidl_generator_c/test/test_compilation.c
+++ b/rosidl_generator_c/test/test_compilation.c
@@ -15,8 +15,8 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "rosidl_generator_c/msg/constants__struct.h"
-#include "rosidl_generator_c/msg/constants__functions.h"
+#include "rosidl_generator_c/msg/detail/constants__struct.h"
+#include "rosidl_generator_c/msg/detail/constants__functions.h"
 
 #include "./separate_compilation.h"
 

--- a/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_interfaces.cmake
+++ b/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_interfaces.cmake
@@ -22,9 +22,9 @@ foreach(_abs_idl_file ${rosidl_generate_interfaces_ABS_IDL_FILES})
 
   list(APPEND _generated_headers
     "${_output_path}/${_parent_folder}/${_header_name}.hpp"
-    "${_output_path}/${_parent_folder}/${_header_name}__builder.hpp"
-    "${_output_path}/${_parent_folder}/${_header_name}__struct.hpp"
-    "${_output_path}/${_parent_folder}/${_header_name}__traits.hpp"
+    "${_output_path}/${_parent_folder}/detail/${_header_name}__builder.hpp"
+    "${_output_path}/${_parent_folder}/detail/${_header_name}__struct.hpp"
+    "${_output_path}/${_parent_folder}/detail/${_header_name}__traits.hpp"
   )
 endforeach()
 

--- a/rosidl_generator_cpp/resource/idl.hpp.em
+++ b/rosidl_generator_cpp/resource/idl.hpp.em
@@ -14,8 +14,10 @@
 from rosidl_cmake import convert_camel_case_to_lower_case_underscore
 include_parts = [package_name] + list(interface_path.parents[0].parts) + \
     [convert_camel_case_to_lower_case_underscore(interface_path.stem)]
+include_parts_detail = [package_name] + list(interface_path.parents[0].parts) + [
+    'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
 header_guard_variable = '__'.join([x.upper() for x in include_parts]) + '_HPP_'
-include_base = '/'.join(include_parts)
+include_base = '/'.join(include_parts_detail)
 }@
 #ifndef @(header_guard_variable)
 #define @(header_guard_variable)

--- a/rosidl_generator_cpp/resource/idl__builder.hpp.em
+++ b/rosidl_generator_cpp/resource/idl__builder.hpp.em
@@ -12,8 +12,8 @@
 @#######################################################################
 @{
 from rosidl_cmake import convert_camel_case_to_lower_case_underscore
-include_parts = [package_name] + list(interface_path.parents[0].parts) + \
-    [convert_camel_case_to_lower_case_underscore(interface_path.stem)]
+include_parts = [package_name] + list(interface_path.parents[0].parts) + [
+    'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
 include_base = '/'.join(include_parts)
 header_guard_variable = '__'.join([x.upper() for x in include_parts]) + \
     '__BUILDER_HPP_'

--- a/rosidl_generator_cpp/resource/idl__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/idl__struct.hpp.em
@@ -12,8 +12,8 @@
 @#######################################################################
 @{
 from rosidl_cmake import convert_camel_case_to_lower_case_underscore
-include_parts = [package_name] + list(interface_path.parents[0].parts) + \
-    [convert_camel_case_to_lower_case_underscore(interface_path.stem)]
+include_parts = [package_name] + list(interface_path.parents[0].parts) + [
+    'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
 header_guard_variable = '__'.join([x.upper() for x in include_parts]) + \
     '__STRUCT_HPP_'
 

--- a/rosidl_generator_cpp/resource/idl__traits.hpp.em
+++ b/rosidl_generator_cpp/resource/idl__traits.hpp.em
@@ -12,8 +12,8 @@
 @#######################################################################
 @{
 from rosidl_cmake import convert_camel_case_to_lower_case_underscore
-include_parts = [package_name] + list(interface_path.parents[0].parts) + \
-    [convert_camel_case_to_lower_case_underscore(interface_path.stem)]
+include_parts = [package_name] + list(interface_path.parents[0].parts) + [
+    'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
 include_base = '/'.join(include_parts)
 header_guard_variable = '__'.join([x.upper() for x in include_parts]) + \
     '__TRAITS_HPP_'

--- a/rosidl_generator_cpp/resource/msg__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.em
@@ -46,7 +46,7 @@ for member in message.structure.members:
         else:
             typename = type_.name
         member_names = includes.setdefault(
-            '/'.join((type_.namespaces + [convert_camel_case_to_lower_case_underscore(typename)])) + '__struct.hpp', [])
+            '/'.join((type_.namespaces + ['detail', convert_camel_case_to_lower_case_underscore(typename)])) + '__struct.hpp', [])
         member_names.append(member.name)
 }@
 @#>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

--- a/rosidl_generator_cpp/resource/msg__traits.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__traits.hpp.em
@@ -33,7 +33,7 @@ for member in message.structure.members:
         else:
             typename = type_.name
         member_names = includes.setdefault(
-            '/'.join((type_.namespaces + [convert_camel_case_to_lower_case_underscore(typename)])) + '__traits.hpp', [])
+            '/'.join((type_.namespaces + ['detail', convert_camel_case_to_lower_case_underscore(typename)])) + '__traits.hpp', [])
         member_names.append(member.name)
 }@
 @#>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

--- a/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
+++ b/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
@@ -31,9 +31,9 @@ from rosidl_parser.definition import UnboundedSequence
 def generate_cpp(generator_arguments_file):
     mapping = {
         'idl.hpp.em': '%s.hpp',
-        'idl__builder.hpp.em': '%s__builder.hpp',
-        'idl__struct.hpp.em': '%s__struct.hpp',
-        'idl__traits.hpp.em': '%s__traits.hpp',
+        'idl__builder.hpp.em': 'detail/%s__builder.hpp',
+        'idl__struct.hpp.em': 'detail/%s__struct.hpp',
+        'idl__traits.hpp.em': 'detail/%s__traits.hpp',
     }
     generate_files(
         generator_arguments_file, mapping,

--- a/rosidl_generator_cpp/test/test_msg_builder.cpp
+++ b/rosidl_generator_cpp/test/test_msg_builder.cpp
@@ -14,12 +14,11 @@
 
 #include <gtest/gtest.h>
 
-#include "rosidl_generator_cpp/msg/arrays__builder.hpp"
-#include "rosidl_generator_cpp/msg/basic_types__builder.hpp"
-#include "rosidl_generator_cpp/msg/empty__builder.hpp"
-#include "rosidl_generator_cpp/msg/multi_nested__builder.hpp"
-#include "rosidl_generator_cpp/msg/nested__builder.hpp"
-#include "rosidl_generator_cpp/msg/empty.hpp"
+#include "rosidl_generator_cpp/msg/detail/arrays__builder.hpp"
+#include "rosidl_generator_cpp/msg/detail/basic_types__builder.hpp"
+#include "rosidl_generator_cpp/msg/detail/empty__builder.hpp"
+#include "rosidl_generator_cpp/msg/detail/multi_nested__builder.hpp"
+#include "rosidl_generator_cpp/msg/detail/nested__builder.hpp"
 
 TEST(Test_msg_initialization, build) {
   ::rosidl_generator_cpp::msg::BasicTypes basic =

--- a/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
+++ b/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
@@ -15,6 +15,9 @@ from rosidl_parser.definition import NamespacedType
 include_parts = [package_name] + list(interface_path.parents[0].parts) + \
     [convert_camel_case_to_lower_case_underscore(interface_path.stem)]
 include_base = '/'.join(include_parts)
+include_parts_detail = [package_name] + list(interface_path.parents[0].parts) + [
+    'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
+include_base_detail = '/'.join(include_parts_detail)
 
 header_files = [
     'stddef.h',  # providing offsetof()
@@ -23,8 +26,8 @@ header_files = [
     'rosidl_typesupport_introspection_c/field_types.h',
     'rosidl_typesupport_introspection_c/identifier.h',
     'rosidl_typesupport_introspection_c/message_introspection.h',
-    include_base + '__functions.h',
-    include_base + '__struct.h',
+    include_base_detail + '__functions.h',
+    include_base_detail + '__struct.h',
 ]
 
 function_prefix = message.structure.namespaced_type.name + '__rosidl_typesupport_introspection_c'

--- a/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
@@ -11,8 +11,8 @@ from rosidl_parser.definition import BoundedSequence
 from rosidl_parser.definition import NamespacedType
 from rosidl_cmake import convert_camel_case_to_lower_case_underscore
 
-include_parts = [package_name] + list(interface_path.parents[0].parts) + \
-    [convert_camel_case_to_lower_case_underscore(interface_path.stem)]
+include_parts = [package_name] + list(interface_path.parents[0].parts) + [
+    'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
 include_base = '/'.join(include_parts)
 
 header_files = [

--- a/rosidl_typesupport_introspection_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_introspection_cpp/resource/srv__type_support.cpp.em
@@ -15,8 +15,8 @@ TEMPLATE(
 
 @{
 from rosidl_cmake import convert_camel_case_to_lower_case_underscore
-include_parts = [package_name] + list(interface_path.parents[0].parts) + \
-    [convert_camel_case_to_lower_case_underscore(interface_path.stem)]
+include_parts = [package_name] + list(interface_path.parents[0].parts) + [
+    'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
 include_base = '/'.join(include_parts)
 
 header_files = [


### PR DESCRIPTION
Follow up of #446 and #447 moving the non-entry point headers into a subdirectory. Since we don't distinguish the directories anywhere based on the language (C or C++) but do so based on the file extension I kept all of the moved headers in a `detail` subdirectory.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10194)](http://ci.ros2.org/job/ci_linux/10194/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=5747)](http://ci.ros2.org/job/ci_linux-aarch64/5747/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8293)](http://ci.ros2.org/job/ci_osx/8293/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=10082)](http://ci.ros2.org/job/ci_windows/10082/)