### PR TITLE
Treat \t as whitespace

### DIFF
--- a/rosidl_adapter/rosidl_adapter/parser.py
+++ b/rosidl_adapter/rosidl_adapter/parser.py
@@ -459,6 +459,9 @@ def parse_message_string(pkg_name, msg_name, message_string):
     for line in lines:
         line = line.rstrip()
 
+        # replace tabs with spaces
+        line = line.replace('\t', ' ')
+
         # ignore empty lines
         if not line:
             # file-level comments stop at the first empty line

--- a/rosidl_adapter/test/test_parse_message_file.py
+++ b/rosidl_adapter/test/test_parse_message_file.py
@@ -26,7 +26,7 @@ def test_parse_message_file():
     try:
         filename = os.path.join(path, 'Foo.msg')
         with open(filename, 'w') as handle:
-            handle.write('bool foo')
+            handle.write('bool \tfoo')
         msg_spec = parse_message_file('pkg', filename)
 
         assert len(msg_spec.fields) == 1


### PR DESCRIPTION
Fixes #556.