### PR TITLE
Remove unnecessary assert on pointer created with new

### DIFF
--- a/rosidl_generator_cpp/test/test_msg_initialization.cpp
+++ b/rosidl_generator_cpp/test/test_msg_initialization.cpp
@@ -175,7 +175,7 @@ TEST(Test_msg_initialization, defaults_only_constructor) {
 // it does no initialization.
 TEST(Test_msg_initialization, skip_constructor) {
   char * memory = new char[sizeof(rosidl_generator_cpp::msg::BoundedSequences)];
-  ASSERT_TRUE(nullptr != memory);
+
   std::memset(memory, 0xfe, sizeof(rosidl_generator_cpp::msg::BoundedSequences));
   rosidl_generator_cpp::msg::BoundedSequences * bounded =
     new(memory) rosidl_generator_cpp::msg::BoundedSequences(


### PR DESCRIPTION
This return path was flagged by clang static analysis as potentially leaking memory. I'm pretty sure it won't, but clang was a bit confused by it I think. In either case, new will throw an exception if it can't allocate instead of returning NULL.

Signed-off-by: Stephen Brawner <brawner@gmail.com>