### PR TITLE
fix build with single introspection typesupport

### DIFF
--- a/rosidl_typesupport_introspection_c/cmake/rosidl_typesupport_introspection_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_introspection_c/cmake/rosidl_typesupport_introspection_c_generate_interfaces.cmake
@@ -22,9 +22,9 @@ foreach(_abs_idl_file ${rosidl_generate_interfaces_ABS_IDL_FILES})
   get_filename_component(_idl_name "${_abs_idl_file}" NAME_WE)
   string_camel_case_to_lower_case_underscore("${_idl_name}" _header_name)
   list(APPEND _generated_header_files
-    "${_output_path}/${_parent_folder}/${_header_name}__rosidl_typesupport_introspection_c.h")
+    "${_output_path}/${_parent_folder}/detail/${_header_name}__rosidl_typesupport_introspection_c.h")
   list(APPEND _generated_source_files
-    "${_output_path}/${_parent_folder}/${_header_name}__type_support.c")
+    "${_output_path}/${_parent_folder}/detail/${_header_name}__type_support.c")
 endforeach()
 
 set(_dependency_files "")

--- a/rosidl_typesupport_introspection_c/resource/idl__rosidl_typesupport_introspection_c.h.em
+++ b/rosidl_typesupport_introspection_c/resource/idl__rosidl_typesupport_introspection_c.h.em
@@ -12,8 +12,8 @@
 @#######################################################################
 @{
 from rosidl_cmake import convert_camel_case_to_lower_case_underscore
-include_parts = [package_name] + list(interface_path.parents[0].parts) + \
-    [convert_camel_case_to_lower_case_underscore(interface_path.stem)]
+include_parts = [package_name] + list(interface_path.parents[0].parts) + [
+    'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
 header_guard_variable = '__'.join([x.upper() for x in include_parts]) + \
     '__ROSIDL_TYPESUPPORT_INTROSPECTION_C_H_'
 }@

--- a/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
+++ b/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
@@ -12,12 +12,9 @@ from rosidl_parser.definition import BasicType
 from rosidl_parser.definition import BoundedSequence
 from rosidl_parser.definition import NamespacedType
 
-include_parts = [package_name] + list(interface_path.parents[0].parts) + \
-    [convert_camel_case_to_lower_case_underscore(interface_path.stem)]
-include_base = '/'.join(include_parts)
-include_parts_detail = [package_name] + list(interface_path.parents[0].parts) + [
+include_parts = [package_name] + list(interface_path.parents[0].parts) + [
     'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
-include_base_detail = '/'.join(include_parts_detail)
+include_base = '/'.join(include_parts)
 
 header_files = [
     'stddef.h',  # providing offsetof()
@@ -26,8 +23,8 @@ header_files = [
     'rosidl_typesupport_introspection_c/field_types.h',
     'rosidl_typesupport_introspection_c/identifier.h',
     'rosidl_typesupport_introspection_c/message_introspection.h',
-    include_base_detail + '__functions.h',
-    include_base_detail + '__struct.h',
+    include_base + '__functions.h',
+    include_base + '__struct.h',
 ]
 
 function_prefix = message.structure.namespaced_type.name + '__rosidl_typesupport_introspection_c'
@@ -72,8 +69,9 @@ for member in message.structure.members:
         member_names = includes.setdefault(
             include_prefix + '.h', [])
         member_names.append(member.name)
+        include_prefix_detail = idl_structure_type_to_c_include_prefix(type_, 'detail')
         member_names = includes.setdefault(
-            include_prefix + '__rosidl_typesupport_introspection_c.h', [])
+            include_prefix_detail + '__rosidl_typesupport_introspection_c.h', [])
         member_names.append(member.name)
 }@
 @#>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

--- a/rosidl_typesupport_introspection_c/resource/srv__type_support.c.em
+++ b/rosidl_typesupport_introspection_c/resource/srv__type_support.c.em
@@ -15,8 +15,8 @@ TEMPLATE(
 
 @{
 from rosidl_cmake import convert_camel_case_to_lower_case_underscore
-include_parts = [package_name] + list(interface_path.parents[0].parts) + \
-    [convert_camel_case_to_lower_case_underscore(interface_path.stem)]
+include_parts = [package_name] + list(interface_path.parents[0].parts) + [
+    'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
 include_base = '/'.join(include_parts)
 
 header_files = [

--- a/rosidl_typesupport_introspection_c/rosidl_typesupport_introspection_c/__init__.py
+++ b/rosidl_typesupport_introspection_c/rosidl_typesupport_introspection_c/__init__.py
@@ -18,7 +18,7 @@ from rosidl_cmake import generate_files
 def generate_c(generator_arguments_file):
     mapping = {
         'idl__rosidl_typesupport_introspection_c.h.em':
-        '%s__rosidl_typesupport_introspection_c.h',
-        'idl__type_support.c.em': '%s__type_support.c',
+        'detail/%s__rosidl_typesupport_introspection_c.h',
+        'idl__type_support.c.em': 'detail/%s__type_support.c',
     }
     generate_files(generator_arguments_file, mapping)

--- a/rosidl_typesupport_introspection_cpp/cmake/rosidl_typesupport_introspection_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_introspection_cpp/cmake/rosidl_typesupport_introspection_cpp_generate_interfaces.cmake
@@ -22,9 +22,9 @@ foreach(_abs_idl_file ${rosidl_generate_interfaces_ABS_IDL_FILES})
   get_filename_component(_idl_name "${_abs_idl_file}" NAME_WE)
   string_camel_case_to_lower_case_underscore("${_idl_name}" _header_name)
   list(APPEND _generated_header_files
-    "${_output_path}/${_parent_folder}/${_header_name}__rosidl_typesupport_introspection_cpp.hpp")
+    "${_output_path}/${_parent_folder}/detail/${_header_name}__rosidl_typesupport_introspection_cpp.hpp")
   list(APPEND _generated_source_files
-    "${_output_path}/${_parent_folder}/${_header_name}__type_support.cpp")
+    "${_output_path}/${_parent_folder}/detail/${_header_name}__type_support.cpp")
 endforeach()
 
 set(_dependency_files "")

--- a/rosidl_typesupport_introspection_cpp/resource/idl__rosidl_typesupport_introspection_cpp.hpp.em
+++ b/rosidl_typesupport_introspection_cpp/resource/idl__rosidl_typesupport_introspection_cpp.hpp.em
@@ -12,11 +12,10 @@
 @#######################################################################
 @{
 from rosidl_cmake import convert_camel_case_to_lower_case_underscore
-include_parts = [package_name] + list(interface_path.parents[0].parts) + \
-    [convert_camel_case_to_lower_case_underscore(interface_path.stem)]
+include_parts = [package_name] + list(interface_path.parents[0].parts) + [
+    'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
 header_guard_variable = '__'.join([x.upper() for x in include_parts]) + \
     '__ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_HPP_'
-include_base = '/'.join(include_parts)
 }@
 
 #ifndef @(header_guard_variable)

--- a/rosidl_typesupport_introspection_cpp/rosidl_typesupport_introspection_cpp/__init__.py
+++ b/rosidl_typesupport_introspection_cpp/rosidl_typesupport_introspection_cpp/__init__.py
@@ -18,7 +18,7 @@ from rosidl_cmake import generate_files
 def generate_cpp(generator_arguments_file):
     mapping = {
         'idl__rosidl_typesupport_introspection_cpp.hpp.em':
-        '%s__rosidl_typesupport_introspection_cpp.hpp',
-        'idl__type_support.cpp.em': '%s__type_support.cpp',
+        'detail/%s__rosidl_typesupport_introspection_cpp.hpp',
+        'idl__type_support.cpp.em': 'detail/%s__type_support.cpp',
     }
     generate_files(generator_arguments_file, mapping)


### PR DESCRIPTION
Fixes #469.

CI with only CycloneDDS and up to `demo_nodes_cpp` / `demo_nodes_py`:
Before: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10350)](https://ci.ros2.org/job/ci_linux/10350/)
After: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10355)](https://ci.ros2.org/job/ci_linux/10355/)

Same but with all three RMW: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10356)](https://ci.ros2.org/job/ci_linux/10356/)