### PR TITLE
Relocate to_yaml() under message namespace.

### DIFF
--- a/rosidl_generator_cpp/resource/msg__traits.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__traits.hpp.em
@@ -12,6 +12,7 @@ from rosidl_parser.definition import NamespacedType
 from rosidl_parser.definition import AbstractSequence
 from rosidl_parser.definition import UnboundedSequence
 
+message_namespace = '::'.join(message.structure.namespaced_type.namespaces)
 message_typename = '::'.join(message.structure.namespaced_type.namespaced_name())
 message_fully_qualified_name = '/'.join(message.structure.namespaced_type.namespaced_name())
 }@
@@ -60,11 +61,13 @@ for member in message.structure.members:
 @[end if]@
 @#>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 @
-namespace rosidl_generator_traits
+@[for ns in message.structure.namespaced_type.namespaces]@
+namespace @(ns)
 {
 
+@[end for]@
 inline void to_yaml(
-  const @(message_typename) & msg,
+  const @(message.structure.namespaced_type.name) & msg,
   std::ostream & out, size_t indentation = 0)
 {
 @[if len(message.structure.members) == 1 and message.structure.members[0].name == EMPTY_STRUCTURE_REQUIRED_MEMBER_NAME]@
@@ -84,14 +87,14 @@ inline void to_yaml(
 @[    if isinstance(member.type, BasicType)]@
     out << "@(member.name): ";
 @[      if member.type.typename in ('octet', 'char', 'wchar')]@
-    character_value_to_yaml(msg.@(member.name), out);
+    rosidl_generator_traits::character_value_to_yaml(msg.@(member.name), out);
 @[      else]@
-    value_to_yaml(msg.@(member.name), out);
+    rosidl_generator_traits::value_to_yaml(msg.@(member.name), out);
 @[      end if]@
     out << "\n";
 @[    elif isinstance(member.type, AbstractGenericString)]@
     out << "@(member.name): ";
-    value_to_yaml(msg.@(member.name), out);
+    rosidl_generator_traits::value_to_yaml(msg.@(member.name), out);
     out << "\n";
 @[    elif isinstance(member.type, NamespacedType)]@
     out << "@(member.name):\n";
@@ -108,14 +111,14 @@ inline void to_yaml(
 @[      if isinstance(member.type.value_type, BasicType)]@
         out << "- ";
 @[        if member.type.value_type.typename in ('octet', 'char', 'wchar')]@
-        character_value_to_yaml(item, out);
+        rosidl_generator_traits::character_value_to_yaml(item, out);
 @[        else]@
-        value_to_yaml(item, out);
+        rosidl_generator_traits::value_to_yaml(item, out);
 @[        end if]@
         out << "\n";
 @[      elif isinstance(member.type.value_type, AbstractGenericString)]@
         out << "- ";
-        value_to_yaml(item, out);
+        rosidl_generator_traits::value_to_yaml(item, out);
         out << "\n";
 @[      elif isinstance(member.type.value_type, NamespacedType)]@
         out << "-\n";
@@ -129,11 +132,32 @@ inline void to_yaml(
 @[end if]@
 }  // NOLINT(readability/fn_size)
 
-inline std::string to_yaml(const @(message_typename) & msg)
+inline std::string to_yaml(const @(message.structure.namespaced_type.name) & msg)
 {
   std::ostringstream out;
   to_yaml(msg, out);
   return out.str();
+}
+@[for ns in reversed(message.structure.namespaced_type.namespaces)]@
+
+}  // namespace @(ns)
+@[end for]@
+
+namespace rosidl_generator_traits
+{
+
+[[deprecated("use @(message_namespace)::to_yaml() instead")]]
+inline void to_yaml(
+  const @(message_typename) & msg,
+  std::ostream & out, size_t indentation = 0)
+{
+  @(message_namespace)::to_yaml(msg, out, indentation);
+}
+
+[[deprecated("use @(message_namespace)::to_yaml() instead")]]
+inline std::string to_yaml(const @(message_typename) & msg)
+{
+  return @(message_namespace)::to_yaml(msg);
 }
 
 template<>

--- a/rosidl_generator_cpp/test/test_traits.cpp
+++ b/rosidl_generator_cpp/test/test_traits.cpp
@@ -30,7 +30,7 @@ using rosidl_generator_traits::is_message;
 using rosidl_generator_traits::is_service;
 using rosidl_generator_traits::is_service_request;
 using rosidl_generator_traits::is_service_response;
-using rosidl_generator_traits::to_yaml;
+using rosidl_generator_cpp::msg::to_yaml;
 
 TEST(Test_rosidl_generator_traits, to_yaml) {
   {


### PR DESCRIPTION
Closes #607. This enables [argument dependent lookup](https://en.cppreference.com/w/cpp/language/adl). `to_yaml()` overloads under the `rosidl_generator_traits` namespace were kept but deprecated. 

CI up to `rosidl_generator_cpp` (to start with):

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=14972)](http://ci.ros2.org/job/ci_linux/14972/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=9713)](http://ci.ros2.org/job/ci_linux-aarch64/9713/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=12652)](http://ci.ros2.org/job/ci_osx/12652/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=15136)](http://ci.ros2.org/job/ci_windows/15136/)
