### PR TITLE
Fix misuses of input iterators in BoundedVector

### DIFF
--- a/rosidl_runtime_cpp/test/test_bounded_vector.cpp
+++ b/rosidl_runtime_cpp/test/test_bounded_vector.cpp
@@ -16,6 +16,7 @@
 #include <utility>
 #include <sstream>
 #include <iterator>
+#include <forward_list>
 
 #include "rosidl_runtime_cpp/bounded_vector.hpp"
 
@@ -37,7 +38,7 @@ TEST(rosidl_generator_cpp, bounded_vector) {
 }
 
 TEST(rosidl_generator_cpp, bounded_vector_rvalue) {
-  rosidl_runtime_cpp::BoundedVector<int, 2> v;
+  rosidl_runtime_cpp::BoundedVector<int, 2> v, vv;
   // emplace back
   ASSERT_EQ(v.size(), 0u);
   ASSERT_EQ(v.max_size(), 2u);
@@ -46,7 +47,6 @@ TEST(rosidl_generator_cpp, bounded_vector_rvalue) {
   ASSERT_THROW(v.emplace_back(3), std::length_error);
   ASSERT_EQ(v.size(), 2u);
   // move assignment
-  decltype(v) vv;
   vv = std::move(v);
   ASSERT_EQ(vv.size(), 2u);
   ASSERT_EQ(vv[0], 1);
@@ -101,5 +101,24 @@ TEST(rosidl_generator_cpp, bounded_vector_input_iterators) {
   v.pop_back();
   vv.pop_back();
   ASSERT_THROW(v.insert(v.begin() + 1, ii, end), std::length_error);
+  ASSERT_EQ(v, vv);
+}
+
+TEST(rosidl_generator_cpp, bounded_vector_forward_iterators) {
+  rosidl_runtime_cpp::BoundedVector<int, 4> v, vv{1, 2, 3};
+  std::forward_list<int> l{1, 2, 3};
+  v.assign(l.begin(), l.end());
+  ASSERT_EQ(v, vv);
+  l = {10, 11, 12, 13, 14, 15};
+  ASSERT_THROW(v.assign(l.begin(), l.end()), std::length_error);
+  ASSERT_EQ(v, vv);
+  l = {0};
+  v.insert(v.begin(), l.begin(), l.end());
+  vv.insert(vv.begin(), 0);
+  ASSERT_EQ(v, vv);
+  l = {10, 11, 12, 13};
+  v.pop_back();
+  vv.pop_back();
+  ASSERT_THROW(v.insert(v.begin() + 1, l.begin(), l.end()), std::length_error);
   ASSERT_EQ(v, vv);
 }

--- a/rosidl_runtime_cpp/test/test_bounded_vector.cpp
+++ b/rosidl_runtime_cpp/test/test_bounded_vector.cpp
@@ -14,6 +14,8 @@
 
 #include <gtest/gtest.h>
 #include <utility>
+#include <sstream>
+#include <iterator>
 
 #include "rosidl_runtime_cpp/bounded_vector.hpp"
 
@@ -65,4 +67,39 @@ TEST(rosidl_generator_cpp, bounded_vector_insert) {
   ASSERT_NO_THROW(v1.insert(it + 1, v2.begin(), v2.end()));
   // insert v2 after the 4th position
   ASSERT_THROW(v1.insert(it + 4, v2.begin(), v2.end()), std::length_error);
+}
+
+TEST(rosidl_generator_cpp, bounded_vector_comparisons) {
+  rosidl_runtime_cpp::BoundedVector<int, 2> v, vv;
+  ASSERT_EQ(v, vv);
+  v.push_back(1);
+  ASSERT_NE(v, vv);
+  ASSERT_GT(v, vv);
+  ASSERT_LT(vv, v);
+}
+
+TEST(rosidl_generator_cpp, bounded_vector_input_iterators) {
+  rosidl_runtime_cpp::BoundedVector<int, 4> v, vv{1, 2, 3};
+  std::istringstream ss("1 2 3");
+  std::istream_iterator<int> ii(ss), end;
+  v.assign(ii, end);
+  ASSERT_EQ(v, vv);
+  ss.clear();
+  ss.str("10 11 12 13 14 15");
+  ii = ss;
+  ASSERT_THROW(v.assign(ii, end), std::length_error);
+  ASSERT_EQ(v, vv);
+  ss.clear();
+  ss.str("0");
+  ii = ss;
+  v.insert(v.begin(), ii, end);
+  vv.insert(vv.begin(), 0);
+  ASSERT_EQ(v, vv);
+  ss.clear();
+  ss.str("10 11 12 13");
+  ii = ss;
+  v.pop_back();
+  vv.pop_back();
+  ASSERT_THROW(v.insert(v.begin() + 1, ii, end), std::length_error);
+  ASSERT_EQ(v, vv);
 }

--- a/rosidl_runtime_cpp/test/test_bounded_vector.cpp
+++ b/rosidl_runtime_cpp/test/test_bounded_vector.cpp
@@ -65,8 +65,8 @@ TEST(rosidl_generator_cpp, bounded_vector_insert) {
   ASSERT_THROW(v1.insert(it + 1, v2.end(), v2.begin()), std::length_error);
   // insert v2 after the 1st position
   ASSERT_NO_THROW(v1.insert(it + 1, v2.begin(), v2.end()));
-  // insert v2 after the 4th position
-  ASSERT_THROW(v1.insert(it + 4, v2.begin(), v2.end()), std::length_error);
+  rosidl_runtime_cpp::BoundedVector<int, 6> vv1{1, 2, 3, 4};
+  ASSERT_EQ(v1, vv1);
 }
 
 TEST(rosidl_generator_cpp, bounded_vector_comparisons) {


### PR DESCRIPTION
Input iterators are single pass, so calling std::distance(first, last)
will consume the input and leave [first,last) as an empty range.

This change makes assign(InputIterator, InputIterator) and
insert(const_iterator, InputIterator, InputIterator) dispatch to
overloaded functions that choose the right overload based on the
iterator category. For forward iterators the original implementation is
used. For input iterators assign will construct a new vector and if that
doesn't throw, use swap to replace the contents of *this. For insert
each value is inserted at the end and if the bound is not exceeded
std::rotate is used to shift them to the desired position, otherwise the
inserted elements are removed from the end before the function exits.

This retains the strong exception safety guarantee for both operations,
so that exceeding the bound does not alter the existing contents of the
vector.

Fixes #486

Signed-off-by: Jonathan Wakely <github@kayari.org>