### PR TITLE
[eloquent backport] Add pytest.ini so tests succeed locally. (#502)

### DIFF
--- a/rosidl_adapter/pytest.ini
+++ b/rosidl_adapter/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2

--- a/rosidl_parser/pytest.ini
+++ b/rosidl_parser/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2


### PR DESCRIPTION
Backport #502 to Eloquent.

Connects to ros2/ros2#1016