### PR TITLE
Generate documentation in generated C header files based on ROS interfaces comments

### DIFF
--- a/rosidl_generator_c/resource/msg__struct.h.em
+++ b/rosidl_generator_c/resource/msg__struct.h.em
@@ -60,7 +60,11 @@ for member in message.structure.members:
 @[if comments]@
 /**
 @[  for line in comments]@
+@[    if line]@
   * @(line)
+@[    else]@
+  *
+@[    end if]@
 @[  end for]@
  */
 @[end if]@
@@ -142,7 +146,11 @@ enum
 @[if comments]@
 /**
 @[  for line in comments]@
+@[    if line]@
   * @(line)
+@[    else]@
+  *
+@[    end if]@
 @[  end for]@
  */
 @[end if]@
@@ -150,7 +158,11 @@ typedef struct @(idl_structure_type_to_c_typename(message.structure.namespaced_t
 {
 @[for member in message.structure.members]@
 @[  for line in member.get_comment_lines()]@
+@[    if line]@
   /// @(line)
+@[    else]@
+  ///
+@[    end if]@
 @[  end for]@
   @(idl_declaration_to_c(member.type, member.name));
 @[end for]@

--- a/rosidl_generator_c/resource/msg__struct.h.em
+++ b/rosidl_generator_c/resource/msg__struct.h.em
@@ -56,12 +56,11 @@ for member in message.structure.members:
 @[for constant in message.constants]@
 
 /// Constant '@(constant.name)'.
-@[if constant.annotations]@
+@{comments = constant.get_comment_lines()}@
+@[if comments]@
 /**
-@[  for x in constant.get_annotation_values('verbatim')]@
-@[    if x['language'] == 'comment']@
-  * @(x['text'])
-@[    end if]@
+@[  for line in comments]@
+  * @(line)
 @[  end for]@
  */
 @[end if]@
@@ -139,22 +138,19 @@ enum
 
 @#<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 /// Struct defined in @(interface_path_to_string(interface_path)) in the package @(package_name).
-@[if message.structure.annotations]@
+@{comments = message.structure.get_comment_lines()}@
+@[if comments]@
 /**
-@[  for x in message.structure.get_annotation_values('verbatim')]@
-@[    if x['language'] == 'comment']@
-  * @(x['text'])
-@[    end if]@
+@[  for line in comments]@
+  * @(line)
 @[  end for]@
  */
 @[end if]@
 typedef struct @(idl_structure_type_to_c_typename(message.structure.namespaced_type))
 {
 @[for member in message.structure.members]@
-@[  for x in member.get_annotation_values('verbatim')]@
-@[    if x['language'] == 'comment']@
-  /// @(x['text'])
-@[    end if]@
+@[  for line in member.get_comment_lines()]@
+  /// @(line)
 @[  end for]@
   @(idl_declaration_to_c(member.type, member.name));
 @[end for]@

--- a/rosidl_generator_c/resource/msg__struct.h.em
+++ b/rosidl_generator_c/resource/msg__struct.h.em
@@ -56,6 +56,15 @@ for member in message.structure.members:
 @[for constant in message.constants]@
 
 /// Constant '@(constant.name)'.
+@[if constant.annotations]@
+/**
+@[  for x in constant.get_annotation_values('verbatim')]@
+@[    if x['language'] == 'comment']@
+  * @(x['text'])
+@[    end if]@
+@[  end for]@
+ */
+@[end if]@
 @[    if isinstance(constant.type, BasicType)]@
 @[        if constant.type.typename in (
                 *INTEGER_TYPES, *CHARACTER_TYPES, OCTET_TYPE
@@ -129,10 +138,24 @@ enum
 @#>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 @#<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-// Struct defined in @(interface_path_to_string(interface_path)) in the package @(package_name).
+/// Struct defined in @(interface_path_to_string(interface_path)) in the package @(package_name).
+@[if message.structure.annotations]@
+/**
+@[  for x in message.structure.get_annotation_values('verbatim')]@
+@[    if x['language'] == 'comment']@
+  * @(x['text'])
+@[    end if]@
+@[  end for]@
+ */
+@[end if]@
 typedef struct @(idl_structure_type_to_c_typename(message.structure.namespaced_type))
 {
 @[for member in message.structure.members]@
+@[  for x in member.get_annotation_values('verbatim')]@
+@[    if x['language'] == 'comment']@
+  /// @(x['text'])
+@[    end if]@
+@[  end for]@
   @(idl_declaration_to_c(member.type, member.name));
 @[end for]@
 } @(idl_structure_type_to_c_typename(message.structure.namespaced_type));

--- a/rosidl_parser/rosidl_parser/definition.py
+++ b/rosidl_parser/rosidl_parser/definition.py
@@ -436,6 +436,22 @@ class Annotatable:
         """
         return [a.value for a in self.annotations if a.name == name]
 
+    def get_comment_lines(self):
+        """
+        Get the comment lines of the annotatable.
+
+        :param str name: the name of the annotation type
+        :returns: a list of comment lines
+        """
+        comments = [
+            x['text'] for x in self.get_annotation_values('verbatim') if
+            'language' in x and 'text' in x and x['language'] == 'comment'
+        ]
+        lines = []
+        for comment in comments:
+            lines.extend(comment.split('\n'))
+        return lines
+
     def has_annotation(self, name):
         """
         Check if there is exactly one annotation of a specific type.

--- a/rosidl_parser/rosidl_parser/definition.py
+++ b/rosidl_parser/rosidl_parser/definition.py
@@ -440,7 +440,6 @@ class Annotatable:
         """
         Get the comment lines of the annotatable.
 
-        :param str name: the name of the annotation type
         :returns: a list of comment lines
         """
         comments = [

--- a/rosidl_parser/rosidl_parser/definition.py
+++ b/rosidl_parser/rosidl_parser/definition.py
@@ -448,7 +448,7 @@ class Annotatable:
         ]
         lines = []
         for comment in comments:
-            lines.extend(comment.split('\n'))
+            lines.extend(comment.splitlines())
         return lines
 
     def has_annotation(self, name):


### PR DESCRIPTION
This PR does a bit more of what the title says, as I ended up fixing some old bugs.
I can create individual PRs for those if desired, but I'm creating only one now so there's more context.

* Generate documentation based on comments in ROS interface files.
  * This followed the current "parsing rules" in rosidl_adapter:
    ```
    # The top level comment is associated with the structure of the message.
    # The top level comment ends after the first new line.
    #
    # This is still part of the top level comment.
    
    # This comment is documentation for field1.

    # This is also documentation for field1.
    float field1;  # This is documentation for field1 as well.
    ```
    We might want to review those rules.
  * Done in commits: https://github.com/ros2/rosidl/commit/faa7c03b7ee291d3eecef4674d870856ccc7e67b, https://github.com/ros2/rosidl/commit/9b9d091f7746eaf3e4b5bada1e2bfca76cc9f3ea, https://github.com/ros2/rosidl/commit/ee86652d617940a57f47e7c1d440b3cb398dcbaf.
* Improve comment parsing in ROS interfaces:
  * Ignore multiple `#`.
  * Dedent comments.
  * Done in: https://github.com/ros2/rosidl/commit/3138141d36e0734dc50619c7cbe9714041c6c8b7, https://github.com/ros2/rosidl/commit/fd6de7a55a4152119c5febe2df354c47b1ca03da, https://github.com/ros2/rosidl/commit/b8360eeca11266ed569d8395748b79b860ac63c2.
* We weren't parsing escape sequences correctly in .idl files string literals.
  * Fixed in commit: https://github.com/ros2/rosidl/commit/7eb60df1308423381913ba05ea7481e9596299f6.
* rosidl_adapter was generating array default values that couldn't be correctly processed (the previous bug was hiding that).
  * The fact that we're using [ast.literal_eval](https://github.com/ros2/rosidl/blob/608761cd1bcf6f01e4d25f8fcc9745f1ea41d0b0/rosidl_generator_c/resource/msg__functions.c.em#L3) is extremely strange. I'm not sure what's the standard IDL way of specifying arrays defaults, it doesn't seem to be specified AFAIS.
  * Repeating that code in all generators also seems wrong, [Member](https://github.com/ros2/rosidl/blob/608761cd1bcf6f01e4d25f8fcc9745f1ea41d0b0/rosidl_parser/rosidl_parser/definition.py#L460) could use a `get_default_value`/`has_default_value` methods.
    I haven't addressed that here.
  * Fixed in https://github.com/ros2/rosidl/commit/daf38331f64b68001c392a0eb0c45b94b1864edd.
* We weren't passing ROS interface comments in constants to IDL, and also our IDL parser didn't support annotations in constants. Fixed in https://github.com/ros2/rosidl/commit/9bbd1ec3e384238a8fcb5cf8c053fdb363ab4d16.