### PR TITLE
document string structs and sequence functions

### DIFF
--- a/rosidl_runtime_c/include/rosidl_runtime_c/primitives_sequence.h
+++ b/rosidl_runtime_c/include/rosidl_runtime_c/primitives_sequence.h
@@ -22,7 +22,7 @@
 #define ROSIDL_RUNTIME_C__PRIMITIVE_SEQUENCE(STRUCT_NAME, TYPE_NAME) \
   typedef struct rosidl_runtime_c__ ## STRUCT_NAME ## __Sequence \
   { \
-    TYPE_NAME * data; \
+    TYPE_NAME * data; /*!< The pointer to an array of STRUCT_NAME */ \
     size_t size; /*!< The number of valid items in data */ \
     size_t capacity; /*!< The number of allocated items in data */ \
   } rosidl_runtime_c__ ## STRUCT_NAME ## __Sequence;

--- a/rosidl_runtime_c/include/rosidl_runtime_c/primitives_sequence_functions.h
+++ b/rosidl_runtime_c/include/rosidl_runtime_c/primitives_sequence_functions.h
@@ -26,60 +26,112 @@ extern "C"
 {
 #endif
 
-#define ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(STRUCT_NAME, TYPE_NAME) \
+/**
+ * \def ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_INIT(STRUCT_NAME)
+ *
+ * \brief Allocate the memory for the sequence.
+ *
+ * Calling the function with an already allocated sequence will leak the
+ * previously allocated memory.
+ *
+ * param sequence a pointer to a sequence struct
+ * param size the number of items to allocate in the sequence, both sequence
+ *   fields `size` and `capacity` are set to this parameter
+ * return true if successful, false if the passed sequence pointer is null
+ *   or the memory allocation failed
+ */
+#define ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_INIT(STRUCT_NAME) \
+  /** See #ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_INIT(STRUCT_NAME) */ \
   ROSIDL_GENERATOR_C_PUBLIC \
   bool rosidl_runtime_c__ ## STRUCT_NAME ## __Sequence__init( \
-    rosidl_runtime_c__ ## STRUCT_NAME ## __Sequence * sequence, size_t size); \
- \
+    rosidl_runtime_c__ ## STRUCT_NAME ## __Sequence * sequence, size_t size);
+
+/**
+ * \def ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FINI(STRUCT_NAME)
+ *
+ * \brief Deallocate the memory of the sequence.
+ *
+ * Calling the function with an already deallocated sequence is a no-op.
+ *
+ * param sequence a pointer to a sequence struct
+ */
+#define ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FINI(STRUCT_NAME) \
+  /** See #ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FINI(STRUCT_NAME) */ \
   ROSIDL_GENERATOR_C_PUBLIC \
   void rosidl_runtime_c__ ## STRUCT_NAME ## __Sequence__fini( \
     rosidl_runtime_c__ ## STRUCT_NAME ## __Sequence * sequence);
 
-// array functions for all basic types
-ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(float, float)
-ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(double, double)
-ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(long_double, long double)
-ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(char, signed char)
-ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(wchar, uint16_t)
-ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(boolean, bool)
-ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(octet, uint8_t)
-ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(uint8, uint8_t)
-ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(int8, int8_t)
-ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(uint16, uint16_t)
-ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(int16, int16_t)
-ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(uint32, uint32_t)
-ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(int32, int32_t)
-ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(uint64, uint64_t)
-ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(int64, int64_t)
+/**
+ * \def ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(STRUCT_NAME)
+ *
+ * \brief See #ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_INIT(STRUCT_NAME) and
+ * #ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FINI(STRUCT_NAME)
+ */
+#define ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(STRUCT_NAME) \
+  ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_INIT(STRUCT_NAME) \
+  ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FINI(STRUCT_NAME)
 
-// emulate legacy API
+/**
+ * \defgroup primitives_sequence_functions__basic_types Sequence functions for all basic types.
+ */
+/**@{*/
+ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(float)
+ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(double)
+ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(long_double)
+ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(char)
+ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(wchar)
+ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(boolean)
+ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(octet)
+ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(uint8)
+ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(int8)
+ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(uint16)
+ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(int16)
+ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(uint32)
+ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(int32)
+ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(uint64)
+ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(int64)
+/**@}*/
+
+/**
+ * \defgroup primitives_sequence_functions__legacy Sequence functions for legacy types for backward compatibility.
+ */
+/**@{*/
+/** See #ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_INIT(bool) */
 ROSIDL_GENERATOR_C_PUBLIC
 bool rosidl_runtime_c__bool__Sequence__init(
   rosidl_runtime_c__boolean__Sequence * sequence, size_t size);
+/** See #ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FINI(bool) */ \
 ROSIDL_GENERATOR_C_PUBLIC
 void rosidl_runtime_c__bool__Sequence__fini(
   rosidl_runtime_c__boolean__Sequence * sequence);
 
+/** See #ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_INIT(byte) */
 ROSIDL_GENERATOR_C_PUBLIC
 bool rosidl_runtime_c__byte__Sequence__init(
   rosidl_runtime_c__octet__Sequence * sequence, size_t size);
+/** See #ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FINI(byte) */ \
 ROSIDL_GENERATOR_C_PUBLIC
 void rosidl_runtime_c__byte__Sequence__fini(
   rosidl_runtime_c__octet__Sequence * sequence);
 
+/** See #ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_INIT(float32) */
 ROSIDL_GENERATOR_C_PUBLIC
 bool rosidl_runtime_c__float32__Sequence__init(
   rosidl_runtime_c__float__Sequence * sequence, size_t size);
+/** See #ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FINI(float32) */ \
 ROSIDL_GENERATOR_C_PUBLIC
 void rosidl_runtime_c__float32__Sequence__fini(
   rosidl_runtime_c__float__Sequence * sequence);
 
+/** See #ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_INIT(float64) */
 ROSIDL_GENERATOR_C_PUBLIC
 bool rosidl_runtime_c__float64__Sequence__init(
   rosidl_runtime_c__double__Sequence * sequence, size_t size);
+/** See #ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FINI(float64) */ \
 ROSIDL_GENERATOR_C_PUBLIC
 void rosidl_runtime_c__float64__Sequence__fini(
   rosidl_runtime_c__double__Sequence * sequence);
+/**@}*/
 
 #ifdef __cplusplus
 }

--- a/rosidl_runtime_c/include/rosidl_runtime_c/primitives_sequence_functions.h
+++ b/rosidl_runtime_c/include/rosidl_runtime_c/primitives_sequence_functions.h
@@ -100,7 +100,7 @@ ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(int64)
 ROSIDL_GENERATOR_C_PUBLIC
 bool rosidl_runtime_c__bool__Sequence__init(
   rosidl_runtime_c__boolean__Sequence * sequence, size_t size);
-/** See #ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FINI(bool) */ \
+/** See #ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FINI(bool) */
 ROSIDL_GENERATOR_C_PUBLIC
 void rosidl_runtime_c__bool__Sequence__fini(
   rosidl_runtime_c__boolean__Sequence * sequence);
@@ -109,7 +109,7 @@ void rosidl_runtime_c__bool__Sequence__fini(
 ROSIDL_GENERATOR_C_PUBLIC
 bool rosidl_runtime_c__byte__Sequence__init(
   rosidl_runtime_c__octet__Sequence * sequence, size_t size);
-/** See #ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FINI(byte) */ \
+/** See #ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FINI(byte) */
 ROSIDL_GENERATOR_C_PUBLIC
 void rosidl_runtime_c__byte__Sequence__fini(
   rosidl_runtime_c__octet__Sequence * sequence);
@@ -118,7 +118,7 @@ void rosidl_runtime_c__byte__Sequence__fini(
 ROSIDL_GENERATOR_C_PUBLIC
 bool rosidl_runtime_c__float32__Sequence__init(
   rosidl_runtime_c__float__Sequence * sequence, size_t size);
-/** See #ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FINI(float32) */ \
+/** See #ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FINI(float32) */
 ROSIDL_GENERATOR_C_PUBLIC
 void rosidl_runtime_c__float32__Sequence__fini(
   rosidl_runtime_c__float__Sequence * sequence);
@@ -127,7 +127,7 @@ void rosidl_runtime_c__float32__Sequence__fini(
 ROSIDL_GENERATOR_C_PUBLIC
 bool rosidl_runtime_c__float64__Sequence__init(
   rosidl_runtime_c__double__Sequence * sequence, size_t size);
-/** See #ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FINI(float64) */ \
+/** See #ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FINI(float64) */
 ROSIDL_GENERATOR_C_PUBLIC
 void rosidl_runtime_c__float64__Sequence__fini(
   rosidl_runtime_c__double__Sequence * sequence);

--- a/rosidl_runtime_c/include/rosidl_runtime_c/string.h
+++ b/rosidl_runtime_c/include/rosidl_runtime_c/string.h
@@ -19,9 +19,10 @@
 
 #include "rosidl_runtime_c/primitives_sequence.h"
 
-/// String struct
+/// An array of 8-bit characters terminated by a null byte.
 typedef struct rosidl_runtime_c__String
 {
+  /// The pointer to the first character, the sequence ends with a null byte.
   char * data;
   /// The length of the string (excluding the null byte).
   size_t size;

--- a/rosidl_runtime_c/include/rosidl_runtime_c/string_bounds.h
+++ b/rosidl_runtime_c/include/rosidl_runtime_c/string_bounds.h
@@ -17,10 +17,10 @@
 
 #include <stddef.h>
 
-/// String struct
+/// Upper boundary for #rosidl_runtime_c__String or #rosidl_runtime_c__U16String.
 typedef struct rosidl_runtime_c__String__bounds
 {
-  /// The length of the string (excluding the null byte).
+  /// The number of characters in the string (excluding the null character).
   size_t bounds;
 } rosidl_runtime_c__String__bounds;
 

--- a/rosidl_runtime_c/include/rosidl_runtime_c/u16string.h
+++ b/rosidl_runtime_c/include/rosidl_runtime_c/u16string.h
@@ -19,14 +19,14 @@
 
 #include "rosidl_runtime_c/primitives_sequence.h"
 
-/// U16String struct
+/// An array of 16-bit characters terminated by a null character.
 typedef struct rosidl_runtime_c__U16String
 {
-  /// The pointer to the first character.
+  /// The pointer to the first character, the sequence ends with a null character.
   uint_least16_t * data;  // using uint_least16_t to match a C++ std::u16string
-  /// The length of the u16string (excluding the null byte).
+  /// The length of the u16string (excluding the null character).
   size_t size;
-  /// The capacity represents the number of allocated characters (including the null byte).
+  /// The capacity represents the number of allocated characters (including the null character).
   size_t capacity;
 } rosidl_runtime_c__U16String;
 


### PR DESCRIPTION
Follow up of #446.

Beside adding docblocks this patch only splits the content of the `ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS` macros into `ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_INIT` and `ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FINI` in order to document them. The second argument was removed from the existing macro since it wasn't used.