### PR TITLE
Update rosidl_runtime_c QD to QL 2

### DIFF
--- a/rosidl_runtime_c/QUALITY_DECLARATION.md
+++ b/rosidl_runtime_c/QUALITY_DECLARATION.md
@@ -2,9 +2,9 @@ This document is a declaration of software quality for the `rosidl_runtime_c` pa
 
 # rosidl_runtime_c Quality Declaration
 
-The package `rosidl_runtime_c` claims to be in the **Quality Level 4** category.
+The package `rosidl_runtime_c` claims to be in the **Quality Level 2** category.
 
-Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 4 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 2 in REP-2004](https://www.ros.org/reps/rep-2004.html).
 
 ## Version Policy [1]
 
@@ -101,7 +101,18 @@ Most recent test results can be found [here](https://ci.ros2.org/job/nightly_lin
 
 ### Coverage [4.iv]
 
-`rosidl_runtime_c` does not currently track test coverage.
+`rosidl_runtime_c` follows the recommendations for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#code-coverage), and opts to use line coverage instead of branch coverage.
+
+This includes:
+
+- tracking and reporting line coverage statistics
+- achieving and maintaining a reasonable branch line coverage (90-100%)
+- no lines are manually skipped in coverage calculations
+
+Changes are required to make a best effort to keep or increase coverage before being accepted, but decreases are allowed if properly justified and accepted by reviewers.
+
+Current coverage statistics can be viewed [here](https://ci.ros2.org/job/ci_linux_coverage/lastSuccessfulBuild/cobertura/).
+A description of how coverage statistics are summarized from this page, can be found in the [ROS 2 Onboarding Guide](https://index.ros.org/doc/ros2/Contributing/ROS-2-On-boarding-Guide/#note-on-coverage-runs).
 
 ### Performance [4.iv]
 
@@ -126,7 +137,7 @@ It also has several test dependencies, which do not affect the resulting quality
 
 The `rosidl_typesupport_interface` package provides several macros to define the rosidl C typesupport interface.
 
-It is **Quality Level 4**, see its [Quality Declaration document](../rosidl_typesupport_interface/QUALITY_DECLARATION.md).
+It is **Quality Level 2**, see its [Quality Declaration document](../rosidl_typesupport_interface/QUALITY_DECLARATION.md).
 
 ### Direct Runtime Non-ROS Dependencies [5.iii]
 

--- a/rosidl_runtime_c/README.md
+++ b/rosidl_runtime_c/README.md
@@ -1,6 +1,6 @@
 # rosidl_generator_c
 
-`rosidl_runtime_c` is a package and provides runtime ROSIDL functionality C.
+`rosidl_runtime_c` is a package and provides runtime ROSIDL functionality in C.
 
 ## Features
 
@@ -8,4 +8,4 @@ A list of features provided by `rosidl_runtime_c` is available in its [feature d
 
 ## Quality Declaration
 
-This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](QUALITY_DECLARATION.md) for more details.
+This package claims to be in the **Quality Level 2** category, see the [Quality Declaration](QUALITY_DECLARATION.md) for more details.


### PR DESCRIPTION
Like #499, this updates rosidl_runtime_c to reflect it's current status as QL 2.

Signed-off-by: Stephen Brawner <brawner@gmail.com>