### PR TITLE
Add rcutils dependency.

### DIFF
--- a/rosidl_runtime_c/package.xml
+++ b/rosidl_runtime_c/package.xml
@@ -13,8 +13,9 @@
 
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
 
-  <build_export_depend>rcutils</build_export_depend>
   <build_export_depend>rosidl_typesupport_interface</build_export_depend>
+
+  <depend>rcutils</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
Commit 279731bf72ab1f60553eb381fba7ba3f38947d44 added in fault
injection and tests, which require rcutils to be present to
succeed on the buildfarm.  Add in the rcutils dependency
here.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>