### PR TITLE
rename nested loop index

### DIFF
--- a/rosidl_adapter/rosidl_adapter/resource/struct.idl.em
+++ b/rosidl_adapter/rosidl_adapter/resource/struct.idl.em
@@ -68,14 +68,14 @@ else:
     struct @(msg.msg_name) {
 @[if msg.fields]@
 @[  for i, field in enumerate(msg.fields)]@
-@[if i > 0]@
+@[    if i > 0]@
 
-@[end if]@
+@[    end if]@
 @[    if field.annotations.get('comment', [])]@
       @@verbatim (language="comment", text=@
-@[      for i, line in enumerate(field.annotations['comment'])]
+@[      for j, line in enumerate(field.annotations['comment'])]
         @(string_to_idl_string_literal(line))@
-@[        if i < len(field.annotations.get('comment')) - 1]@
+@[        if j < len(field.annotations.get('comment')) - 1]@
  "\n"@
 @[        end if]@
 @[      end for]@


### PR DESCRIPTION
Fixing minor issue with loop index mentioned in:
https://github.com/ros2/rosidl/issues/642

rosidl_adapter  pytest passed and no changes in IDL output visible. 