### PR TITLE
Add missing f for format string

### DIFF
--- a/rosidl_cli/rosidl_cli/entry_points.py
+++ b/rosidl_cli/rosidl_cli/entry_points.py
@@ -42,7 +42,7 @@ def get_entry_points(group_name, *, specs=None, strict=False):
             continue
         if name in entry_points:
             msg = (f"Found duplicate entry point '{name}': "
-                   'got {entry_point} and {entry_points[name]}')
+                   f'got {entry_point} and {entry_points[name]}')
             if strict:
                 raise RuntimeError(msg)
             logger.warning(msg)


### PR DESCRIPTION
I noticed this while debugging a windows debug test failure.

Without this PR

```
25: E                   RuntimeError: Found duplicate entry point 'py': got {entry_point} and {entry_points[name]}
```

With this PR

```
25: E                   RuntimeError: Found duplicate entry point 'py': got EntryPoint(name='py', value='rosidl_generator_py.cli:GeneratePython', group='rosidl_cli.command.generate.type_extensions') and EntryPoint(name='py', value='rosidl_generator_py.cli:GeneratePython', group='rosidl_cli.command.generate.type_extensions')
```