### PR TITLE
Use ASSERT_TRUE to check for nullptr.

### DIFF
--- a/rosidl_generator_cpp/test/test_msg_initialization.cpp
+++ b/rosidl_generator_cpp/test/test_msg_initialization.cpp
@@ -175,7 +175,7 @@ TEST(Test_msg_initialization, defaults_only_constructor) {
 // it does no initialization.
 TEST(Test_msg_initialization, skip_constructor) {
   char * memory = new char[sizeof(rosidl_generator_cpp::msg::BoundedSequences)];
-  ASSERT_NE(memory, nullptr);
+  ASSERT_TRUE(nullptr != memory);
   std::memset(memory, 0xfe, sizeof(rosidl_generator_cpp::msg::BoundedSequences));
   rosidl_generator_cpp::msg::BoundedSequences * bounded =
     new(memory) rosidl_generator_cpp::msg::BoundedSequences(


### PR DESCRIPTION
clang static analysis reports this as a false positive for
a possible memory leak.  This is incorrect, but the FAQ
for googletest also has this tidbit:

https://github.com/google/googletest/blob/master/googletest/docs/faq.md#why-does-googletest-support-expect_eqnull-ptr-and-assert_eqnull-ptr-but-not-expect_nenull-ptr-and-assert_nenull-ptr

Thus, just switch to ASSERT_TRUE for the check, which is
good enough and makes clang static analysis happier.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>