### PR TITLE
Fix up the documentation for rosidl_typesupport_introspection_cpp

### DIFF
--- a/rosidl_typesupport_introspection_cpp/Doxyfile
+++ b/rosidl_typesupport_introspection_cpp/Doxyfile
@@ -1,0 +1,23 @@
+# All settings not listed here will use the Doxygen default values.
+
+PROJECT_NAME           = "rosidl_typesupport_introspection_cpp"
+PROJECT_NUMBER         = master
+PROJECT_BRIEF          = "Generate the message type support for dynamic message construction in C++."
+
+INPUT                  = README.md QUALITY_DECLARATION.md ./include ./docs
+USE_MDFILE_AS_MAINPAGE = README.md
+RECURSIVE              = YES
+OUTPUT_DIRECTORY       = docs_output
+
+EXTRACT_ALL            = YES
+SORT_MEMBER_DOCS       = NO
+
+GENERATE_LATEX         = NO
+GENERATE_XML           = YES
+EXCLUDE_SYMBOLS        = detail details
+
+ENABLE_PREPROCESSING   = YES
+MACRO_EXPANSION        = YES
+EXPAND_ONLY_PREDEF     = YES
+PREDEFINED             += ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC
+PREDEFINED             += ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_IMPORT

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/message_introspection.hpp
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/message_introspection.hpp
@@ -27,7 +27,7 @@
 namespace rosidl_typesupport_introspection_cpp
 {
 
-typedef struct ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC MessageMember
+typedef struct ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC MessageMember_s
 {
   const char * name_;
   uint8_t type_id_;
@@ -44,7 +44,7 @@ typedef struct ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC MessageMember
   void (* resize_function)(void *, size_t size);
 } MessageMember;
 
-typedef struct ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC MessageMembers
+typedef struct ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC MessageMembers_s
 {
   const char * message_namespace_;
   const char * message_name_;

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/service_introspection.hpp
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/service_introspection.hpp
@@ -26,7 +26,7 @@
 namespace rosidl_typesupport_introspection_cpp
 {
 
-typedef struct ServiceMembers
+typedef struct ServiceMembers_s
 {
   const char * service_namespace_;
   const char * service_name_;


### PR DESCRIPTION
With these changes (and one in rosbag2_cpp), this package now
builds without warnings.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Note that this requires https://github.com/ros2/rosbag2/pull/903 to go in first.