### PR TITLE
Add rosidl_get_typesupport_target and deprecate rosidl_target_interfaces

### DIFF
--- a/rosidl_cmake/cmake/rosidl_get_typesupport_target.cmake
+++ b/rosidl_cmake/cmake/rosidl_get_typesupport_target.cmake
@@ -27,7 +27,7 @@
 function(rosidl_get_typesupport_target var generate_interfaces_target typesupport_name)
   if(NOT TARGET ${generate_interfaces_target})
     message(FATAL_ERROR
-      "${generate_interfaces_target} is not a CMake target - maybe rosidl_generate_interfaces wasn't called or was given a different target name?")
+      "${generate_interfaces_target} is not a CMake target. Maybe rosidl_generate_interfaces was given a different target name?")
   endif()
 
   set(output_target "${generate_interfaces_target}__${typesupport_name}")

--- a/rosidl_cmake/cmake/rosidl_get_typesupport_target.cmake
+++ b/rosidl_cmake/cmake/rosidl_get_typesupport_target.cmake
@@ -1,0 +1,41 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Get the name of a Typesupport target so it can be used to depend on
+# generated messages in the same package that generated them.
+#
+# :param var: A name of a variable to store the typesupport target name
+# :param generate_interfaces_target: the target name passed to
+#   rosidl_generate_interfaces
+# :type generate_interfaces_target: string
+# :param typesupport_name: the package name of the type support
+# :type typesupport_name: string
+#
+# @public
+#
+function(rosidl_get_typesupport_target var generate_interfaces_target typesupport_name)
+  if(NOT TARGET ${generate_interfaces_target})
+    message(FATAL_ERROR
+      "${generate_interfaces_target} is not a CMake target - maybe rosidl_generate_interfaces wasn't called or was given a different target name?")
+  endif()
+
+  set(output_target "${generate_interfaces_target}__${typesupport_name}")
+
+  if(NOT TARGET ${output_target})
+    message(FATAL_ERROR "${output_target} is not a CMake target - maybe the typesupport '${typesupport_name}' doesn't exist?")
+  endif()
+
+  set("${var}" "${output_target}" PARENT_SCOPE)
+endfunction()
+

--- a/rosidl_cmake/cmake/rosidl_get_typesupport_target.cmake
+++ b/rosidl_cmake/cmake/rosidl_get_typesupport_target.cmake
@@ -38,4 +38,3 @@ function(rosidl_get_typesupport_target var generate_interfaces_target typesuppor
 
   set("${var}" "${output_target}" PARENT_SCOPE)
 endfunction()
-

--- a/rosidl_cmake/cmake/rosidl_target_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_target_interfaces.cmake
@@ -29,6 +29,7 @@
 # @public
 #
 function(rosidl_target_interfaces target interface_target typesupport_name)
+  message(DEPRECATION "Use rosidl_get_typesupport_target() and target_link_libraries() instead of rosidl_target_interfaces()")
   if(ARGN)
     message(FATAL_ERROR
       "rosidl_target_interfaces() called with unused arguments: ${ARGN}")

--- a/rosidl_cmake/rosidl_cmake-extras.cmake
+++ b/rosidl_cmake/rosidl_cmake-extras.cmake
@@ -30,6 +30,7 @@ endmacro()
 find_package(rosidl_adapter)  # not required, being used when available
 
 include("${rosidl_cmake_DIR}/rosidl_generate_interfaces.cmake")
+include("${rosidl_cmake_DIR}/rosidl_get_typesupport_target.cmake")
 include("${rosidl_cmake_DIR}/rosidl_target_interfaces.cmake")
 include("${rosidl_cmake_DIR}/rosidl_write_generator_arguments.cmake")
 include("${rosidl_cmake_DIR}/string_camel_case_to_lower_case_underscore.cmake")


### PR DESCRIPTION
This adds `rosidl_get_typesupport_target()` which returns the name of a typesupport target. This can be used in a `target_link_libraries()` call to make a target depend on generated code for interfaces generated in the same CMake project.

This PR also deprecates `rosidl_target_interfaces()` which inconveniently wraps `target_link_libraries()` and has what appears to be extra unnecessary `add_dependencies()` and `target_include_directories()` calls.

Adding `rosidl_get_typesupport_target()` is in support of ros2/python_cmake_module#6 , specifically replacing a good bit of `FindPythonExtra` with `Python3_add_library()`. `Python3_add_library()` calls `target_link_libraries()` internally on the given target with a Keyword argument, but that conflicts with `rosidl_target_interfaces()` which uses the non-keyword version of `target_link_libraries()` internally. CMake won't allow those two styles to mix on the same target (without using the `OLD` policy of [CMP0023](https://cmake.org/cmake/help/latest/policy/CMP0023.html)). This PR allows more control over which version of `target_link_libraries()` is used, and that should allow `rosidl_generator_py` to use `Python3_add_library()`