### PR TITLE
Revert "Bundle and ensure the exportation of rosidl generated targets (#601)"

### DIFF
--- a/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
@@ -220,12 +220,6 @@ macro(rosidl_generate_interfaces target)
   )
 
   if(NOT _ARG_SKIP_INSTALL)
-    # Ensure exported targets are imported before first use in downstream packages.
-    # This hook registers the ament_export_targets() extension, which populates
-    # ${PROJECT_NAME}_CONFIG_EXTRAS upon ament_package() invocation. It is crucial
-    # that ament_export_targets() configuration extras are found and included before
-    # any other configuration extras that make use of imported targets.
-    _ament_cmake_export_targets_register_package_hook()
     if(NOT _ARG_SKIP_GROUP_MEMBERSHIP_CHECK)
       set(_group_name "rosidl_interface_packages")
       if(NOT _AMENT_PACKAGE_NAME)
@@ -307,7 +301,6 @@ macro(rosidl_generate_interfaces target)
   endif()
 
   if(NOT _ARG_SKIP_INSTALL)
-    ament_export_targets(${rosidl_generate_interfaces_TARGET})
     foreach(_idl_tuple ${_idl_tuples})
       string(REGEX REPLACE ":([^:]*)$" ";\\1" _idl_list "${_idl_tuple}")
       list(GET _idl_list 1 _idl_relpath)

--- a/rosidl_generator_c/cmake/rosidl_generator_c_generate_interfaces.cmake
+++ b/rosidl_generator_c/cmake/rosidl_generator_c_generate_interfaces.cmake
@@ -152,9 +152,10 @@ if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
     )
   endif()
   ament_export_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix})
+  ament_export_targets(${rosidl_generate_interfaces_TARGET}${_target_suffix})
   install(
     TARGETS ${rosidl_generate_interfaces_TARGET}${_target_suffix}
-    EXPORT ${rosidl_generate_interfaces_TARGET}
+    EXPORT ${rosidl_generate_interfaces_TARGET}${_target_suffix}
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin

--- a/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_interfaces.cmake
+++ b/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_interfaces.cmake
@@ -126,8 +126,9 @@ if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
 
   install(
     TARGETS ${rosidl_generate_interfaces_TARGET}${_target_suffix}
-    EXPORT ${rosidl_generate_interfaces_TARGET}
+    EXPORT ${rosidl_generate_interfaces_TARGET}${_target_suffix}
   )
+  ament_export_targets(${rosidl_generate_interfaces_TARGET}${_target_suffix})
 endif()
 
 if(BUILD_TESTING AND rosidl_generate_interfaces_ADD_LINTER_TESTS)

--- a/rosidl_typesupport_introspection_c/cmake/rosidl_typesupport_introspection_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_introspection_c/cmake/rosidl_typesupport_introspection_c_generate_interfaces.cmake
@@ -142,13 +142,14 @@ if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
   endif()
   install(
     TARGETS ${rosidl_generate_interfaces_TARGET}${_target_suffix}
-    EXPORT ${rosidl_generate_interfaces_TARGET}
+    EXPORT ${rosidl_generate_interfaces_TARGET}${_target_suffix}
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin
   )
   rosidl_export_typesupport_targets(${_target_suffix}
     ${rosidl_generate_interfaces_TARGET}${_target_suffix})
+  ament_export_targets(${rosidl_generate_interfaces_TARGET}${_target_suffix})
 endif()
 
 if(BUILD_TESTING AND rosidl_generate_interfaces_ADD_LINTER_TESTS)

--- a/rosidl_typesupport_introspection_cpp/cmake/rosidl_typesupport_introspection_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_introspection_cpp/cmake/rosidl_typesupport_introspection_cpp_generate_interfaces.cmake
@@ -99,9 +99,10 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     COMPILE_OPTIONS -Wall -Wextra -Wpedantic
   )
 endif()
-target_link_libraries(
-  ${rosidl_generate_interfaces_TARGET}${_target_suffix}
-  ${rosidl_generate_interfaces_TARGET}__rosidl_generator_cpp)
+target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+  PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp>"
+)
 ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   "rosidl_runtime_c"
   "rosidl_typesupport_interface"
@@ -134,13 +135,14 @@ if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
   endif()
   install(
     TARGETS ${rosidl_generate_interfaces_TARGET}${_target_suffix}
-    EXPORT ${rosidl_generate_interfaces_TARGET}
+    EXPORT ${rosidl_generate_interfaces_TARGET}${_target_suffix}
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin
   )
   rosidl_export_typesupport_targets(${_target_suffix}
     ${rosidl_generate_interfaces_TARGET}${_target_suffix})
+  ament_export_targets(${rosidl_generate_interfaces_TARGET}${_target_suffix})
 endif()
 
 if(BUILD_TESTING AND rosidl_generate_interfaces_ADD_LINTER_TESTS)


### PR DESCRIPTION
Precisely what the title says. This patch rolls back #601. While it doesn't affect downstream builds per se, it does go down a path that is incompatible with how ROS 2 binaries are built.
