### PR TITLE
Fix escaping in string literals

### DIFF
--- a/rosidl_adapter/rosidl_adapter/msg/__init__.py
+++ b/rosidl_adapter/rosidl_adapter/msg/__init__.py
@@ -61,10 +61,8 @@ MSG_TYPE_TO_IDL = {
 
 def to_idl_literal(idl_type, value):
     if idl_type[-1] == ']' or idl_type.startswith('sequence<'):
-        elements = [repr(v) for v in value]
-        while len(elements) < 2:
-            elements.append('')
-        return '"(%s)"' % ', '.join(e.replace('"', r'\"') for e in elements)
+        content = repr(tuple(value)).replace('\\', r'\\').replace('"', r'\"')
+        return f'"{content}"'
 
     if 'boolean' == idl_type:
         return 'TRUE' if value else 'FALSE'

--- a/rosidl_parser/rosidl_parser/parser.py
+++ b/rosidl_parser/rosidl_parser/parser.py
@@ -643,14 +643,14 @@ def _get_escape_sequences_regex(*, allow_unicode):
     pattern = '('
     # newline, horizontal tab, vertical tab, backspace, carriage return,
     # form feed, alert, backslash, question mark, single quote, double quote
-    pattern += '\\[ntvbrfa\\?\'"]'
+    pattern += r'\\[ntvbrfa\\?\'"]'
     # octal number
-    pattern += '|' + '\\[0-7]{1,3}'
+    pattern += '|' + r'\\[0-7]{1,3}'
     # hexadecimal number
-    pattern += '|' + r'\\x.{1,2}'
+    pattern += '|' + r'\\x[0-9a-fA-F]{1,2}'
     if allow_unicode:
         # unicode character
-        pattern += '|' + '\\u.{1,4}'
+        pattern += '|' + r'\\u[0-9a-fA-F]{1,4}'
     pattern += ')'
 
     return re.compile(pattern)


### PR DESCRIPTION
* rosidl_parser: Fix regex matching escape sequences.
* rosidl_adapter: Generate default values with correct escape sequences.

Extracted from https://github.com/ros2/rosidl/pull/593.