### PR TITLE
rename rosidl_runtime_c__String__bounds to singular

### DIFF
--- a/rosidl_runtime_c/include/rosidl_runtime_c/string_bound.h
+++ b/rosidl_runtime_c/include/rosidl_runtime_c/string_bound.h
@@ -18,10 +18,10 @@
 #include <stddef.h>
 
 /// Upper boundary for #rosidl_runtime_c__String or #rosidl_runtime_c__U16String.
-typedef struct rosidl_runtime_c__String__bounds
+typedef struct rosidl_runtime_c__String__bound
 {
   /// The number of characters in the string (excluding the null character).
-  size_t bounds;
-} rosidl_runtime_c__String__bounds;
+  size_t bound;
+} rosidl_runtime_c__String__bound;
 
 #endif  // ROSIDL_RUNTIME_C__STRING_BOUNDS_H_


### PR DESCRIPTION
To match the naming in (to-be-updated) ros2/rosidl#475.

There is no usage of this symbol so I am not planning to run any CI.