### PR TITLE
Revert "Make rosidl packages use FindPython3 instead of FindPythonInterp (#612)"

### DIFF
--- a/rosidl_adapter/CMakeLists.txt
+++ b/rosidl_adapter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.5)
 
 project(rosidl_adapter NONE)
 

--- a/rosidl_adapter/cmake/rosidl_adapt_interfaces.cmake
+++ b/rosidl_adapter/cmake/rosidl_adapt_interfaces.cmake
@@ -37,13 +37,14 @@ function(rosidl_adapt_interfaces idl_var arguments_file)
       "arguments: ${ARG_UNPARSED_ARGUMENTS}")
   endif()
 
-  find_package(ament_cmake_core REQUIRED)  # for get_executable_path
-  find_package(Python3 REQUIRED COMPONENTS Interpreter)
-  get_executable_path(python_interpreter Python3::Interpreter CONFIGURE)
+  find_package(PythonInterp REQUIRED)
+  if(NOT PYTHON_EXECUTABLE)
+    message(FATAL_ERROR "Variable 'PYTHON_EXECUTABLE' must not be empty")
+  endif()
 
   set(idl_output "${CMAKE_CURRENT_BINARY_DIR}/rosidl_adapter/${ARG_TARGET}.idls")
   set(cmd
-    "${python_interpreter}" -m rosidl_adapter
+    "${PYTHON_EXECUTABLE}" -m rosidl_adapter
     --package-name ${PROJECT_NAME}
     --arguments-file "${arguments_file}"
     --output-dir "${CMAKE_CURRENT_BINARY_DIR}/rosidl_adapter/${PROJECT_NAME}"

--- a/rosidl_adapter/package.xml
+++ b/rosidl_adapter/package.xml
@@ -11,9 +11,6 @@
   <license>Apache License 2.0</license>
   <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
-  <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
-  <buildtool_export_depend>python3</buildtool_export_depend>
-
   <build_depend>ament_cmake</build_depend>
 
   <exec_depend>python3-empy</exec_depend>

--- a/rosidl_generator_c/CMakeLists.txt
+++ b/rosidl_generator_c/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.5)
 
 project(rosidl_generator_c C)
 

--- a/rosidl_generator_c/cmake/rosidl_generator_c_generate_interfaces.cmake
+++ b/rosidl_generator_c/cmake/rosidl_generator_c_generate_interfaces.cmake
@@ -79,12 +79,9 @@ rosidl_write_generator_arguments(
   TARGET_DEPENDENCIES ${target_dependencies}
 )
 
-find_package(Python3 REQUIRED COMPONENTS Interpreter)
-
 add_custom_command(
   OUTPUT ${_generated_headers} ${_generated_sources}
-  COMMAND Python3::Interpreter
-  ARGS ${rosidl_generator_c_BIN}
+  COMMAND ${PYTHON_EXECUTABLE} ${rosidl_generator_c_BIN}
   --generator-arguments-file "${generator_arguments_file}"
   DEPENDS ${target_dependencies}
   COMMENT "Generating C code for ROS interfaces"

--- a/rosidl_generator_c/package.xml
+++ b/rosidl_generator_c/package.xml
@@ -14,7 +14,6 @@
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
-  <buildtool_export_depend>python3</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
 
   <build_export_depend>rosidl_typesupport_interface</build_export_depend>

--- a/rosidl_generator_cpp/CMakeLists.txt
+++ b/rosidl_generator_cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.5)
 
 project(rosidl_generator_cpp)
 

--- a/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_interfaces.cmake
+++ b/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_interfaces.cmake
@@ -74,12 +74,9 @@ rosidl_write_generator_arguments(
   TARGET_DEPENDENCIES ${target_dependencies}
 )
 
-find_package(Python3 REQUIRED COMPONENTS Interpreter)
-
 add_custom_command(
   OUTPUT ${_generated_headers}
-  COMMAND Python3::Interpreter
-  ARGS ${rosidl_generator_cpp_BIN}
+  COMMAND ${PYTHON_EXECUTABLE} ${rosidl_generator_cpp_BIN}
   --generator-arguments-file "${generator_arguments_file}"
   DEPENDS ${target_dependencies}
   COMMENT "Generating C++ code for ROS interfaces"

--- a/rosidl_generator_cpp/package.xml
+++ b/rosidl_generator_cpp/package.xml
@@ -12,7 +12,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
-  <buildtool_export_depend>python3</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
 
   <!-- This is needed for the rosidl_message_type_support_t struct and visibility macros -->

--- a/rosidl_typesupport_introspection_c/CMakeLists.txt
+++ b/rosidl_typesupport_introspection_c/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.5)
 
 project(rosidl_typesupport_introspection_c C)
 

--- a/rosidl_typesupport_introspection_c/cmake/rosidl_typesupport_introspection_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_introspection_c/cmake/rosidl_typesupport_introspection_c_generate_interfaces.cmake
@@ -72,12 +72,9 @@ rosidl_write_generator_arguments(
   TARGET_DEPENDENCIES ${target_dependencies}
 )
 
-find_package(Python3 REQUIRED COMPONENTS Interpreter)
-
 add_custom_command(
   OUTPUT ${_generated_header_files} ${_generated_source_files}
-  COMMAND Python3::Interpreter
-  ARGS ${rosidl_typesupport_introspection_c_BIN}
+  COMMAND ${PYTHON_EXECUTABLE} ${rosidl_typesupport_introspection_c_BIN}
   --generator-arguments-file "${generator_arguments_file}"
   DEPENDS ${target_dependencies}
   COMMENT "Generating C introspection for ROS interfaces"

--- a/rosidl_typesupport_introspection_c/package.xml
+++ b/rosidl_typesupport_introspection_c/package.xml
@@ -14,7 +14,6 @@
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
-  <buildtool_export_depend>python3</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
 
   <build_export_depend>rosidl_runtime_c</build_export_depend>

--- a/rosidl_typesupport_introspection_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_introspection_cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.5)
 
 project(rosidl_typesupport_introspection_cpp)
 

--- a/rosidl_typesupport_introspection_cpp/cmake/rosidl_typesupport_introspection_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_introspection_cpp/cmake/rosidl_typesupport_introspection_cpp_generate_interfaces.cmake
@@ -72,12 +72,9 @@ rosidl_write_generator_arguments(
   TARGET_DEPENDENCIES ${target_dependencies}
 )
 
-find_package(Python3 REQUIRED COMPONENTS Interpreter)
-
 add_custom_command(
   OUTPUT ${_generated_header_files} ${_generated_source_files}
-  COMMAND Python3::Interpreter
-  ARGS ${rosidl_typesupport_introspection_cpp_BIN}
+  COMMAND ${PYTHON_EXECUTABLE} ${rosidl_typesupport_introspection_cpp_BIN}
   --generator-arguments-file "${generator_arguments_file}"
   DEPENDS ${target_dependencies}
   COMMENT "Generating C++ introspection for ROS interfaces"

--- a/rosidl_typesupport_introspection_cpp/package.xml
+++ b/rosidl_typesupport_introspection_cpp/package.xml
@@ -14,7 +14,6 @@
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
-  <buildtool_export_depend>python3</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
 
   <build_export_depend>rosidl_runtime_c</build_export_depend>


### PR DESCRIPTION
This reverts commit 36ed120f43daeaab31fd9ba2bf8dfb58db05091d.