### PR TITLE
[rosidl_typesupport_introspection_c] Fix get_function and get_const_function semantics for arrays

### DIFF
--- a/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
+++ b/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
@@ -137,9 +137,9 @@ const void * @(function_prefix)__get_const_function__@(member.type.value_type.na
   const void * untyped_member, size_t index)
 {
 @[    if isinstance(member.type, Array)]@
-  const @('__'.join(member.type.value_type.namespaced_name())) ** member =
-    (const @('__'.join(member.type.value_type.namespaced_name())) **)(untyped_member);
-  return &(*member)[index];
+  const @('__'.join(member.type.value_type.namespaced_name())) * member =
+    (const @('__'.join(member.type.value_type.namespaced_name())) *)(untyped_member);
+  return &member[index];
 @[    else]@
   const @('__'.join(member.type.value_type.namespaced_name()))__Sequence * member =
     (const @('__'.join(member.type.value_type.namespaced_name()))__Sequence *)(untyped_member);
@@ -151,9 +151,9 @@ void * @(function_prefix)__get_function__@(member.type.value_type.name)__@(membe
   void * untyped_member, size_t index)
 {
 @[    if isinstance(member.type, Array)]@
-  @('__'.join(member.type.value_type.namespaced_name())) ** member =
-    (@('__'.join(member.type.value_type.namespaced_name())) **)(untyped_member);
-  return &(*member)[index];
+  @('__'.join(member.type.value_type.namespaced_name())) * member =
+    (@('__'.join(member.type.value_type.namespaced_name())) *)(untyped_member);
+  return &member[index];
 @[    else]@
   @('__'.join(member.type.value_type.namespaced_name()))__Sequence * member =
     (@('__'.join(member.type.value_type.namespaced_name()))__Sequence *)(untyped_member);


### PR DESCRIPTION
Fixes https://github.com/ros2/rosidl/issues/522.
For all arrays/sequences/bounded_sequences in rosidl_typesupport_introspection_c/cpp, the following code works:

```c
member->get_function(ros_message + member->offset_, index)
```
except for rosidl_typesupport_introspection_c arrays, where the correct code is:

```c
member->get_function(&(ros_message + member->offset_), index)
```

This PR fixes the semantic difference.

The following PRs must be merged simultaneously:
- https://github.com/ros2/rmw_cyclonedds/pull/248
- https://github.com/ros2/rmw_fastrtps/pull/448
- https://github.com/ros2/ros2_documentation/pull/877.

This error wasn't detected before, because both `rmw_fastrtps_dynamic_cpp` and `rmw_cyclonedds_cpp` were doing "weird stuff" instead of using the "get function" and "resize function" provided by the introspection typesupport.
For further reference, see:
- ros2/rmw_cyclonedds#219
- ros2/rmw_fastrtps#428