### PR TITLE
Add documentation for generators and API

### DIFF
--- a/rosidl_typesupport_introspection_c/bin/rosidl_typesupport_introspection_c
+++ b/rosidl_typesupport_introspection_c/bin/rosidl_typesupport_introspection_c
@@ -7,6 +7,16 @@ from rosidl_typesupport_introspection_c import generate_c
 
 
 def main(argv=sys.argv[1:]):
+    """
+    Main function for the command-line tool to generate the C-language
+    introspection type support for an interface.
+
+    Parameters
+    ----------
+    argv : List[str]
+        The command-line arguments to be parsed. Defaults to sys.argv[1:].
+
+    """
     parser = argparse.ArgumentParser(
         description='Generate the C type support to dynamically handle ROS messages.',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)

--- a/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/field_types.h
+++ b/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/field_types.h
@@ -22,32 +22,54 @@ extern "C"
 {
 #endif
 
+/// Primitive (plain-old data) types supported by the ROS type system.
 enum
 {
+  /// IEEE-754 binary32 format floating point number.
   rosidl_typesupport_introspection_c__ROS_TYPE_FLOAT = 1,
+  /// IEEE-754 binary64 format floating point number.
   rosidl_typesupport_introspection_c__ROS_TYPE_DOUBLE = 2,
+  /// IEEE-754 binary128 format floating point number.
   rosidl_typesupport_introspection_c__ROS_TYPE_LONG_DOUBLE = 3,
+  /// Unsigned char, 8 bits wide.
   rosidl_typesupport_introspection_c__ROS_TYPE_CHAR = 4,
+  /// Wide character, large enough to support Unicode code points.
   rosidl_typesupport_introspection_c__ROS_TYPE_WCHAR = 5,
+  /// Boolean value. The size is implementation defined.
   rosidl_typesupport_introspection_c__ROS_TYPE_BOOLEAN = 6,
+  /// A single unsigned byte in raw form.
   rosidl_typesupport_introspection_c__ROS_TYPE_OCTET = 7,
+  /// Unsigned 8-bit integer.
   rosidl_typesupport_introspection_c__ROS_TYPE_UINT8 = 8,
+  /// Signed 8-bit integer.
   rosidl_typesupport_introspection_c__ROS_TYPE_INT8 = 9,
+  /// Unsigned 16-bit integer.
   rosidl_typesupport_introspection_c__ROS_TYPE_UINT16 = 10,
+  /// Signed 16-bit integer.
   rosidl_typesupport_introspection_c__ROS_TYPE_INT16 = 11,
+  /// Unsigned 32-bit integer.
   rosidl_typesupport_introspection_c__ROS_TYPE_UINT32 = 12,
+  /// Signed 32-bit integer.
   rosidl_typesupport_introspection_c__ROS_TYPE_INT32 = 13,
+  /// Unsigned 64-bit integer.
   rosidl_typesupport_introspection_c__ROS_TYPE_UINT64 = 14,
+  /// Signed 64-bit integer.
   rosidl_typesupport_introspection_c__ROS_TYPE_INT64 = 15,
+  /// String, represented as an array of char's.
   rosidl_typesupport_introspection_c__ROS_TYPE_STRING = 16,
+  /// Wide string, represented as an array of elements at least 16-bits wide each.
   rosidl_typesupport_introspection_c__ROS_TYPE_WSTRING = 17,
 
+  /// An embedded message type.
   rosidl_typesupport_introspection_c__ROS_TYPE_MESSAGE = 18,
 
-  // for backward compatibility only
+  /// For backward compatibility only.
   rosidl_typesupport_introspection_c__ROS_TYPE_FLOAT32 = 1,
+  /// For backward compatibility only.
   rosidl_typesupport_introspection_c__ROS_TYPE_FLOAT64 = 2,
+  /// For backward compatibility only.
   rosidl_typesupport_introspection_c__ROS_TYPE_BOOL = 6,
+  /// For backward compatibility only.
   rosidl_typesupport_introspection_c__ROS_TYPE_BYTE = 7
 };
 

--- a/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/identifier.h
+++ b/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/identifier.h
@@ -22,6 +22,7 @@ extern "C"
 {
 #endif
 
+/// String identifying the typesupport introspection implementation in use.
 ROSIDL_TYPESUPPORT_INTROSPECTION_C_PUBLIC
 extern const char * rosidl_typesupport_introspection_c__identifier;
 

--- a/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/message_introspection.h
+++ b/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/message_introspection.h
@@ -24,31 +24,64 @@
 
 #include "rosidl_typesupport_introspection_c/visibility_control.h"
 
+/// Structure used to describe a single field of an interface type.
 typedef struct rosidl_typesupport_introspection_c__MessageMember_s
 {
+  /// The name of the field.
   const char * name_;
+  /// The type of the field as a value of the field types enum,
+  /// e.g. rosidl_typesupport_introspection_c__ROS_TYPE_FLOAT
   uint8_t type_id_;
+  /// If the field is a string, the upper bound on the length of the string.
   size_t string_upper_bound_;
+  /// If the type_id_ value is rosidl_typesupport_introspection_c__ROS_TYPE_MESSAGE,
+  /// this points to an array describing the fields of the sub-interface.
   const rosidl_message_type_support_t * members_;
+  /// True if this field is an array, false if it is a unary type. An array has the same value for
+  /// type_id_.
   bool is_array_;
+  /// If is_array_ is true, this contains the number of members in the array.
   size_t array_size_;
+  /// If is_array_ is true, this specifies if the array has a maximum size. If it is true, the
+  /// value in array_size_ is the maximum size.
   bool is_upper_bound_;
+  /// The bytes into the interface's in-memory representation that this field can be found at.
   uint32_t offset_;
+  /// If the interface has a default value, this points to it.
   const void * default_value_;
+  /// If is_array_ is true, a pointer to a function that gives the size of one member of the array.
+  /// Only used for nested interface types.
   size_t (* size_function)(const void *);
+  /// If is_array_ is true, a pointer to a function that gives a const pointer to the member of the
+  /// array indicated by index.
+  /// Only used for nested interface types.
   const void * (*get_const_function)(const void *, size_t index);
+  /// If is_array_ is true, a pointer to a function that gives a pointer to the member of the
+  /// array indicated by index.
+  /// Only used for nested interface types.
   void * (*get_function)(void *, size_t index);
+  /// If is_array_ is true, a pointer to a function that resizes the array.
+  /// Only used for nested interface types.
   bool (* resize_function)(void *, size_t size);
 } rosidl_typesupport_introspection_c__MessageMember;
 
+/// Structure used to describe all fields of a single interface type.
 typedef struct rosidl_typesupport_introspection_c__MessageMembers_s
 {
+  /// The namespace in which the interface resides, e.g. "example_messages__msg" for
+  /// example_messages/msg
   const char * message_namespace_;
+  /// The name of the interface, e.g. "Int16"
   const char * message_name_;
+  /// The number of fields in the interface
   uint32_t member_count_;
+  /// The size of the interface structure in memory
   size_t size_of_;
+  /// A pointer to the array that describes each field of the interface
   const rosidl_typesupport_introspection_c__MessageMember * members_;
+  /// The function used to initialise the interface's in-memory representation
   void (* init_function)(void *, enum rosidl_runtime_c__message_initialization);
+  /// The function used to clean up the interface's in-memory representation
   void (* fini_function)(void *);
 } rosidl_typesupport_introspection_c__MessageMembers;
 

--- a/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/service_introspection.h
+++ b/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/service_introspection.h
@@ -23,11 +23,18 @@
 
 #include "rosidl_typesupport_introspection_c/message_introspection.h"
 
+/// This struct provides introspection information for one service definition.
+/// A service is comprised of two interfaces: the request and the response.
 typedef struct rosidl_typesupport_introspection_c__ServiceMembers_s
 {
+  /// The namespace in which the service resides, e.g. "example_messages__srv" for
+  /// example_messages/srv
   const char * service_namespace_;
+  /// The name of the service, e.g. "AddTwoInts"
   const char * service_name_;
+  /// A pointer to the introspection information structure for the request interface.
   const rosidl_typesupport_introspection_c__MessageMembers * request_members_;
+  /// A pointer to the introspection information structure for the response interface.
   const rosidl_typesupport_introspection_c__MessageMembers * response_members_;
 } rosidl_typesupport_introspection_c__ServiceMembers;
 

--- a/rosidl_typesupport_introspection_c/rosidl_typesupport_introspection_c/__init__.py
+++ b/rosidl_typesupport_introspection_c/rosidl_typesupport_introspection_c/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2018 Open Source Robotics Foundation, Inc.
+# Copyright 2014-2021 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,15 @@ from rosidl_cmake import generate_files
 
 
 def generate_c(generator_arguments_file):
+    """
+    Generate the C implementation of the type support.
+
+    Parameters
+    ----------
+    generator_arguments_file : str
+        The path to the file containing the arguments for the generator.
+
+    """
     mapping = {
         'idl__rosidl_typesupport_introspection_c.h.em':
         'detail/%s__rosidl_typesupport_introspection_c.h',

--- a/rosidl_typesupport_introspection_c/rosidl_typesupport_introspection_c/cli.py
+++ b/rosidl_typesupport_introspection_c/rosidl_typesupport_introspection_c/cli.py
@@ -25,7 +25,10 @@ from rosidl_typesupport_introspection_c import generate_c
 
 
 class GenerateIntrospectionCTypesupport(GenerateCommandExtension):
+    """
+    Generator class for generating the C implementation of the type support.
 
+    """
     def generate(
         self,
         package_name,

--- a/rosidl_typesupport_introspection_cpp/bin/rosidl_typesupport_introspection_cpp
+++ b/rosidl_typesupport_introspection_cpp/bin/rosidl_typesupport_introspection_cpp
@@ -7,6 +7,16 @@ from rosidl_typesupport_introspection_cpp import generate_cpp
 
 
 def main(argv=sys.argv[1:]):
+    """
+    Main function for the command-line tool to generate the C++-language
+    introspection type support for an interface.
+
+    Parameters
+    ----------
+    argv : List[str]
+        The command-line arguments to be parsed. Defaults to sys.argv[1:].
+
+    """
     parser = argparse.ArgumentParser(
         description='Generate the C++ type support to dynamically handle ROS messages.',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/field_types.hpp
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/field_types.hpp
@@ -21,30 +21,53 @@
 namespace rosidl_typesupport_introspection_cpp
 {
 
+/// Primitive (plain-old data) types supported by the ROS type system.
+
+/// IEEE-754 binary32 format floating point number.
 const uint8_t ROS_TYPE_FLOAT = rosidl_typesupport_introspection_c__ROS_TYPE_FLOAT;
+/// IEEE-754 binary64 format floating point number.
 const uint8_t ROS_TYPE_DOUBLE = rosidl_typesupport_introspection_c__ROS_TYPE_DOUBLE;
+/// IEEE-754 binary128 format floating point number.
 const uint8_t ROS_TYPE_LONG_DOUBLE = rosidl_typesupport_introspection_c__ROS_TYPE_LONG_DOUBLE;
+/// Unsigned char, 8 bits wide.
 const uint8_t ROS_TYPE_CHAR = rosidl_typesupport_introspection_c__ROS_TYPE_CHAR;
+/// Wide character, large enough to support Unicode code points.
 const uint8_t ROS_TYPE_WCHAR = rosidl_typesupport_introspection_c__ROS_TYPE_WCHAR;
+/// Boolean value. The size is implementation defined.
 const uint8_t ROS_TYPE_BOOLEAN = rosidl_typesupport_introspection_c__ROS_TYPE_BOOLEAN;
+/// A single unsigned byte in raw form.
 const uint8_t ROS_TYPE_OCTET = rosidl_typesupport_introspection_c__ROS_TYPE_OCTET;
+/// Unsigned 8-bit integer.
 const uint8_t ROS_TYPE_UINT8 = rosidl_typesupport_introspection_c__ROS_TYPE_UINT8;
+/// Signed 8-bit integer.
 const uint8_t ROS_TYPE_INT8 = rosidl_typesupport_introspection_c__ROS_TYPE_INT8;
+/// Unsigned 16-bit integer.
 const uint8_t ROS_TYPE_UINT16 = rosidl_typesupport_introspection_c__ROS_TYPE_UINT16;
+/// Signed 16-bit integer.
 const uint8_t ROS_TYPE_INT16 = rosidl_typesupport_introspection_c__ROS_TYPE_INT16;
+/// Unsigned 32-bit integer.
 const uint8_t ROS_TYPE_UINT32 = rosidl_typesupport_introspection_c__ROS_TYPE_UINT32;
+/// Signed 32-bit integer.
 const uint8_t ROS_TYPE_INT32 = rosidl_typesupport_introspection_c__ROS_TYPE_INT32;
+/// Unsigned 64-bit integer.
 const uint8_t ROS_TYPE_UINT64 = rosidl_typesupport_introspection_c__ROS_TYPE_UINT64;
+/// Signed 64-bit integer.
 const uint8_t ROS_TYPE_INT64 = rosidl_typesupport_introspection_c__ROS_TYPE_INT64;
+/// String, represented as an array of char's.
 const uint8_t ROS_TYPE_STRING = rosidl_typesupport_introspection_c__ROS_TYPE_STRING;
+/// Wide string, represented as an array of elements at least 16-bits wide each.
 const uint8_t ROS_TYPE_WSTRING = rosidl_typesupport_introspection_c__ROS_TYPE_WSTRING;
 
+/// An embedded message type.
 const uint8_t ROS_TYPE_MESSAGE = rosidl_typesupport_introspection_c__ROS_TYPE_MESSAGE;
 
-// for backward compatibility only
+/// For backward compatibility only.
 const uint8_t ROS_TYPE_BOOL = rosidl_typesupport_introspection_c__ROS_TYPE_BOOL;
+/// For backward compatibility only.
 const uint8_t ROS_TYPE_BYTE = rosidl_typesupport_introspection_c__ROS_TYPE_BYTE;
+/// For backward compatibility only.
 const uint8_t ROS_TYPE_FLOAT32 = rosidl_typesupport_introspection_c__ROS_TYPE_FLOAT32;
+/// For backward compatibility only.
 const uint8_t ROS_TYPE_FLOAT64 = rosidl_typesupport_introspection_c__ROS_TYPE_FLOAT64;
 
 }  // namespace rosidl_typesupport_introspection_cpp

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/identifier.hpp
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/identifier.hpp
@@ -20,6 +20,7 @@
 namespace rosidl_typesupport_introspection_cpp
 {
 
+/// String identifying the typesupport introspection implementation in use.
 ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_IMPORT
 extern const char * typesupport_identifier;
 

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/message_introspection.hpp
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/message_introspection.hpp
@@ -27,31 +27,64 @@
 namespace rosidl_typesupport_introspection_cpp
 {
 
+/// Structure used to describe a single field of an interface type.
 typedef struct ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC MessageMember_s
 {
+  /// The name of the field.
   const char * name_;
+  /// The type of the field as a value of the field types enum,
+  /// e.g. rosidl_typesupport_introspection_c__ROS_TYPE_FLOAT
   uint8_t type_id_;
+  /// If the field is a string, the upper bound on the length of the string.
   size_t string_upper_bound_;
+  /// If the type_id_ value is rosidl_typesupport_introspection_c__ROS_TYPE_MESSAGE,
+  /// this points to an array describing the fields of the sub-interface.
   const rosidl_message_type_support_t * members_;
+  /// True if this field is an array, false if it is a unary type. An array has the same value for
+  /// type_id_.
   bool is_array_;
+  /// If is_array_ is true, this contains the number of members in the array.
   size_t array_size_;
+  /// If is_array_ is true, this specifies if the array has a maximum size. If it is true, the
+  /// value in array_size_ is the maximum size.
   bool is_upper_bound_;
+  /// The bytes into the interface's in-memory representation that this field can be found at.
   uint32_t offset_;
+  /// If the interface has a default value, this points to it.
   const void * default_value_;
+  /// If is_array_ is true, a pointer to a function that gives the size of one member of the array.
+  /// Only used for nested interface types.
   size_t (* size_function)(const void *);
+  /// If is_array_ is true, a pointer to a function that gives a const pointer to the member of the
+  /// array indicated by index.
+  /// Only used for nested interface types.
   const void * (*get_const_function)(const void *, size_t index);
+  /// If is_array_ is true, a pointer to a function that gives a pointer to the member of the
+  /// array indicated by index.
+  /// Only used for nested interface types.
   void * (*get_function)(void *, size_t index);
+  /// If is_array_ is true, a pointer to a function that resizes the array.
+  /// Only used for nested interface types.
   void (* resize_function)(void *, size_t size);
 } MessageMember;
 
+/// Structure used to describe all fields of a single interface type.
 typedef struct ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC MessageMembers_s
 {
+  /// The namespace in which the interface resides, e.g. "example_messages__msg" for
+  /// example_messages/msg
   const char * message_namespace_;
+  /// The name of the interface, e.g. "Int16"
   const char * message_name_;
+  /// The number of fields in the interface
   uint32_t member_count_;
+  /// The size of the interface structure in memory
   size_t size_of_;
+  /// A pointer to the array that describes each field of the interface
   const MessageMember * members_;
+  /// The function used to initialise the interface's in-memory representation
   void (* init_function)(void *, rosidl_runtime_cpp::MessageInitialization);
+  /// The function used to clean up the interface's in-memory representation
   void (* fini_function)(void *);
 } MessageMembers;
 

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/message_type_support_decl.hpp
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/message_type_support_decl.hpp
@@ -23,7 +23,9 @@
 namespace rosidl_typesupport_introspection_cpp
 {
 
-// This is implemented in the shared library provided by this package.
+/// Returns a pointer to the type support structure provided by this library for introspecting
+/// interfaces.
+/// This is implemented in the shared library provided by this package.
 template<typename T>
 ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC
 const rosidl_message_type_support_t * get_message_type_support_handle();

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/service_introspection.hpp
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/service_introspection.hpp
@@ -26,11 +26,18 @@
 namespace rosidl_typesupport_introspection_cpp
 {
 
+/// This struct provides introspection information for one service definition.
+/// A service is comprised of two interfaces: the request and the response.
 typedef struct ServiceMembers_s
 {
+  /// The namespace in which the service resides, e.g. "example_messages__srv" for
+  /// example_messages/srv
   const char * service_namespace_;
+  /// The name of the service, e.g. "AddTwoInts"
   const char * service_name_;
+  /// A pointer to the introspection information structure for the request interface.
   const MessageMembers * request_members_;
+  /// A pointer to the introspection information structure for the response interface.
   const MessageMembers * response_members_;
 } ServiceMembers;
 

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/service_type_support_decl.hpp
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/service_type_support_decl.hpp
@@ -23,7 +23,9 @@
 namespace rosidl_typesupport_introspection_cpp
 {
 
-// This is implemented in the shared library provided by this package.
+/// Returns a pointer to the type support structure provided by this library for introspecting
+/// services.
+/// This is implemented in the shared library provided by this package.
 template<typename T>
 ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC
 const rosidl_service_type_support_t * get_service_type_support_handle();

--- a/rosidl_typesupport_introspection_cpp/rosidl_typesupport_introspection_cpp/__init__.py
+++ b/rosidl_typesupport_introspection_cpp/rosidl_typesupport_introspection_cpp/__init__.py
@@ -16,6 +16,15 @@ from rosidl_cmake import generate_files
 
 
 def generate_cpp(generator_arguments_file):
+    """
+    Generate the C++ implementation of the type support.
+
+    Parameters
+    ----------
+    generator_arguments_file : str
+        The path to the file containing the arguments for the generator.
+
+    """
     mapping = {
         'idl__rosidl_typesupport_introspection_cpp.hpp.em':
         'detail/%s__rosidl_typesupport_introspection_cpp.hpp',

--- a/rosidl_typesupport_introspection_cpp/rosidl_typesupport_introspection_cpp/cli.py
+++ b/rosidl_typesupport_introspection_cpp/rosidl_typesupport_introspection_cpp/cli.py
@@ -24,6 +24,10 @@ from rosidl_typesupport_introspection_cpp import generate_cpp
 
 
 class GenerateIntrospectionCppTypesupport(GenerateCommandExtension):
+    """
+    Generator class for generating the C++ implementation of the type support.
+
+    """
 
     def generate(
         self,


### PR DESCRIPTION
This PR adds documentation to the type support APIs and generators for C and C++.

The documentation needs review by someone with a good understanding of `rosidl`, to ensure it is correct and identify any missing documentation.