### PR TITLE
Fix a cpplint allocator regression.

### DIFF
--- a/rosidl_generator_c/resource/idl__functions.c.em
+++ b/rosidl_generator_c/resource/idl__functions.c.em
@@ -16,7 +16,7 @@ include_parts = [package_name] + list(interface_path.parents[0].parts) + [
     'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
 include_base = '/'.join(include_parts)
 
-include_directives = {include_base + '__functions.h'}
+include_directives = {include_base + '__functions.h', 'rcutils/allocator.h'}
 }@
 #include "@(include_base)__functions.h"
 
@@ -24,6 +24,8 @@ include_directives = {include_base + '__functions.h'}
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
+
+#include "rcutils/allocator.h"
 @
 @#######################################################################
 @# Handle message

--- a/rosidl_generator_c/resource/msg__functions.c.em
+++ b/rosidl_generator_c/resource/msg__functions.c.em
@@ -52,8 +52,6 @@ for member in message.structure.members:
 @#>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 @
 @#<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-#include <rcutils/allocator.h>
-
 @[if includes]@
 
 // Include directives for member types


### PR DESCRIPTION
We can't unconditionally include rcutils/allocator.h in the
msg__functions.c.em, because that file is used multiple times
when generating services.  That causes cpplint to complain
about a duplicate include.  Instead put the include in
idl__functions.c.em, and mark it as already included so we
won't try to include it again.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix a regression we are seeing, like: https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_debug/1594/testReport/junit/(root)/projectroot/cpplint_rosidl_generated_c/ .  I'm going to run full CI on it to be sure.

Fixes regression introduced in #584