### PR TITLE
refactor regex for valid package/field names

### DIFF
--- a/rosidl_adapter/rosidl_adapter/parser.py
+++ b/rosidl_adapter/rosidl_adapter/parser.py
@@ -57,8 +57,14 @@ PRIMITIVE_TYPES = [
     'time',  # for compatibility only
 ]
 
-VALID_PACKAGE_NAME_PATTERN = re.compile('^[a-z]([a-z0-9_]?[a-z0-9]+)*$')
-VALID_FIELD_NAME_PATTERN = re.compile('^[a-z]([a-z0-9_]?[a-z0-9]+)*$')
+VALID_PACKAGE_NAME_PATTERN = re.compile(
+    '^'
+    '(?!.*__)'  # no consecutive underscores
+    '(?!.*_$)'  # no underscore at the end
+    '[a-z]'  # first character must be alpha
+    '[a-z0-9_]*'  # followed by alpha, numeric, and underscore
+    '$')
+VALID_FIELD_NAME_PATTERN = VALID_PACKAGE_NAME_PATTERN
 # relaxed patterns used for compatibility with ROS 1 messages
 # VALID_FIELD_NAME_PATTERN = re.compile('^[A-Za-z][A-Za-z0-9_]*$')
 VALID_MESSAGE_NAME_PATTERN = re.compile('^[A-Z][A-Za-z0-9]*$')


### PR DESCRIPTION
Fixes a problem reported in colcon/colcon-core#364.

Without the patch the regex can take an huge amount of time for some invalid input, e.g.:

```
import re
x = re.compile('^[a-z]([a-z0-9_]?[a-z0-9]+)*$')
x.match('txt_msg_autoflow_added_to_current_ventilation_mode"')
```

CI builds testing `rosidl_adapter` and downstream packages (with only Fast DDS):
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11597)](http://ci.ros2.org/job/ci_linux/11597/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6738)](http://ci.ros2.org/job/ci_linux-aarch64/6738/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9482)](http://ci.ros2.org/job/ci_osx/9482/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11561)](http://ci.ros2.org/job/ci_windows/11561/)
  * (Unrelated test failure)