### PR TITLE
Update function prefix

### DIFF
--- a/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
+++ b/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
@@ -27,7 +27,7 @@ header_files = [
     include_base + '__struct.h',
 ]
 
-function_prefix = message.structure.namespaced_type.name + '__rosidl_typesupport_introspection_c'
+function_prefix = '__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]) + '__rosidl_typesupport_introspection_c'
 }@
 @[for header_file in header_files]@
 @[    if header_file in include_directives]@


### PR DESCRIPTION
I have found that this template will generate objects with same name if two packages have a .msg named equal.

This generate symbols named equal and in some cases, the linker will complain about this duplication.

In order to solve it, I propose to append also the package name that is guaranteed to be unique.