### PR TITLE
Align rosidl_cli package version with the rest of the repo.

### DIFF
--- a/rosidl_cli/package.xml
+++ b/rosidl_cli/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>rosidl_cli</name>
-  <version>0.1.0</version>
+  <version>2.0.3</version>
   <description>
     Command line tools for ROS interface generation.
   </description>

--- a/rosidl_cli/setup.py
+++ b/rosidl_cli/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='rosidl_cli',
-    version='0.1.0',
+    version='2.0.3',
     packages=find_packages(exclude=['test']),
     extras_require={
         'completion': ['argcomplete'],


### PR DESCRIPTION
Precisely what the title says. Missed it on #567.