### PR TITLE
Declaring is_message in namespace rosidl_generator_traits.

### DIFF
--- a/rosidl_generator_cpp/test/test_traits.cpp
+++ b/rosidl_generator_cpp/test/test_traits.cpp
@@ -28,8 +28,13 @@ struct Message {};
 // Empty testing struct, with template instantiation
 struct Message2 {};
 
+namespace rosidl_generator_traits
+{
+
 template<>
-struct rosidl_generator_traits::is_message<Message2>: std::true_type {};
+struct is_message<Message2>: std::true_type {};
+
+}  // namespace rosidl_generator_traits
 
 TEST(Test_rosidl_generator_traits, is_message) {
   // A message is not a service


### PR DESCRIPTION
Resolves issues with older GCC versions, as described in https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480.

Resolves #479.

#479 seems to be a [bug in gcc](https://stackoverflow.com/a/25594741). The [original bug report](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480) states that:

```cpp
namespace Foo 
{
    template <typename T>
    struct Meow
    {
    };
}

template <>
struct Foo::Meow<int>
{
};
```

failed, while 

> The code is accepted if a declaration (without definition) of the specialization is placed in the namespace.

So changing 

https://github.com/ros2/rosidl/blob/76c536eb35b15076c619f835bea3561e2c6fc6a3/rosidl_generator_cpp/test/test_traits.cpp#L31-L32

to

```cpp
namespace rosidl_generator_traits
{

template<>
struct is_message<Message2>: std::true_type {};

}
```

resolves #479.