### PR TITLE
Fix variable suffix in rosidl_export_typesupport_targets

### DIFF
--- a/rosidl_cmake/cmake/rosidl_cmake_export_typesupport_targets-extras.cmake.in
+++ b/rosidl_cmake/cmake/rosidl_cmake_export_typesupport_targets-extras.cmake.in
@@ -7,7 +7,12 @@ set(_exported_typesupport_targets
 # populate @PROJECT_NAME@_TARGETS_<suffix>
 if(NOT _exported_typesupport_targets STREQUAL "")
   # loop over typesupport targets
-  foreach(_target ${_exported_typesupport_targets})
+  foreach(_tuple ${_exported_typesupport_targets})
+    string(REPLACE ":" ";" _tuple "${_tuple}")
+    list(GET _tuple 0 _suffix)
+    list(GET _tuple 1 _target)
+
+    set(_target "@PROJECT_NAME@::${_target}")
     if(NOT TARGET "${_target}")
       # the exported target must exist
       message(WARNING "Package '@PROJECT_NAME@' exports the typesupport target '${_target}' which doesn't exist")

--- a/rosidl_cmake/cmake/rosidl_export_typesupport_targets.cmake
+++ b/rosidl_cmake/cmake/rosidl_export_typesupport_targets.cmake
@@ -15,13 +15,15 @@
 #
 # Export typesupport targets to downstream packages.
 #
+# :param library_suffix: the suffix of the library
+# :type library_suffix: string
 # :param ARGN: a list of targets.
 #   Each element must be an exported CMake library target.
 # :type ARGN: list of strings
 #
 # @public
 #
-macro(rosidl_export_typesupport_targets)
+macro(rosidl_export_typesupport_targets library_suffix)
   if(_${PROJECT_NAME}_AMENT_PACKAGE)
     message(FATAL_ERROR
       "rosidl_export_typesupport_targets() must be called before "
@@ -44,7 +46,10 @@ macro(rosidl_export_typesupport_targets)
           "not-imported targets")
       endif()
 
-      list(APPEND _ROSIDL_CMAKE_EXPORT_TYPESUPPORT_TARGETS "${PROJECT_NAME}::${_target}")
+      list(APPEND
+        _ROSIDL_CMAKE_EXPORT_TYPESUPPORT_TARGETS
+        "${library_suffix}:${_target}"
+      )
     endforeach()
   endif()
 endmacro()

--- a/rosidl_typesupport_introspection_c/cmake/rosidl_typesupport_introspection_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_introspection_c/cmake/rosidl_typesupport_introspection_c_generate_interfaces.cmake
@@ -147,7 +147,7 @@ if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin
   )
-  rosidl_export_typesupport_targets(
+  rosidl_export_typesupport_targets(${_target_suffix}
     ${rosidl_generate_interfaces_TARGET}${_target_suffix})
   ament_export_targets(${rosidl_generate_interfaces_TARGET}${_target_suffix})
 endif()

--- a/rosidl_typesupport_introspection_cpp/cmake/rosidl_typesupport_introspection_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_introspection_cpp/cmake/rosidl_typesupport_introspection_cpp_generate_interfaces.cmake
@@ -140,7 +140,7 @@ if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin
   )
-  rosidl_export_typesupport_targets(
+  rosidl_export_typesupport_targets(${_target_suffix}
     ${rosidl_generate_interfaces_TARGET}${_target_suffix})
   ament_export_targets(${rosidl_generate_interfaces_TARGET}${_target_suffix})
 endif()


### PR DESCRIPTION
`_suffix` wasn't being set here:

https://github.com/ros2/rosidl/blob/f3f639df4cef29fda1dc18074fe0b1e2c3b108e6/rosidl_cmake/cmake/rosidl_cmake_export_typesupport_targets-extras.cmake.in#L15

This PR fixes that.