### PR TITLE
Fix parsing of floating_pt_literal and fixed_pt_literal

### DIFF
--- a/rosidl_parser/rosidl_parser/grammar.lark
+++ b/rosidl_parser/rosidl_parser/grammar.lark
@@ -8,9 +8,11 @@
 // 7.4.15.4.2 Applying Annotations
 //   Only supported on modules, structs, members, enums and enum identifiers
 
+%import common.DECIMAL
 %import common.DIGIT
 %import common.FLOAT
 %import common.HEXDIGIT
+%import common.INT
 %import common.LETTER
 %import common.WS
 %ignore WS
@@ -79,10 +81,8 @@ wide_string_literal: "L\"\"" | "L\"" /(\\\"|[^"])+/ "\""
 floating_pt_literal: FLOAT
 
 // 7.2.6.5 Fixed-Point Literals
-fixed_pt_literal: DIGIT+ "." DIGIT+ "d"i
-  |"." DIGIT+ "d"i
-  | DIGIT+ "." "d"i
-  | DIGIT+ "d"i
+fixed_pt_literal: DECIMAL "d"i
+  | INT "d"i
 
 
 // 7.3 Preprocessing

--- a/rosidl_parser/rosidl_parser/grammar.lark
+++ b/rosidl_parser/rosidl_parser/grammar.lark
@@ -9,6 +9,7 @@
 //   Only supported on modules, structs, members, enums and enum identifiers
 
 %import common.DIGIT
+%import common.FLOAT
 %import common.HEXDIGIT
 %import common.LETTER
 %import common.WS
@@ -75,13 +76,7 @@ string_literal: "\"\"" | "\"" /(\\\"|[^"])+/ "\""
 wide_string_literal: "L\"\"" | "L\"" /(\\\"|[^"])+/ "\""
 
 // 7.2.6.4 Floating-point Literals
-floating_pt_literal: DIGIT+ floating_pt_literal_dot DIGIT+ floating_pt_literal_e DIGIT*
-  | floating_pt_literal_dot DIGIT+ (floating_pt_literal_e DIGIT*)?
-  | DIGIT+ floating_pt_literal_dot DIGIT* (floating_pt_literal_e DIGIT*)?
-  | DIGIT+ floating_pt_literal_e DIGIT*
-// separate rules to identify the components
-floating_pt_literal_dot: "."
-floating_pt_literal_e: "e"i
+floating_pt_literal: FLOAT
 
 // 7.2.6.5 Fixed-Point Literals
 fixed_pt_literal: DIGIT+ "." DIGIT+ "d"i

--- a/rosidl_parser/rosidl_parser/parser.py
+++ b/rosidl_parser/rosidl_parser/parser.py
@@ -588,10 +588,6 @@ def get_floating_pt_literal_value(floating_pt_literal):
     for child in floating_pt_literal.children:
         if isinstance(child, Token):
             value += child.value
-        elif child.data == 'floating_pt_literal_dot':
-            value += '.'
-        elif child.data == 'floating_pt_literal_e':
-            value += 'e'
         else:
             assert False, 'Unsupported tree: ' + str(floating_pt_literal)
     return float(value)

--- a/rosidl_parser/rosidl_parser/parser.py
+++ b/rosidl_parser/rosidl_parser/parser.py
@@ -557,6 +557,12 @@ def get_const_expr_value(const_expr):
                 value = -value
             return value
 
+        if child.data == 'fixed_pt_literal':
+            value = get_fixed_pt_literal_value(child)
+            if negate_value:
+                value = -value
+            return value
+
         if child.data == 'boolean_literal':
             assert len(child.children) == 1
             child = child.children[0]
@@ -590,6 +596,16 @@ def get_floating_pt_literal_value(floating_pt_literal):
             value += child.value
         else:
             assert False, 'Unsupported tree: ' + str(floating_pt_literal)
+    return float(value)
+
+
+def get_fixed_pt_literal_value(fixed_pt_literal):
+    value = ''
+    for child in fixed_pt_literal.children:
+        if isinstance(child, Token):
+            value += child.value
+        else:
+            assert False, 'Unsupported tree: ' + str(fixed_pt_literal)
     return float(value)
 
 

--- a/rosidl_parser/test/msg/MyMessage.idl
+++ b/rosidl_parser/test/msg/MyMessage.idl
@@ -71,6 +71,16 @@ module rosidl_parser {
       float int_with_explicit_positive_scientific;
       @default ( value=9e-05 )
       float int_with_negative_scientific;
+
+      // Tests of the fixed point parser (7.2.6.5)
+      @default ( value=8.7d )
+      float fixed_int_and_frac;
+      @default ( value=4.d )
+      float fixed_int_with_dot_only;
+      @default ( value=.3d )
+      float fixed_frac_only;
+      @default ( value=7d )
+      float fixed_int_only;
     };
   };
 };

--- a/rosidl_parser/test/msg/MyMessage.idl
+++ b/rosidl_parser/test/msg/MyMessage.idl
@@ -51,6 +51,26 @@ module rosidl_parser {
       sequence<string<3>> unbounded_values_of_bounded_strings;
       sequence<string<3>, 4> bounded_values_of_bounded_strings;
       short array_short_values[23];
+
+      // Tests of the floating point parser (7.2.6.4)
+      @default ( value=1.9e10 )
+      float int_and_frac_with_positive_scientific;
+      @default ( value=1.9e+10 )
+      float int_and_frac_with_explicit_positive_scientific;
+      @default ( value=1.1e-10)
+      float int_and_frac_with_negative_scientific;
+      @default ( value=0.00009 )
+      float int_and_frac;
+      @default ( value = 1. )
+      float int_with_empty_frac;
+      @default ( value = .1 )
+      float frac_only;
+      @default ( value=9e05 )
+      float int_with_positive_scientific;
+      @default ( value=9e+05 )
+      float int_with_explicit_positive_scientific;
+      @default ( value=9e-05 )
+      float int_with_negative_scientific;
     };
   };
 };

--- a/rosidl_parser/test/test_parser.py
+++ b/rosidl_parser/test/test_parser.py
@@ -99,7 +99,7 @@ def test_message_parser_structure(message_idl_file):
     structure = messages[0].structure
     assert structure.namespaced_type.namespaces == ['rosidl_parser', 'msg']
     assert structure.namespaced_type.name == 'MyMessage'
-    assert len(structure.members) == 32
+    assert len(structure.members) == 41
 
     assert isinstance(structure.members[0].type, BasicType)
     assert structure.members[0].type.typename == 'int16'
@@ -186,6 +186,60 @@ def test_message_parser_annotations(message_idl_file):
     assert structure.members[3].annotations[1].value['min'] == -10
     assert 'max' in structure.members[3].annotations[1].value
     assert structure.members[3].annotations[1].value['max'] == 10
+
+    assert isinstance(structure.members[32].type, BasicType)
+    assert structure.members[32].type.typename == 'float'
+    assert structure.members[32].name == 'int_and_frac_with_positive_scientific'
+    assert len(structure.members[32].annotations) == 1
+    assert structure.members[32].annotations[0].name == 'default'
+
+    assert isinstance(structure.members[33].type, BasicType)
+    assert structure.members[33].type.typename == 'float'
+    assert structure.members[33].name == 'int_and_frac_with_explicit_positive_scientific'
+    assert len(structure.members[33].annotations) == 1
+    assert structure.members[33].annotations[0].name == 'default'
+
+    assert isinstance(structure.members[34].type, BasicType)
+    assert structure.members[34].type.typename == 'float'
+    assert structure.members[34].name == 'int_and_frac_with_negative_scientific'
+    assert len(structure.members[34].annotations) == 1
+    assert structure.members[34].annotations[0].name == 'default'
+
+    assert isinstance(structure.members[35].type, BasicType)
+    assert structure.members[35].type.typename == 'float'
+    assert structure.members[35].name == 'int_and_frac'
+    assert len(structure.members[35].annotations) == 1
+    assert structure.members[35].annotations[0].name == 'default'
+
+    assert isinstance(structure.members[36].type, BasicType)
+    assert structure.members[36].type.typename == 'float'
+    assert structure.members[36].name == 'int_with_empty_frac'
+    assert len(structure.members[36].annotations) == 1
+    assert structure.members[36].annotations[0].name == 'default'
+
+    assert isinstance(structure.members[37].type, BasicType)
+    assert structure.members[37].type.typename == 'float'
+    assert structure.members[37].name == 'frac_only'
+    assert len(structure.members[37].annotations) == 1
+    assert structure.members[37].annotations[0].name == 'default'
+
+    assert isinstance(structure.members[38].type, BasicType)
+    assert structure.members[38].type.typename == 'float'
+    assert structure.members[38].name == 'int_with_positive_scientific'
+    assert len(structure.members[38].annotations) == 1
+    assert structure.members[38].annotations[0].name == 'default'
+
+    assert isinstance(structure.members[39].type, BasicType)
+    assert structure.members[39].type.typename == 'float'
+    assert structure.members[39].name == 'int_with_explicit_positive_scientific'
+    assert len(structure.members[39].annotations) == 1
+    assert structure.members[39].annotations[0].name == 'default'
+
+    assert isinstance(structure.members[40].type, BasicType)
+    assert structure.members[40].type.typename == 'float'
+    assert structure.members[40].name == 'int_with_negative_scientific'
+    assert len(structure.members[40].annotations) == 1
+    assert structure.members[40].annotations[0].name == 'default'
 
 
 @pytest.fixture(scope='module')

--- a/rosidl_parser/test/test_parser.py
+++ b/rosidl_parser/test/test_parser.py
@@ -99,7 +99,7 @@ def test_message_parser_structure(message_idl_file):
     structure = messages[0].structure
     assert structure.namespaced_type.namespaces == ['rosidl_parser', 'msg']
     assert structure.namespaced_type.name == 'MyMessage'
-    assert len(structure.members) == 41
+    assert len(structure.members) == 45
 
     assert isinstance(structure.members[0].type, BasicType)
     assert structure.members[0].type.typename == 'int16'
@@ -240,6 +240,30 @@ def test_message_parser_annotations(message_idl_file):
     assert structure.members[40].name == 'int_with_negative_scientific'
     assert len(structure.members[40].annotations) == 1
     assert structure.members[40].annotations[0].name == 'default'
+
+    assert isinstance(structure.members[41].type, BasicType)
+    assert structure.members[41].type.typename == 'float'
+    assert structure.members[41].name == 'fixed_int_and_frac'
+    assert len(structure.members[41].annotations) == 1
+    assert structure.members[41].annotations[0].name == 'default'
+
+    assert isinstance(structure.members[42].type, BasicType)
+    assert structure.members[42].type.typename == 'float'
+    assert structure.members[42].name == 'fixed_int_with_dot_only'
+    assert len(structure.members[42].annotations) == 1
+    assert structure.members[42].annotations[0].name == 'default'
+
+    assert isinstance(structure.members[43].type, BasicType)
+    assert structure.members[43].type.typename == 'float'
+    assert structure.members[43].name == 'fixed_frac_only'
+    assert len(structure.members[43].annotations) == 1
+    assert structure.members[43].annotations[0].name == 'default'
+
+    assert isinstance(structure.members[44].type, BasicType)
+    assert structure.members[44].type.typename == 'float'
+    assert structure.members[44].name == 'fixed_int_only'
+    assert len(structure.members[44].annotations) == 1
+    assert structure.members[44].annotations[0].name == 'default'
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
The problem comes about because the msg -> idl transformer
can generate IDL defaults like "9e-05", which the lark
grammar wasn't ready to handle.  But Lark provides a FLOAT
terminal type, which *does* handle it, so use that instead.

Also add a test for this situation.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

@dirk-thomas Looking for any insight from you why we didn't use the FLOAT builtin before.  Maybe it was an oversight, but maybe there was a reason.  Once I have some idea of whether this is the right thing to do, I'll run a full CI run on all messages, services, and actions just to make sure nothing breaks here.

Should fix #541 .