### PR TITLE
Add function for getting a types fully qualified name

### DIFF
--- a/rosidl_generator_cpp/CMakeLists.txt
+++ b/rosidl_generator_cpp/CMakeLists.txt
@@ -92,13 +92,13 @@ if(BUILD_TESTING)
       ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}
     )
   endif()
-  ament_add_gtest(test_fully_qualified_name test/test_fully_qualified_name.cpp)
-  if(TARGET test_fully_qualified_name)
-    add_dependencies(test_fully_qualified_name ${PROJECT_NAME})
-    ament_target_dependencies(test_fully_qualified_name
+  ament_add_gtest(test_name test/test_name.cpp)
+  if(TARGET test_name)
+    add_dependencies(test_name ${PROJECT_NAME})
+    ament_target_dependencies(test_name
       rosidl_runtime_cpp
       rosidl_runtime_c)
-    target_include_directories(test_fully_qualified_name PUBLIC
+    target_include_directories(test_name PUBLIC
       ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}
     )
   endif()

--- a/rosidl_generator_cpp/CMakeLists.txt
+++ b/rosidl_generator_cpp/CMakeLists.txt
@@ -92,6 +92,16 @@ if(BUILD_TESTING)
       ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}
     )
   endif()
+  ament_add_gtest(test_fully_qualified_name test/test_fully_qualified_name.cpp)
+  if(TARGET test_fully_qualified_name)
+    add_dependencies(test_fully_qualified_name ${PROJECT_NAME})
+    ament_target_dependencies(test_fully_qualified_name
+      rosidl_runtime_cpp
+      rosidl_runtime_c)
+    target_include_directories(test_fully_qualified_name PUBLIC
+      ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}
+    )
+  endif()
   ament_add_gtest(test_traits test/test_traits.cpp)
   if(TARGET test_traits)
     add_dependencies(test_traits ${PROJECT_NAME})

--- a/rosidl_generator_cpp/resource/msg__traits.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__traits.hpp.em
@@ -68,7 +68,7 @@ inline const char * data_type<@(message_typename)>()
 }
 
 template<>
-inline const char * fully_qualified_name<@(message_typename)>()
+inline const char * name<@(message_typename)>()
 {
   return "@(message_fully_qualified_name)";
 }

--- a/rosidl_generator_cpp/resource/msg__traits.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__traits.hpp.em
@@ -11,6 +11,7 @@ from rosidl_parser.definition import AbstractSequence
 from rosidl_parser.definition import UnboundedSequence
 
 message_typename = '::'.join(message.structure.namespaced_type.namespaced_name())
+message_fully_qualified_name = '/'.join(message.structure.namespaced_type.namespaced_name())
 }@
 @
 @#<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
@@ -64,6 +65,12 @@ template<>
 inline const char * data_type<@(message_typename)>()
 {
   return "@(message_typename)";
+}
+
+template<>
+inline const char * fully_qualified_name<@(message_typename)>()
+{
+  return "@(message_fully_qualified_name)";
 }
 
 @{

--- a/rosidl_generator_cpp/resource/srv__traits.hpp.em
+++ b/rosidl_generator_cpp/resource/srv__traits.hpp.em
@@ -15,6 +15,7 @@ TEMPLATE(
 
 @{
 service_typename = '::'.join(service.namespaced_type.namespaced_name())
+service_fully_qualified_name = '/'.join(service.namespaced_type.namespaced_name())
 }@
 @
 namespace rosidl_generator_traits
@@ -24,6 +25,12 @@ template<>
 inline const char * data_type<@(service_typename)>()
 {
   return "@(service_typename)";
+}
+
+template<>
+inline const char * fully_qualified_name<@(service_typename)>()
+{
+  return "@(service_fully_qualified_name)";
 }
 
 template<>

--- a/rosidl_generator_cpp/resource/srv__traits.hpp.em
+++ b/rosidl_generator_cpp/resource/srv__traits.hpp.em
@@ -28,7 +28,7 @@ inline const char * data_type<@(service_typename)>()
 }
 
 template<>
-inline const char * fully_qualified_name<@(service_typename)>()
+inline const char * name<@(service_typename)>()
 {
   return "@(service_fully_qualified_name)";
 }

--- a/rosidl_generator_cpp/test/test_fully_qualified_name.cpp
+++ b/rosidl_generator_cpp/test/test_fully_qualified_name.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 Open Source Robotics Foundation, Inc.
+// Copyright 2020 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rosidl_generator_cpp/test/test_fully_qualified_name.cpp
+++ b/rosidl_generator_cpp/test/test_fully_qualified_name.cpp
@@ -1,0 +1,37 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include "rosidl_generator_cpp/msg/empty.hpp"
+#include "rosidl_generator_cpp/msg/strings.hpp"
+#include "rosidl_generator_cpp/srv/basic_types.hpp"
+#include "rosidl_generator_cpp/srv/empty.hpp"
+
+TEST(Test_rosidl_generator_traits, check_msg_fully_qualified_name) {
+  ASSERT_STREQ(
+    "rosidl_generator_cpp/msg/Strings",
+    rosidl_generator_traits::fully_qualified_name<rosidl_generator_cpp::msg::Strings>());
+  ASSERT_STREQ(
+    "rosidl_generator_cpp/msg/Empty",
+    rosidl_generator_traits::fully_qualified_name<rosidl_generator_cpp::msg::Empty>());
+}
+
+TEST(Test_rosidl_generator_traits, check_srv_fully_qualified_name) {
+  ASSERT_STREQ(
+    "rosidl_generator_cpp/srv/BasicTypes",
+    rosidl_generator_traits::fully_qualified_name<rosidl_generator_cpp::srv::BasicTypes>());
+  ASSERT_STREQ(
+    "rosidl_generator_cpp/srv/Empty",
+    rosidl_generator_traits::fully_qualified_name<rosidl_generator_cpp::srv::Empty>());
+}

--- a/rosidl_generator_cpp/test/test_name.cpp
+++ b/rosidl_generator_cpp/test/test_name.cpp
@@ -18,20 +18,20 @@
 #include "rosidl_generator_cpp/srv/basic_types.hpp"
 #include "rosidl_generator_cpp/srv/empty.hpp"
 
-TEST(Test_rosidl_generator_traits, check_msg_fully_qualified_name) {
+TEST(Test_rosidl_generator_traits, check_msg_name) {
   ASSERT_STREQ(
     "rosidl_generator_cpp/msg/Strings",
-    rosidl_generator_traits::fully_qualified_name<rosidl_generator_cpp::msg::Strings>());
+    rosidl_generator_traits::name<rosidl_generator_cpp::msg::Strings>());
   ASSERT_STREQ(
     "rosidl_generator_cpp/msg/Empty",
-    rosidl_generator_traits::fully_qualified_name<rosidl_generator_cpp::msg::Empty>());
+    rosidl_generator_traits::name<rosidl_generator_cpp::msg::Empty>());
 }
 
-TEST(Test_rosidl_generator_traits, check_srv_fully_qualified_name) {
+TEST(Test_rosidl_generator_traits, check_srv_name) {
   ASSERT_STREQ(
     "rosidl_generator_cpp/srv/BasicTypes",
-    rosidl_generator_traits::fully_qualified_name<rosidl_generator_cpp::srv::BasicTypes>());
+    rosidl_generator_traits::name<rosidl_generator_cpp::srv::BasicTypes>());
   ASSERT_STREQ(
     "rosidl_generator_cpp/srv/Empty",
-    rosidl_generator_traits::fully_qualified_name<rosidl_generator_cpp::srv::Empty>());
+    rosidl_generator_traits::name<rosidl_generator_cpp::srv::Empty>());
 }

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/traits.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/traits.hpp
@@ -24,6 +24,9 @@ template<typename T>
 inline const char * data_type();
 
 template<typename T>
+inline const char * fully_qualified_name();
+
+template<typename T>
 struct has_fixed_size : std::false_type {};
 
 template<typename T>

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/traits.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/traits.hpp
@@ -24,7 +24,7 @@ template<typename T>
 inline const char * data_type();
 
 template<typename T>
-inline const char * fully_qualified_name();
+inline const char * name();
 
 template<typename T>
 struct has_fixed_size : std::false_type {};


### PR DESCRIPTION
As opposed the type name 'foo::msg::Bar', the new function let's us get the ROS namespaced name 'foo/msg/Bar'.

This seems generally useful, and would simplify logic in https://github.com/ros2/rviz/pull/591 for example.

I'm open to changing the name of the new function if there are better suggestions.