### PR TITLE
Update QD to reflect QL 2 status of rosidl_runtime_cpp

### DIFF
--- a/rosidl_runtime_cpp/QUALITY_DECLARATION.md
+++ b/rosidl_runtime_cpp/QUALITY_DECLARATION.md
@@ -2,7 +2,7 @@ This document is a declaration of software quality for the `rosidl_runtime_cpp` 
 
 # rosidl_runtime_cpp Quality Declaration
 
-The package `rosidl_runtime_cpp` claims to be in the **Quality Level 4** category.
+The package `rosidl_runtime_cpp` claims to be in the **Quality Level 2** category.
 
 Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 4 in REP-2004](https://www.ros.org/reps/rep-2004.html).
 
@@ -99,7 +99,17 @@ The BoundedVector class is tested and the most recent test results can be found 
 
 ### Coverage [4.iv]
 
-`rosidl_runtime_cpp` does not currently track test coverage.
+`rosidl_runtime_cpp` follows the recommendations for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#code-coverage), and opts to use line coverage instead of branch coverage.
+
+This includes:
+
+- tracking and reporting line coverage statistics
+- achieving and maintaining a reasonable branch line coverage (90-100%)
+- no lines are manually skipped in coverage calculations
+
+Changes are required to make a best effort to keep or increase coverage before being accepted, but decreases are allowed if properly justified and accepted by reviewers.
+
+Current coverage statistics can be viewed [here](https://ci.ros2.org/job/ci_linux_coverage/lastBuild/cobertura/src_rosidl_rosidl_runtime_cpp_include_rosidl_runtime_cpp/).
 
 ### Performance [4.iv]
 

--- a/rosidl_runtime_cpp/README.md
+++ b/rosidl_runtime_cpp/README.md
@@ -8,4 +8,4 @@ The features provided by `rosidl_runtime_cpp` are documented in its [feature doc
 
 ## Quality Declaration
 
-This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](QUALITY_DECLARATION.md) for more details.
+This package claims to be in the **Quality Level 2** category, see the [Quality Declaration](QUALITY_DECLARATION.md) for more details.


### PR DESCRIPTION
This updates the QUALITY DECLARATION of the rosidl_runtime_cpp package to support its new status as QL 2.

Signed-off-by: Stephen Brawner <brawner@gmail.com>