### PR TITLE
Strip action service suffixes from C include prefix

### DIFF
--- a/rosidl_generator_c/rosidl_generator_c/__init__.py
+++ b/rosidl_generator_c/rosidl_generator_c/__init__.py
@@ -87,6 +87,10 @@ def idl_structure_type_to_c_include_prefix(namespaced_type, subdirectory=None):
         include_prefix = include_prefix[:-8]
     elif include_prefix.endswith('__feedback'):
         include_prefix = include_prefix[:-10]
+    elif include_prefix.endswith('__send_goal'):
+        include_prefix = include_prefix[:-11]
+    elif include_prefix.endswith('__get_result'):
+        include_prefix = include_prefix[:-12]
     return include_prefix
 
 


### PR DESCRIPTION
This adds logic for the two missing services that are part of an action: `send_goal` and `get_result`.
For example, "fibonacci__send_goal.h" is not a valid header and we should instead use "fibonacci.h".

C++ and Python generators are not affected by this change since they combine all parts of an
action definition into a single file.

But generators like rosidl_generator_java create separate files for the service and message
definitions composing an action, and can take advantage of this common logic.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=12794)](http://ci.ros2.org/job/ci_linux/12794/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7753)](http://ci.ros2.org/job/ci_linux-aarch64/7753/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10508)](http://ci.ros2.org/job/ci_osx/10508/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12741)](http://ci.ros2.org/job/ci_windows/12741/)