### PR TITLE
Fix up the documentation for rosidl_typesupport_introspection_c

### DIFF
--- a/rosidl_typesupport_introspection_c/Doxyfile
+++ b/rosidl_typesupport_introspection_c/Doxyfile
@@ -1,0 +1,22 @@
+# All settings not listed here will use the Doxygen default values.
+
+PROJECT_NAME           = "rosidl_typesupport_introspection_c"
+PROJECT_NUMBER         = master
+PROJECT_BRIEF          = "Generate the message type support for dynamic message construction in C."
+
+INPUT                  = README.md QUALITY_DECLARATION.md ./include ./docs
+USE_MDFILE_AS_MAINPAGE = README.md
+RECURSIVE              = YES
+OUTPUT_DIRECTORY       = docs_output
+
+EXTRACT_ALL            = YES
+SORT_MEMBER_DOCS       = NO
+
+GENERATE_LATEX         = NO
+GENERATE_XML           = YES
+EXCLUDE_SYMBOLS        = detail details
+
+ENABLE_PREPROCESSING   = YES
+MACRO_EXPANSION        = YES
+EXPAND_ONLY_PREDEF     = YES
+PREDEFINED             += ROSIDL_TYPESUPPORT_INTROSPECTION_C_PUBLIC

--- a/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/message_introspection.h
+++ b/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/message_introspection.h
@@ -24,7 +24,7 @@
 
 #include "rosidl_typesupport_introspection_c/visibility_control.h"
 
-typedef struct rosidl_typesupport_introspection_c__MessageMember
+typedef struct rosidl_typesupport_introspection_c__MessageMember_s
 {
   const char * name_;
   uint8_t type_id_;
@@ -41,7 +41,7 @@ typedef struct rosidl_typesupport_introspection_c__MessageMember
   bool (* resize_function)(void *, size_t size);
 } rosidl_typesupport_introspection_c__MessageMember;
 
-typedef struct rosidl_typesupport_introspection_c__MessageMembers
+typedef struct rosidl_typesupport_introspection_c__MessageMembers_s
 {
   const char * message_namespace_;
   const char * message_name_;

--- a/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/service_introspection.h
+++ b/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/service_introspection.h
@@ -23,7 +23,7 @@
 
 #include "rosidl_typesupport_introspection_c/message_introspection.h"
 
-typedef struct rosidl_typesupport_introspection_c__ServiceMembers
+typedef struct rosidl_typesupport_introspection_c__ServiceMembers_s
 {
   const char * service_namespace_;
   const char * service_name_;


### PR DESCRIPTION
With these changes, this package now builds without warnings.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>