### PR TITLE
[rosidl_adapter] Fix how comments in action interfaces are processed.

### DIFF
--- a/rosidl_adapter/rosidl_adapter/parser.py
+++ b/rosidl_adapter/rosidl_adapter/parser.py
@@ -448,35 +448,39 @@ def parse_message_file(pkg_name, interface_filename):
             pkg_name, msg_name, h.read())
 
 
+def extract_file_level_comments(message_string):
+    lines = message_string.splitlines()
+    index = next(
+        (i for i, v in enumerate(lines) if not v.startswith(COMMENT_DELIMITER)), -1)
+    if index != -1:
+        file_level_comments = lines[0:index]
+        other = lines[index:]
+    else:
+        file_level_comments = []
+        other = lines[:]
+    file_level_comments = [line.lstrip(COMMENT_DELIMITER) for line in file_level_comments]
+    return file_level_comments, other
+
+
 def parse_message_string(pkg_name, msg_name, message_string):
-    file_level_ended = False
     message_comments = []
     fields = []
     constants = []
     last_element = None  # either a field or a constant
+    # replace tabs with spaces
+    message_string.replace('\t', ' ')
 
     current_comments = []
-    lines = message_string.splitlines()
+    message_comments, lines = extract_file_level_comments(message_string)
     for line in lines:
         line = line.rstrip()
-
-        # replace tabs with spaces
-        line = line.replace('\t', ' ')
 
         # ignore empty lines
         if not line:
             # file-level comments stop at the first empty line
-            file_level_ended = True
             continue
 
         index = line.find(COMMENT_DELIMITER)
-
-        # file-level comment line
-        if index == 0 and not file_level_ended:
-            message_comments.append(line.lstrip(COMMENT_DELIMITER))
-            continue
-
-        file_level_ended = True
 
         # comment
         comment = None

--- a/rosidl_adapter/rosidl_adapter/parser.py
+++ b/rosidl_adapter/rosidl_adapter/parser.py
@@ -467,7 +467,7 @@ def parse_message_string(pkg_name, msg_name, message_string):
     constants = []
     last_element = None  # either a field or a constant
     # replace tabs with spaces
-    message_string.replace('\t', ' ')
+    message_string = message_string.replace('\t', ' ')
 
     current_comments = []
     message_comments, lines = extract_file_level_comments(message_string)

--- a/rosidl_adapter/rosidl_adapter/parser.py
+++ b/rosidl_adapter/rosidl_adapter/parser.py
@@ -463,7 +463,6 @@ def extract_file_level_comments(message_string):
 
 
 def parse_message_string(pkg_name, msg_name, message_string):
-    message_comments = []
     fields = []
     constants = []
     last_element = None  # either a field or a constant

--- a/rosidl_adapter/rosidl_adapter/parser.py
+++ b/rosidl_adapter/rosidl_adapter/parser.py
@@ -453,7 +453,7 @@ def extract_file_level_comments(message_string):
     index = next(
         (i for i, v in enumerate(lines) if not v.startswith(COMMENT_DELIMITER)), -1)
     if index != -1:
-        file_level_comments = lines[0:index]
+        file_level_comments = lines[:index]
         other = lines[index:]
     else:
         file_level_comments = lines[:]

--- a/rosidl_adapter/rosidl_adapter/parser.py
+++ b/rosidl_adapter/rosidl_adapter/parser.py
@@ -456,8 +456,8 @@ def extract_file_level_comments(message_string):
         file_level_comments = lines[0:index]
         other = lines[index:]
     else:
-        file_level_comments = []
-        other = lines[:]
+        file_level_comments = lines[:]
+        other = []
     file_level_comments = [line.lstrip(COMMENT_DELIMITER) for line in file_level_comments]
     return file_level_comments, other
 

--- a/rosidl_adapter/rosidl_adapter/parser.py
+++ b/rosidl_adapter/rosidl_adapter/parser.py
@@ -884,14 +884,17 @@ def parse_action_file(pkg_name, interface_filename):
 
 
 def parse_action_string(pkg_name, action_name, action_string):
-    action_blocks = re.split(
-        '^' + ACTION_REQUEST_RESPONSE_SEPARATOR + '$', action_string, flags=re.MULTILINE)
-    if len(action_blocks) != 3:
+    lines = action_string.splitlines()
+    separator_indices = [
+        index for index, line in enumerate(lines) if line == ACTION_REQUEST_RESPONSE_SEPARATOR]
+    if len(separator_indices) != 2:
         raise InvalidActionSpecification(
             "Number of '%s' separators nonconformant with action definition" %
             ACTION_REQUEST_RESPONSE_SEPARATOR)
 
-    goal_string, result_string, feedback_string = action_blocks
+    goal_string = '\n'.join(lines[:separator_indices[0]])
+    result_string = '\n'.join(lines[separator_indices[0] + 1:separator_indices[1]])
+    feedback_string = '\n'.join(lines[separator_indices[1] + 1:])
 
     goal_message = parse_message_string(
         pkg_name, action_name + ACTION_GOAL_SUFFIX, goal_string)

--- a/rosidl_adapter/rosidl_adapter/parser.py
+++ b/rosidl_adapter/rosidl_adapter/parser.py
@@ -454,12 +454,12 @@ def extract_file_level_comments(message_string):
         (i for i, v in enumerate(lines) if not v.startswith(COMMENT_DELIMITER)), -1)
     if index != -1:
         file_level_comments = lines[:index]
-        other = lines[index:]
+        file_content = lines[index:]
     else:
         file_level_comments = lines[:]
-        other = []
+        file_content = []
     file_level_comments = [line.lstrip(COMMENT_DELIMITER) for line in file_level_comments]
-    return file_level_comments, other
+    return file_level_comments, file_content
 
 
 def parse_message_string(pkg_name, msg_name, message_string):

--- a/rosidl_adapter/test/data/action/Test.action
+++ b/rosidl_adapter/test/data/action/Test.action
@@ -25,6 +25,7 @@ string string_value
 bool ok
 ---
 # feedback definition
+# more
 
 # sequence docs
 int32[] sequence

--- a/rosidl_adapter/test/data/action/Test.action
+++ b/rosidl_adapter/test/data/action/Test.action
@@ -1,7 +1,12 @@
 # goal definition
+# foo
+
+# bar
 bool bool_value
+# baz
 byte byte_value
-char char_value
+# asd
+char char_value  # bsd
 float32 float32_value
 float64 float64_value
 int8 int8_value
@@ -15,7 +20,11 @@ uint64 uint64_value
 string string_value
 ---
 # result definition
+
+# ok docs
 bool ok
 ---
 # feedback definition
+
+# sequence docs
 int32[] sequence

--- a/rosidl_adapter/test/data/action/Test.expected.idl
+++ b/rosidl_adapter/test/data/action/Test.expected.idl
@@ -6,12 +6,20 @@
 module test_msgs {
   module action {
     @verbatim (language="comment", text=
-      "goal definition")
+      "goal definition" "\n"
+      "foo")
     struct Test_Goal {
+      @verbatim (language="comment", text=
+        "bar")
       boolean bool_value;
 
+      @verbatim (language="comment", text=
+        "baz")
       octet byte_value;
 
+      @verbatim (language="comment", text=
+        "asd" "\n"
+        "bsd")
       uint8 char_value;
 
       float float32_value;
@@ -36,14 +44,18 @@ module test_msgs {
 
       string string_value;
     };
+    @verbatim (language="comment", text=
+      "result definition")
     struct Test_Result {
       @verbatim (language="comment", text=
-        "result definition")
+        "ok docs")
       boolean ok;
     };
+    @verbatim (language="comment", text=
+      "feedback definition")
     struct Test_Feedback {
       @verbatim (language="comment", text=
-        "feedback definition")
+        "sequence docs")
       sequence<int32> sequence;
     };
   };

--- a/rosidl_adapter/test/data/action/Test.expected.idl
+++ b/rosidl_adapter/test/data/action/Test.expected.idl
@@ -52,7 +52,8 @@ module test_msgs {
       boolean ok;
     };
     @verbatim (language="comment", text=
-      "feedback definition")
+      "feedback definition" "\n"
+      "more")
     struct Test_Feedback {
       @verbatim (language="comment", text=
         "sequence docs")

--- a/rosidl_adapter/test/data/msg/Test.expected.idl
+++ b/rosidl_adapter/test/data/msg/Test.expected.idl
@@ -5,11 +5,20 @@
 
 module test_msgs {
   module msg {
+    @verbatim (language="comment", text=
+      "msg level doc")
     struct Test {
+      @verbatim (language="comment", text=
+        "field level doc")
       boolean bool_value;
 
+      @verbatim (language="comment", text=
+        "field level doc, style 2")
       octet byte_value;
 
+      @verbatim (language="comment", text=
+        "combined styles" "\n"
+        "combined styles, part 2")
       uint8 char_value;
 
       float float32_value;

--- a/rosidl_adapter/test/data/msg/Test.msg
+++ b/rosidl_adapter/test/data/msg/Test.msg
@@ -1,6 +1,10 @@
+# msg level doc
+
+# field level doc
 bool bool_value
-byte byte_value
-char char_value
+byte byte_value  # field level doc, style 2
+# combined styles
+char char_value # combined styles, part 2
 float32 float32_value
 float64 float64_value
 int8 int8_value

--- a/rosidl_adapter/test/data/srv/Test.expected.idl
+++ b/rosidl_adapter/test/data/srv/Test.expected.idl
@@ -5,11 +5,21 @@
 
 module test_msgs {
   module srv {
+    @verbatim (language="comment", text=
+      "1" "\n"
+      "2")
     struct Test_Request {
+      @verbatim (language="comment", text=
+        "3")
       boolean bool_value;
 
+      @verbatim (language="comment", text=
+        "4")
       octet byte_value;
 
+      @verbatim (language="comment", text=
+        "5" "\n"
+        "6")
       uint8 char_value;
 
       float float32_value;
@@ -34,7 +44,11 @@ module test_msgs {
 
       string string_value;
     };
+    @verbatim (language="comment", text=
+      "7")
     struct Test_Response {
+      @verbatim (language="comment", text=
+        "8")
       boolean ok;
     };
   };

--- a/rosidl_adapter/test/data/srv/Test.srv
+++ b/rosidl_adapter/test/data/srv/Test.srv
@@ -1,6 +1,11 @@
+# 1
+# 2
+
+# 3
 bool bool_value
-byte byte_value
-char char_value
+byte byte_value # 4
+# 5
+char char_value # 6
 float32 float32_value
 float64 float64_value
 int8 int8_value
@@ -13,4 +18,8 @@ int64 int64_value
 uint64 uint64_value
 string string_value
 ---
+# 7
+
+# 8
+
 bool ok


### PR DESCRIPTION
Add also tests for msg and srv interfaces.

I also wanted to add a top level srv or action doc section.
e.g.

```
# top level srv docs

# top level request docs

# field docs
int my_field
---
# top level response docs

int response_field
```

but there's nowhere where we can put that in the current mapping to DDS idl, so I abandoned that idea.