### PR TITLE
Update API documentation and QDs

### DIFF
--- a/rosidl_runtime_c/QUALITY_DECLARATION.md
+++ b/rosidl_runtime_c/QUALITY_DECLARATION.md
@@ -69,7 +69,7 @@ All pull requests must resolve related documentation changes before merging.
 
 ### Public API Documentation [3.ii]
 
-`rosidl_runtime_c` has some public API documentation.
+`rosidl_runtime_c` has documentation of its public API, but it is not yet hosted.
 
 ### License [3.iii]
 
@@ -95,7 +95,9 @@ Most recent test results can be found [here](https://ci.ros2.org/job/nightly_lin
 
 ### Public API Testing [4.ii]
 
-There are currently no tests for the public API.
+Most of the public API of `rosidl_runtime_c` is tested, and the tests are located in the test directory.
+
+Most recent test results can be found [here](https://ci.ros2.org/job/nightly_linux_release/lastBuild/testReport/rosidl_runtime_c).
 
 ### Coverage [4.iv]
 

--- a/rosidl_runtime_cpp/Doxyfile
+++ b/rosidl_runtime_cpp/Doxyfile
@@ -20,5 +20,6 @@ EXPAND_ONLY_PREDEF     = YES
 
 # Tag files that do not exist will produce a warning and cross-project linking will not work.
 TAGFILES += "../../../../doxygen_tag_files/cppreference-doxygen-web.tag.xml=http://en.cppreference.com/w/"
+TAGFILES += "../../../../doxygen_tag_files/rosidl_runtime_c.tag"
 # Uncomment to generate tag files for cross-project linking.
 GENERATE_TAGFILE = "../../../../doxygen_tag_files/rosidl_runtime_cpp.tag"

--- a/rosidl_runtime_cpp/QUALITY_DECLARATION.md
+++ b/rosidl_runtime_cpp/QUALITY_DECLARATION.md
@@ -69,7 +69,7 @@ All pull requests must resolve related documentation changes before merging.
 
 ### Public API Documentation [3.ii]
 
-`rosidl_runtime_cpp` has some public API documentation.
+`rosidl_runtime_cpp` has documentation of its public API, but it is not yet hosted.
 
 ### License [3.iii]
 
@@ -94,7 +94,8 @@ The BoundedVector class is tested and the most recent test results can be found 
 
 ### Public API Testing [4.ii]
 
-There are currently no tests for the public API.
+Most of the API provided by this package are declarations of types and functions, and therefore do not require testing.
+The BoundedVector class is tested and the most recent test results can be found [here](https://ci.ros2.org/job/nightly_linux_release/lastBuild/testReport/rosidl_runtime_cpp).
 
 ### Coverage [4.iv]
 

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/action_type_support_decl.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/action_type_support_decl.hpp
@@ -21,6 +21,11 @@
 namespace rosidl_runtime_cpp
 {
 
+/// Get the action type support handle.
+/**
+ * Note: this is implemented by generated sources of rosidl packages.
+ * \return Function handler for the action's typesupport.
+ */
 template<typename T>
 const rosidl_action_type_support_t * get_action_type_support_handle();
 

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/message_initialization.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/message_initialization.hpp
@@ -20,6 +20,10 @@
 namespace rosidl_runtime_cpp
 {
 
+/// Enum utilized in rosidl generated sources for describing how members are initialized.
+/**
+ * See the documentation for the `rosidl_runtime_c__message_initialization` enum for more information.
+ */
 enum class MessageInitialization
 {
   ALL = ROSIDL_RUNTIME_C_MSG_INIT_ALL,

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/message_type_support_decl.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/message_type_support_decl.hpp
@@ -21,6 +21,11 @@
 namespace rosidl_runtime_cpp
 {
 
+/// Get the message type support handle.
+/**
+ * Note: this is implemented by generated sources of rosidl packages.
+ * \return Function handler for the message's typesupport.
+ */
 template<typename T>
 const rosidl_message_type_support_t * get_message_type_support_handle();
 

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/service_type_support_decl.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/service_type_support_decl.hpp
@@ -21,6 +21,11 @@
 namespace rosidl_runtime_cpp
 {
 
+/// Get the service type support handle.
+/**
+ * Note: this is implemented by generated sources of rosidl packages.
+ * \return Function handler for the service's typesupport.
+ */
 template<typename T>
 const rosidl_service_type_support_t * get_service_type_support_handle();
 

--- a/rosidl_typesupport_interface/QUALITY_DECLARATION.md
+++ b/rosidl_typesupport_interface/QUALITY_DECLARATION.md
@@ -69,7 +69,7 @@ All pull requests must resolve related documentation changes before merging.
 
 ### Public API Documentation [3.ii]
 
-`rosidl_typesupport_interface` does not have any API documentation.
+`rosidl_typesupport_interface` has API documentation, but it is not yet publicly hosted.
 
 ### License [3.iii]
 
@@ -95,7 +95,9 @@ Most recent test results can be found [here](https://ci.ros2.org/job/nightly_lin
 
 ### Public API Testing [4.ii]
 
-There are currently no tests for the public API.
+The public API of `rosidl_typesupport_interface` is tested, and the tests are located in the test directory.
+
+Most recent test results can be found [here](https://ci.ros2.org/job/nightly_linux_release/lastBuild/testReport/rosidl_typesupport_interface).
 
 ### Coverage [4.iv]
 


### PR DESCRIPTION
This updates the API documentation and QDs for rosidl_runtime_c/cpp and rosidl_typesupport_interface. This should qualify the documentation portion of these packages for QL 1.
Signed-off-by: Stephen Brawner <brawner@gmail.com>