### PR TITLE
[rosidl_adapter, rosidl_parser] Pass comments in ros interface constants to the .idl generated files

### DIFF
--- a/rosidl_adapter/rosidl_adapter/resource/struct.idl.em
+++ b/rosidl_adapter/rosidl_adapter/resource/struct.idl.em
@@ -40,6 +40,16 @@ else:
 @[if msg.constants]@
     module @(msg.msg_name)_Constants {
 @[  for constant in msg.constants]@
+@[    if constant.annotations.get('comment', [])]@
+      @@verbatim (language="comment", text=
+@[      for i, line in enumerate(constant.annotations['comment'])]@
+        @(string_to_idl_string_literal(line))@
+@[        if i < len(constant.annotations.get('comment')) - 1]@
+ "\n"@
+@[        end if]@
+@[      end for]@
+)
+@[    end if]@
       const @(get_idl_type(constant.type)) @(constant.name) = @(to_idl_literal(get_idl_type(constant.type), constant.value));
 @[  end for]@
     };

--- a/rosidl_parser/rosidl_parser/grammar.lark
+++ b/rosidl_parser/rosidl_parser/grammar.lark
@@ -113,8 +113,8 @@ scoped_name.1: IDENTIFIER
 // separate rule to identify the separator
 scoped_name_separator: "::"
 
-// (5)
-const_dcl: "const" const_type IDENTIFIER "=" const_expr
+// (5), 7.4.15.2
+const_dcl: annotation_appl* "const" const_type IDENTIFIER "=" const_expr
 
 // (6)
 const_type: integer_type

--- a/rosidl_parser/rosidl_parser/parser.py
+++ b/rosidl_parser/rosidl_parser/parser.py
@@ -105,11 +105,10 @@ def extract_content_from_ast(tree):
     for const_dcl in const_dcls:
         annotations = get_annotations(const_dcl)
         const_type = next(const_dcl.find_data('const_type'))
-        *_, const_expr_value = const_dcl.find_data('const_expr')
         module_identifiers = get_module_identifier_values(tree, const_dcl)
         module_comments = constants.setdefault(
             module_identifiers[-1], [])
-        value = get_const_expr_value(const_expr_value)
+        value = get_const_expr_value(const_dcl.children[-1])
         constant = Constant(
             get_child_identifier_value(const_dcl),
             get_abstract_type_from_const_expr(const_type, value),

--- a/rosidl_parser/rosidl_parser/parser.py
+++ b/rosidl_parser/rosidl_parser/parser.py
@@ -103,16 +103,19 @@ def extract_content_from_ast(tree):
     constants = {}
     const_dcls = tree.find_data('const_dcl')
     for const_dcl in const_dcls:
+        annotations = get_annotations(const_dcl)
         const_type = next(const_dcl.find_data('const_type'))
-        const_expr = next(const_dcl.find_data('const_expr'))
+        *_, const_expr_value = const_dcl.find_data('const_expr')
         module_identifiers = get_module_identifier_values(tree, const_dcl)
         module_comments = constants.setdefault(
             module_identifiers[-1], [])
-        value = get_const_expr_value(const_expr)
-        module_comments.append(Constant(
-            get_first_identifier_value(const_dcl),
+        value = get_const_expr_value(const_expr_value)
+        constant = Constant(
+            get_child_identifier_value(const_dcl),
             get_abstract_type_from_const_expr(const_type, value),
-            value))
+            value)
+        constant.annotations = annotations
+        module_comments.append(constant)
 
     typedefs = {}
     typedef_dcls = tree.find_data('typedef_dcl')


### PR DESCRIPTION
* [rosidl_adapter] Pass comments in ros interface constants to the .idl generated files
* [rosidl_paraser] Support comments in constant expressions according to the idl standard.

Extracted from https://github.com/ros2/rosidl/pull/593.