### PR TITLE
rosidl_generator_c: don't depend on rosidl_runtime_c when tests are disabled

### DIFF
--- a/rosidl_generator_c/CMakeLists.txt
+++ b/rosidl_generator_c/CMakeLists.txt
@@ -13,7 +13,6 @@ endif()
 
 find_package(ament_cmake_python REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
-find_package(rosidl_runtime_c REQUIRED)
 
 ament_export_dependencies(rosidl_cmake)
 ament_export_dependencies(rosidl_typesupport_interface)
@@ -30,6 +29,7 @@ endif()
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   find_package(test_interface_files REQUIRED)
+  find_package(rosidl_runtime_c REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
   include(cmake/register_c.cmake)


### PR DESCRIPTION
`rosidl_generator_c` currently depends `rosidl_runtime_c` (a `test_depend` in `package.xml`) even when `BUILD_TESTING` is disabled, causing the build to fail if the `test_depend`s are not available. This PR makes the dependency conditional on `BUILD_TESTING`.