### PR TITLE
Rename message_bounds to include typesupport

### DIFF
--- a/rosidl_runtime_c/CMakeLists.txt
+++ b/rosidl_runtime_c/CMakeLists.txt
@@ -15,9 +15,9 @@ find_package(ament_cmake_ros REQUIRED)
 find_package(rosidl_typesupport_interface REQUIRED)
 
 add_library(${PROJECT_NAME}
-  "src/message_bounds.c"
   "src/message_type_support.c"
   "src/primitives_sequence_functions.c"
+  "src/sequence_bound.c"
   "src/service_type_support.c"
   "src/string_functions.c"
   "src/u16string_functions.c"

--- a/rosidl_runtime_c/include/rosidl_runtime_c/sequence_bound.h
+++ b/rosidl_runtime_c/include/rosidl_runtime_c/sequence_bound.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef ROSIDL_RUNTIME_C__MESSAGE_BOUNDS_STRUCT_H_
-#define ROSIDL_RUNTIME_C__MESSAGE_BOUNDS_STRUCT_H_
+#ifndef ROSIDL_RUNTIME_C__SEQUENCE_BOUND_H_
+#define ROSIDL_RUNTIME_C__SEQUENCE_BOUND_H_
 
 #include "rosidl_runtime_c/visibility_control.h"
 #include "rosidl_typesupport_interface/macros.h"
@@ -23,27 +23,27 @@ extern "C"
 {
 #endif
 
-typedef struct rosidl_message_bounds_t rosidl_message_bounds_t;
+typedef struct rosidl_runtime_c__Sequence__bound rosidl_runtime_c__Sequence__bound;
 
-typedef const rosidl_message_bounds_t * (* rosidl_message_bounds_handle_function)(
-  const rosidl_message_bounds_t *, const char *);
+typedef const rosidl_runtime_c__Sequence__bound * (* rosidl_runtime_c__bound_handle_function)(
+  const rosidl_runtime_c__Sequence__bound *, const char *);
 
-struct rosidl_message_bounds_t
+struct rosidl_runtime_c__Sequence__bound
 {
   const char * typesupport_identifier;
   const void * data;
-  rosidl_message_bounds_handle_function func;
+  rosidl_runtime_c__bound_handle_function func;
 };
 
 ROSIDL_GENERATOR_C_PUBLIC
-const rosidl_message_bounds_t * get_message_bounds_handle(
-  const rosidl_message_bounds_t * handle, const char * identifier);
+const rosidl_runtime_c__Sequence__bound * get_sequence_bound_handle(
+  const rosidl_runtime_c__Sequence__bound * handle, const char * identifier);
 
 ROSIDL_GENERATOR_C_PUBLIC
-const rosidl_message_bounds_t * get_message_bounds_handle_function(
-  const rosidl_message_bounds_t * handle, const char * identifier);
+const rosidl_runtime_c__Sequence__bound * get_sequence_bound_handle_function(
+  const rosidl_runtime_c__Sequence__bound * handle, const char * identifier);
 
-#define ROSIDL_GET_MSG_BOUNDS(PkgName, MsgSubfolder, MsgName) \
+#define ROSIDL_GET_SEQUENCE_BOUNDS(PkgName, MsgSubfolder, MsgName) \
   ROSIDL_BOUNDS_INTERFACE__MESSAGE_SYMBOL_NAME( \
     rosidl_typesupport_c, PkgName, MsgSubfolder, MsgName)()
 
@@ -51,4 +51,4 @@ const rosidl_message_bounds_t * get_message_bounds_handle_function(
 }
 #endif
 
-#endif  // ROSIDL_RUNTIME_C__MESSAGE_BOUNDS_STRUCT_H_
+#endif  // ROSIDL_RUNTIME_C__SEQUENCE_BOUND_H_

--- a/rosidl_runtime_c/include/rosidl_runtime_c/string_bound.h
+++ b/rosidl_runtime_c/include/rosidl_runtime_c/string_bound.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef ROSIDL_RUNTIME_C__STRING_BOUNDS_H_
-#define ROSIDL_RUNTIME_C__STRING_BOUNDS_H_
+#ifndef ROSIDL_RUNTIME_C__STRING_BOUND_H_
+#define ROSIDL_RUNTIME_C__STRING_BOUND_H_
 
 #include <stddef.h>
 
@@ -24,4 +24,4 @@ typedef struct rosidl_runtime_c__String__bound
   size_t bound;
 } rosidl_runtime_c__String__bound;
 
-#endif  // ROSIDL_RUNTIME_C__STRING_BOUNDS_H_
+#endif  // ROSIDL_RUNTIME_C__STRING_BOUND_H_

--- a/rosidl_runtime_c/src/sequence_bound.c
+++ b/rosidl_runtime_c/src/sequence_bound.c
@@ -12,23 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "rosidl_runtime_c/message_bounds_struct.h"
+#include "rosidl_runtime_c/sequence_bound.h"
 
 #include <assert.h>
 #include <string.h>
 
-const rosidl_message_bounds_t * get_message_bounds_handle(
-  const rosidl_message_bounds_t * handle, const char * identifier)
+const rosidl_runtime_c__Sequence__bound * get_sequence_bound_handle(
+  const rosidl_runtime_c__Sequence__bound * handle, const char * identifier)
 {
   assert(handle);
   assert(handle->func);
-  rosidl_message_bounds_handle_function func =
-    (rosidl_message_bounds_handle_function)(handle->func);
+  rosidl_runtime_c__bound_handle_function func =
+    (rosidl_runtime_c__bound_handle_function)(handle->func);
   return func(handle, identifier);
 }
 
-const rosidl_message_bounds_t * get_message_bound_handle_function(
-  const rosidl_message_bounds_t * handle, const char * identifier)
+const rosidl_runtime_c__Sequence__bound * get_sequence_bound_handle_function(
+  const rosidl_runtime_c__Sequence__bound * handle, const char * identifier)
 {
   assert(handle);
   assert(handle->typesupport_identifier);


### PR DESCRIPTION
Based on feedback from API review, addresses inconsistency in naming

Closes #467 

Signed-off-by: Michael Carroll <michael@openrobotics.org>