### PR TITLE
rename rosidl_runtime_c_message_initialization to rosidl_runtime_c__message_initialization

### DIFF
--- a/rosidl_runtime_c/include/rosidl_runtime_c/message_initialization.h
+++ b/rosidl_runtime_c/include/rosidl_runtime_c/message_initialization.h
@@ -15,9 +15,7 @@
 #ifndef ROSIDL_RUNTIME_C__MESSAGE_INITIALIZATION_H_
 #define ROSIDL_RUNTIME_C__MESSAGE_INITIALIZATION_H_
 
-// TODO(clalancette): this should be moved out into a separate runtime package
-
-enum rosidl_runtime_c_message_initialization
+enum rosidl_runtime_c__message_initialization
 {
   // Initialize all fields of the message, either with the default value
   // (if the field has one), or with an empty value (generally 0 or an

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/message_initialization.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/message_initialization.hpp
@@ -15,8 +15,6 @@
 #ifndef ROSIDL_RUNTIME_CPP__MESSAGE_INITIALIZATION_HPP_
 #define ROSIDL_RUNTIME_CPP__MESSAGE_INITIALIZATION_HPP_
 
-// TODO(clalancette): this should be moved out into a separate runtime package
-
 #include <rosidl_runtime_c/message_initialization.h>
 
 namespace rosidl_runtime_cpp

--- a/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/message_introspection.h
+++ b/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/message_introspection.h
@@ -48,7 +48,7 @@ typedef struct rosidl_typesupport_introspection_c__MessageMembers
   uint32_t member_count_;
   size_t size_of_;
   const rosidl_typesupport_introspection_c__MessageMember * members_;
-  void (* init_function)(void *, enum rosidl_runtime_c_message_initialization);
+  void (* init_function)(void *, enum rosidl_runtime_c__message_initialization);
   void (* fini_function)(void *);
 } rosidl_typesupport_introspection_c__MessageMembers;
 

--- a/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
+++ b/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
@@ -107,7 +107,7 @@ extern "C"
 @# define callback functions
 @#######################################################################
 void @(function_prefix)__@(message.structure.namespaced_type.name)_init_function(
-  void * message_memory, enum rosidl_runtime_c_message_initialization _init)
+  void * message_memory, enum rosidl_runtime_c__message_initialization _init)
 {
   // TODO(karsten1987): initializers are not yet implemented for typesupport c
   // see https://github.com/ros2/ros2/issues/397


### PR DESCRIPTION
Follow up of #446.

So that the symbol matches the pattern `<pkgname>__<name>` mimicking C++ namespaces and other symbols in this package.

Since the symbol is only used in this one signature I am not planning to run CI for this trivial rename.