### PR TITLE
[rosidl_adapter] Ignore multiple `#` characters and dedent comments

### DIFF
--- a/rosidl_adapter/rosidl_adapter/parser.py
+++ b/rosidl_adapter/rosidl_adapter/parser.py
@@ -581,8 +581,9 @@ def process_comments(instance):
                 length -= 1
                 continue
             i += 1
-        text = '\n'.join(lines)
-        instance.annotations['comment'] = textwrap.dedent(text).split('\n')
+        if lines:
+            text = '\n'.join(lines)
+            instance.annotations['comment'] = textwrap.dedent(text).split('\n')
 
 
 def parse_value_string(type_, value_string):

--- a/rosidl_adapter/rosidl_adapter/parser.py
+++ b/rosidl_adapter/rosidl_adapter/parser.py
@@ -15,6 +15,7 @@
 import os
 import re
 import sys
+import textwrap
 
 PACKAGE_NAME_MESSAGE_TYPE_SEPARATOR = '/'
 COMMENT_DELIMITER = '#'
@@ -472,7 +473,7 @@ def parse_message_string(pkg_name, msg_name, message_string):
 
         # file-level comment line
         if index == 0 and not file_level_ended:
-            message_comments.append(line[len(COMMENT_DELIMITER):])
+            message_comments.append(line.lstrip(COMMENT_DELIMITER))
             continue
 
         file_level_ended = True
@@ -480,7 +481,7 @@ def parse_message_string(pkg_name, msg_name, message_string):
         # comment
         comment = None
         if index >= 0:
-            comment = line[index + len(COMMENT_DELIMITER):]
+            comment = line[index:].lstrip(COMMENT_DELIMITER)
             line = line[:index]
 
         if comment is not None:
@@ -580,6 +581,8 @@ def process_comments(instance):
                 length -= 1
                 continue
             i += 1
+        text = '\n'.join(lines)
+        instance.annotations['comment'] = textwrap.dedent(text).split('\n')
 
 
 def parse_value_string(type_, value_string):

--- a/rosidl_adapter/test/data/action/Test.expected.idl
+++ b/rosidl_adapter/test/data/action/Test.expected.idl
@@ -6,7 +6,7 @@
 module test_msgs {
   module action {
     @verbatim (language="comment", text=
-      " goal definition")
+      "goal definition")
     struct Test_Goal {
       boolean bool_value;
 
@@ -38,12 +38,12 @@ module test_msgs {
     };
     struct Test_Result {
       @verbatim (language="comment", text=
-        " result definition")
+        "result definition")
       boolean ok;
     };
     struct Test_Feedback {
       @verbatim (language="comment", text=
-        " feedback definition")
+        "feedback definition")
       sequence<int32> sequence;
     };
   };

--- a/rosidl_adapter/test/test_extract_message_comments.py
+++ b/rosidl_adapter/test/test_extract_message_comments.py
@@ -21,9 +21,9 @@ def test_extract_message_comments():
     assert len(msg_spec.annotations) == 1
     assert 'comment' in msg_spec.annotations
     assert len(msg_spec.annotations['comment']) == 3
-    assert msg_spec.annotations['comment'][0] == ' comment 1'
+    assert msg_spec.annotations['comment'][0] == 'comment 1'
     assert msg_spec.annotations['comment'][1] == ''
-    assert msg_spec.annotations['comment'][2] == ' comment 2'
+    assert msg_spec.annotations['comment'][2] == 'comment 2'
 
     assert len(msg_spec.fields) == 1
     assert len(msg_spec.fields[0].annotations) == 1
@@ -35,13 +35,13 @@ def test_extract_message_comments():
     assert len(msg_spec.annotations) == 1
     assert 'comment' in msg_spec.annotations
     assert len(msg_spec.annotations['comment']) == 1
-    assert msg_spec.annotations['comment'] == [' comment 1']
+    assert msg_spec.annotations['comment'] == ['comment 1']
 
     assert len(msg_spec.fields) == 1
     assert len(msg_spec.fields[0].annotations) == 1
     assert 'comment' in msg_spec.fields[0].annotations
     assert len(msg_spec.fields[0].annotations['comment']) == 1
-    assert msg_spec.fields[0].annotations['comment'][0] == ' comment 2'
+    assert msg_spec.fields[0].annotations['comment'][0] == 'comment 2'
 
     # file-level comment, trailing and indented field-level comment
     msg_spec = parse_message_string(
@@ -49,14 +49,14 @@ def test_extract_message_comments():
     assert len(msg_spec.annotations) == 1
     assert 'comment' in msg_spec.annotations
     assert len(msg_spec.annotations['comment']) == 1
-    assert msg_spec.annotations['comment'] == [' comment 1']
+    assert msg_spec.annotations['comment'] == ['comment 1']
 
     assert len(msg_spec.fields) == 2
     assert len(msg_spec.fields[0].annotations) == 1
     assert 'comment' in msg_spec.fields[0].annotations
     assert len(msg_spec.fields[0].annotations['comment']) == 2
-    assert msg_spec.fields[0].annotations['comment'][0] == ' comment 2'
-    assert msg_spec.fields[0].annotations['comment'][1] == ' comment 3'
+    assert msg_spec.fields[0].annotations['comment'][0] == 'comment 2'
+    assert msg_spec.fields[0].annotations['comment'][1] == 'comment 3'
 
     assert len(msg_spec.fields[1].annotations) == 1
     assert 'comment' in msg_spec.fields[1].annotations
@@ -73,12 +73,12 @@ def test_extract_message_comments():
     assert len(msg_spec.fields[0].annotations) == 1
     assert 'comment' in msg_spec.fields[0].annotations
     assert len(msg_spec.fields[0].annotations['comment']) == 1
-    assert msg_spec.fields[0].annotations['comment'][0] == ' comment 2'
+    assert msg_spec.fields[0].annotations['comment'][0] == 'comment 2'
 
     assert len(msg_spec.fields[1].annotations) == 1
     assert 'comment' in msg_spec.fields[1].annotations
     assert len(msg_spec.fields[1].annotations['comment']) == 1
-    assert msg_spec.fields[1].annotations['comment'][0] == ' comment 3'
+    assert msg_spec.fields[1].annotations['comment'][0] == 'comment 3'
 
     # field-level comment with a unit
     msg_spec = parse_message_string(
@@ -88,7 +88,7 @@ def test_extract_message_comments():
     assert len(msg_spec.fields[0].annotations) == 2
     assert 'comment' in msg_spec.fields[0].annotations
     assert len(msg_spec.fields[0].annotations['comment']) == 1
-    assert msg_spec.fields[0].annotations['comment'][0] == ' comment'
+    assert msg_spec.fields[0].annotations['comment'][0] == 'comment'
 
     assert 'unit' in msg_spec.fields[0].annotations
     assert msg_spec.fields[0].annotations['unit'] == 'unit'


### PR DESCRIPTION
Extracted from https://github.com/ros2/rosidl/pull/593, as I want to narrow the scope of that PR.