### PR TITLE
Update and add package.xml descriptions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,26 @@
 
 ```rosidl``` is one of the ros_core packages.
 See [documentation](http://docs.ros2.org/latest/developer_overview.html#the-rosidl-repository) for details of this package.
+
+## Packages
+
+* [rosidl_adapter](./rosidl_adapter)
+  * API and scripts to parse `.msg`/`.srv`/`.action` files and convert them to `.idl`
+* [rosidl_cmake](./rosidl_cmake)
+  * CMake functionality to invoke code generation for ROS interface files
+* [rosidl_generator_c](./rosidl_generator_c)
+  * Generate the ROS interfaces in C
+* [rosidl_generator_cpp](./rosidl_generator_cpp)
+  * Generate the ROS interfaces in C++
+* [rosidl_parser](./rosidl_parser)
+  * Parser for `.idl` ROS interface files
+* [rosidl_runtime_c](./rosidl_runtime_c)
+  * Provides definitions, initialization and finalization functions, and macros for getting and working with rosidl typesupport types in C
+* [rosidl_runtime_cpp](./rosidl_runtime_cpp)
+  * Provides definitions and templated functions for getting and working with rosidl typesupport types in C++
+* [rosidl_typesupport_interface](./rosidl_typesupport_interface)
+  * Interface for rosidl typesupport packages
+* [rosidl_typesupport_introspection_c](./rosidl_typesupport_introspection_c)
+  * Generate the message type support for dynamic message construction in C
+* [rosidl_typesupport_introspection_cpp](./rosidl_typesupport_introspection_cpp)
+  * Generate the message type support for dynamic message construction in C++

--- a/rosidl_parser/package.xml
+++ b/rosidl_parser/package.xml
@@ -3,7 +3,7 @@
 <package format="2">
   <name>rosidl_parser</name>
   <version>2.0.1</version>
-  <description>The parser for ROS interface files.</description>
+  <description>The parser for `.idl` ROS interface files.</description>
   <maintainer email="clalancette@openrobotics.org">Chris Lalancette</maintainer>
   <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>Apache License 2.0</license>

--- a/rosidl_runtime_c/package.xml
+++ b/rosidl_runtime_c/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>rosidl_runtime_c</name>
   <version>2.0.1</version>
-  <description>Generate the ROS interfaces in C.</description>
+  <description>Provides definitions, initialization and finalization functions, and macros for getting and working with rosidl typesupport types in C.</description>
   <maintainer email="clalancette@openrobotics.org">Chris Lalancette</maintainer>
   <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>Apache License 2.0</license>

--- a/rosidl_runtime_cpp/package.xml
+++ b/rosidl_runtime_cpp/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>rosidl_runtime_cpp</name>
   <version>2.0.1</version>
-  <description>Generate the ROS interfaces in C++.</description>
+  <description>Provides definitions and templated functions for getting and working with rosidl typesupport types in C++.</description>
   <maintainer email="clalancette@openrobotics.org">Chris Lalancette</maintainer>
   <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>Apache License 2.0</license>


### PR DESCRIPTION
Inspired by a comment from one of the people on the ROS World software quality panel about many packages only having a single sentence in their README, this PR adds the description from each package's `package.xml` to the repo README. It should make it a little bit easier to navigate, since one only needs to look in one place to see what each package does rather than click through to each package individually.

I also made tiny improvements to some of the descriptions.