### PR TITLE
Remove unnecessary short and unsigned short for cpp generator

### DIFF
--- a/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
+++ b/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
@@ -193,7 +193,6 @@ def primitive_value_to_cpp(type_, value):
         return 'true' if value else 'false'
 
     if type_.typename in [
-        'short', 'unsigned short',
         'char', 'wchar',
         'double', 'long double',
         'octet',


### PR DESCRIPTION
According to this: https://index.ros.org/doc/ros2/Concepts/About-ROS-Interfaces/
short (int16) and unsigned short (uint16) are DDS types not field type names.

Signed-off-by: Sean D'Souza <sdammobubbles@gmail.com>