### PR TITLE
allow zero length string constants

### DIFF
--- a/rosidl_parser/rosidl_parser/definition.py
+++ b/rosidl_parser/rosidl_parser/definition.py
@@ -218,10 +218,9 @@ class BoundedString(AbstractString):
         Create a BoundedString.
 
         :param maximum_size: the maximum length of the string in characters
-          (must be greater than zero)
         """
         super().__init__()
-        assert maximum_size > 0
+        assert maximum_size >= 0
         self.maximum_size = maximum_size
 
     def has_maximum_size(self):

--- a/rosidl_parser/rosidl_parser/parser.py
+++ b/rosidl_parser/rosidl_parser/parser.py
@@ -453,6 +453,7 @@ def get_abstract_type(tree):
                 assert child.children[0].data == 'positive_int_const'
                 maximum_size = get_positive_int_const(child.children[0])
                 if 'string_type' == child.data:
+                    assert maximum_size > 0
                     return BoundedString(maximum_size=maximum_size)
                 if 'wide_string_type' == child.data:
                     return BoundedWString(maximum_size=maximum_size)

--- a/rosidl_parser/test/msg/MyMessage.idl
+++ b/rosidl_parser/test/msg/MyMessage.idl
@@ -10,6 +10,7 @@ module rosidl_parser {
       const boolean BOOLEAN_CONSTANT = TRUE;
       const string STRING_CONSTANT = "string_value";
       const wstring WSTRING_CONSTANT = "wstring_value_\u2122";
+      const string EMPTY_STRING_CONSTANT = "";
     };
 
     @verbatim ( language="comment", text="Documentation of MyMessage." "Adjacent string literal." )

--- a/rosidl_parser/test/test_parser.py
+++ b/rosidl_parser/test/test_parser.py
@@ -62,7 +62,7 @@ def test_message_parser_structure(message_idl_file):
     assert len(messages) == 1
 
     constants = messages[0].constants
-    assert len(constants) == 6
+    assert len(constants) == 7
 
     assert constants[0].name == 'SHORT_CONSTANT'
     assert isinstance(constants[0].type, BasicType)
@@ -91,6 +91,10 @@ def test_message_parser_structure(message_idl_file):
     assert constants[5].name == 'WSTRING_CONSTANT'
     assert isinstance(constants[5].type, BoundedWString)
     assert constants[5].value == 'wstring_value_\\u2122'
+
+    assert constants[6].name == 'EMPTY_STRING_CONSTANT'
+    assert isinstance(constants[6].type, BoundedString)
+    assert constants[6].value == ''
 
     structure = messages[0].structure
     assert structure.namespaced_type.namespaces == ['rosidl_parser', 'msg']


### PR DESCRIPTION
Fixes #506.

CI builds testing above `rosidl_parser`:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11574)](http://ci.ros2.org/job/ci_linux/11574/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6715)](http://ci.ros2.org/job/ci_linux-aarch64/6715/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9452)](http://ci.ros2.org/job/ci_osx/9452/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11528)](http://ci.ros2.org/job/ci_windows/11528/)
  * (The failing test is unrelated.)