### PR TITLE
Support nested types introspection in C/C++

### DIFF
--- a/rosidl_generator_cpp/resource/idl__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/idl__struct.hpp.em
@@ -27,8 +27,8 @@ include_directives = set()
 #include <array>
 #include <memory>
 #include <string>
-#include <vector>
 
+#include "rosidl_runtime_cpp/vector.hpp"
 #include "rosidl_runtime_cpp/bounded_vector.hpp"
 #include "rosidl_runtime_cpp/message_initialization.hpp"
 

--- a/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
+++ b/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
@@ -117,8 +117,8 @@ def msg_type_to_cpp(type_):
     if isinstance(type_, AbstractNestedType):
         if isinstance(type_, UnboundedSequence):
             return \
-                ('std::vector<%s, typename std::allocator_traits<ContainerAllocator>::template ' +
-                 'rebind_alloc<%s>>') % (cpp_type, cpp_type)
+                ('rosidl_runtime_cpp::Vector<%s, typename std::allocator_traits' +
+                 '<ContainerAllocator>::template rebind_alloc<%s>>') % (cpp_type, cpp_type)
         elif isinstance(type_, BoundedSequence):
             return \
                 ('rosidl_runtime_cpp::BoundedVector<%s, %u, typename std::allocator_traits' +

--- a/rosidl_generator_cpp/test/test_interfaces.cpp
+++ b/rosidl_generator_cpp/test/test_interfaces.cpp
@@ -241,7 +241,7 @@ void test_message_bounded(rosidl_generator_cpp::msg::BoundedSequences message)
 
 #define TEST_UNBOUNDED_SEQUENCE_TYPES( \
     Message, FieldName, PrimitiveType, ArraySize, MinVal, MaxVal) \
-  std::vector<PrimitiveType> pattern_ ## FieldName(ArraySize); \
+  rosidl_runtime_cpp::Vector<PrimitiveType> pattern_ ## FieldName(ArraySize); \
   pattern_ ## FieldName.resize(ArraySize); \
   test_vector_fill<decltype(pattern_ ## FieldName)>( \
     &pattern_ ## FieldName, ArraySize, MinVal, MaxVal); \
@@ -251,7 +251,7 @@ void test_message_bounded(rosidl_generator_cpp::msg::BoundedSequences message)
 
 #define TEST_UNBOUNDED_SEQUENCE_STRING( \
     Message, FieldName, PrimitiveType, ArraySize, MinVal, MaxVal, MinLength, MaxLength) \
-  std::vector<PrimitiveType> pattern_ ## FieldName; \
+  rosidl_runtime_cpp::Vector<PrimitiveType> pattern_ ## FieldName; \
   Message.FieldName.resize(ArraySize); \
   pattern_ ## FieldName.resize(ArraySize); \
   test_vector_fill<decltype(pattern_ ## FieldName)>( \

--- a/rosidl_runtime_cpp/CMakeLists.txt
+++ b/rosidl_runtime_cpp/CMakeLists.txt
@@ -44,6 +44,11 @@ if(BUILD_TESTING)
     target_include_directories(test_bounded_vector PUBLIC include)
   endif()
 
+  ament_add_gtest(test_vector test/test_vector.cpp)
+  if(TARGET test_vector)
+    target_include_directories(test_vector PUBLIC include)
+  endif()
+
   add_performance_test(benchmark_bounded_vector test/benchmark/benchmark_bounded_vector.cpp)
   if(TARGET benchmark_bounded_vector)
     target_link_libraries(benchmark_bounded_vector ${PROJECT_NAME})

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/bounded_vector.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/bounded_vector.hpp
@@ -19,7 +19,8 @@
 #include <memory>
 #include <stdexcept>
 #include <utility>
-#include <vector>
+
+#include "rosidl_runtime_cpp/vector.hpp"
 
 namespace rosidl_runtime_cpp
 {
@@ -34,9 +35,9 @@ namespace rosidl_runtime_cpp
  */
 template<typename Tp, std::size_t UpperBound, typename Alloc = std::allocator<Tp>>
 class BoundedVector
-  : protected std::vector<Tp, Alloc>
+  : protected Vector<Tp, Alloc>
 {
-  using Base = std::vector<Tp, Alloc>;
+  using Base = Vector<Tp, Alloc>;
 
 public:
   using typename Base::value_type;

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/vector.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/vector.hpp
@@ -1,0 +1,179 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_RUNTIME_CPP__VECTOR_HPP_
+#define ROSIDL_RUNTIME_CPP__VECTOR_HPP_
+
+#include <memory>
+#include <type_traits>
+#include <vector>
+
+namespace rosidl_runtime_cpp
+{
+namespace internal
+{
+/// A bool value wrapper to avoid std::vector<bool> specializations.
+/**
+ * For all practical purposes, an instance of this class is a bool value.
+ */
+class BoolWrapper
+{
+public:
+  constexpr BoolWrapper()
+  : value_(false) {}
+  constexpr BoolWrapper(bool value)
+  : value_(value) {}
+
+  BoolWrapper & operator=(bool value)
+  {
+    value_ = value;
+    return *this;
+  }
+
+  bool operator==(BoolWrapper other)
+  {
+    return value_ == other.value_;
+  }
+
+  bool operator!=(BoolWrapper other)
+  {
+    return value_ != other.value_;
+  }
+
+  operator bool &() {return value_;}
+
+  operator const bool &() const {return value_;}
+
+  bool * operator&() {return &value_;}  // NOLINT(runtime/operator)
+
+private:
+  bool value_;
+};
+
+static_assert(
+  std::is_standard_layout<BoolWrapper>::value,
+  "BoolWrapper must be a standard layout type "
+  "to afford reinterpret casts to bool.");
+
+}  // namespace internal
+
+/// A container based on std::vector with its own specializations.
+/**
+ * This container transparently interacts with std::vector<T> instances.
+ */
+template<typename T, typename AllocatorT = std::allocator<T>>
+class Vector : public std::vector<T, AllocatorT>
+{
+  using Base = std::vector<T, AllocatorT>;
+
+public:
+  using typename Base::value_type;
+  using typename Base::pointer;
+  using typename Base::const_pointer;
+  using typename Base::reference;
+  using typename Base::const_reference;
+  using typename Base::iterator;
+  using typename Base::const_iterator;
+  using typename Base::const_reverse_iterator;
+  using typename Base::reverse_iterator;
+  using typename Base::size_type;
+  using typename Base::difference_type;
+  using typename Base::allocator_type;
+
+  using Base::vector;
+
+  // Implicit "copy" and "move" constructors from std::vector<T> instances
+  Vector(const std::vector<T, AllocatorT> & other)  // NOLINT(runtime/explicit)
+  : Base(other) {}
+
+  Vector(std::vector<T, AllocatorT> && other)  // NOLINT(runtime/explicit)
+  : Base(other) {}
+};
+
+/// Specialization for a boolean vector with no space optimizations.
+/**
+ * This container transparently interacts with std::vector<bool>
+ * instances while avoiding all the quirks in the latter.
+ */
+template<typename AllocatorT>
+class Vector<bool, AllocatorT>: public std::vector<
+    internal::BoolWrapper,
+    typename std::allocator_traits<AllocatorT>::
+    template rebind_alloc<internal::BoolWrapper>>
+{
+  using Base = std::vector<
+    internal::BoolWrapper,
+    typename std::allocator_traits<AllocatorT>::
+    template rebind_alloc<internal::BoolWrapper>>;
+
+public:
+  using value_type = bool;
+  using reference = bool &;
+  using const_reference = const bool &;
+  using pointer = bool *;
+  using const_pointer = const bool *;
+  using typename Base::iterator;
+  using typename Base::const_iterator;
+  using typename Base::reverse_iterator;
+  using typename Base::const_reverse_iterator;
+  using typename Base::size_type;
+  using typename Base::difference_type;
+  using typename Base::allocator_type;
+
+  using Base::vector;
+
+  // Implicit "copy" and "move" constructors from std::vector<bool> instances
+  Vector(const std::vector<bool, AllocatorT> & other)  // NOLINT(runtime/explicit)
+  : Base(other.begin(), other.end())
+  {
+  }
+
+  Vector(std::vector<bool, AllocatorT> && other)  // NOLINT(runtime/explicit)
+  : Base(other.begin(), other.end())
+  {
+  }
+
+  // Constructor for list initialization with bool values
+  Vector(
+    std::initializer_list<bool> list,
+    const AllocatorT & allocator = AllocatorT())
+  : Base(list.begin(), list.end(), allocator)
+  {
+  }
+
+  // Assignment operator using list initializers with bool values
+  Vector & operator=(std::initializer_list<bool> list)
+  {
+    this->assign(list.begin(), list.end());
+    return *this;
+  }
+
+  // Implicit conversion to std::vector<bool>
+  operator std::vector<bool, AllocatorT>() const {
+    return std::vector<bool, AllocatorT>{
+      this->begin(), this->end(),
+      this->get_allocator()};
+  }
+};
+
+template<typename T, typename AllocatorT>
+inline void
+swap(Vector<T, AllocatorT> & x, Vector<T, AllocatorT> & y)
+{
+  x.swap(y);
+}
+
+}  // namespace rosidl_runtime_cpp
+
+#endif  // ROSIDL_RUNTIME_CPP__VECTOR_HPP_

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/vector.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/vector.hpp
@@ -101,6 +101,13 @@ public:
   : Base(other) {}
 };
 
+template<typename T, typename AllocatorT>
+inline void
+swap(Vector<T, AllocatorT> & x, Vector<T, AllocatorT> & y)
+{
+  x.swap(y);
+}
+
 /// Specialization for a boolean vector with no space optimizations.
 /**
  * This container transparently interacts with std::vector<bool>
@@ -167,11 +174,48 @@ public:
   }
 };
 
-template<typename T, typename AllocatorT>
-inline void
-swap(Vector<T, AllocatorT> & x, Vector<T, AllocatorT> & y)
+// Equality operators to compare Vector<bool> and std::vector<bool>
+template<typename AllocatorT>
+inline bool
+operator==(
+  const Vector<bool, AllocatorT> & a,
+  const std::vector<bool, AllocatorT> & b)
 {
-  x.swap(y);
+  if (a.size() != b.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < a.size(); ++i) {
+    if (a[i] != b[i]) {return false;}
+  }
+  return true;
+}
+
+template<typename AllocatorT>
+inline bool
+operator==(
+  const std::vector<bool, AllocatorT> & a,
+  const Vector<bool, AllocatorT> & b)
+{
+  return b == a;
+}
+
+// Inequality operators to compare Vector<bool> and std::vector<bool>
+template<typename AllocatorT>
+inline bool
+operator!=(
+  const Vector<bool, AllocatorT> & a,
+  const std::vector<bool, AllocatorT> & b)
+{
+  return !(a == b);
+}
+
+template<typename AllocatorT>
+inline bool
+operator!=(
+  const std::vector<bool, AllocatorT> & a,
+  const Vector<bool, AllocatorT> & b)
+{
+  return !(b == a);
 }
 
 }  // namespace rosidl_runtime_cpp

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/vector.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/vector.hpp
@@ -93,6 +93,8 @@ public:
 
   using Base::vector;
 
+  Vector() = default;
+
   // Implicit "copy" and "move" constructors from std::vector<T> instances
   Vector(const std::vector<T, AllocatorT> & other)  // NOLINT(runtime/explicit)
   : Base(other) {}
@@ -139,6 +141,8 @@ public:
   using typename Base::allocator_type;
 
   using Base::vector;
+
+  Vector() = default;
 
   // Implicit "copy" and "move" constructors from std::vector<bool> instances
   Vector(const std::vector<bool, AllocatorT> & other)  // NOLINT(runtime/explicit)

--- a/rosidl_runtime_cpp/test/test_vector.cpp
+++ b/rosidl_runtime_cpp/test/test_vector.cpp
@@ -1,0 +1,75 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <cstring>
+#include <vector>
+
+#include "rosidl_runtime_cpp/vector.hpp"
+
+namespace
+{
+
+template<typename T>
+class VectorTest : public ::testing::Test
+{
+};
+
+using SomeLiteralTypes =
+  testing::Types<bool, char, int, unsigned int>;
+TYPED_TEST_SUITE(VectorTest, SomeLiteralTypes);
+
+// cppcheck-suppress syntaxError
+TYPED_TEST(VectorTest, CanBeListInitialized) {
+  rosidl_runtime_cpp::Vector<TypeParam> vector;
+  EXPECT_TRUE(vector.empty());
+  vector = {TypeParam{0}};
+  EXPECT_EQ(vector.size(), 1u);
+  vector = {{TypeParam{0}, TypeParam{1}, TypeParam{0}}};
+  EXPECT_EQ(vector.size(), 3u);
+}
+
+TYPED_TEST(VectorTest, UsesContiguousStorage) {
+  rosidl_runtime_cpp::Vector<TypeParam> vector;
+  EXPECT_TRUE(vector.empty());
+  vector.push_back(TypeParam{0});
+  EXPECT_EQ(
+    0, std::memcmp(
+      &vector[0], &vector[0],
+      sizeof(TypeParam) * vector.size()));
+}
+
+TYPED_TEST(VectorTest, CanInteractWithStdVector) {
+  std::vector<TypeParam> std_vector{{TypeParam{0}}};
+
+  rosidl_runtime_cpp::Vector<TypeParam>
+  vector_constructed_from_std_vector{std_vector};
+  EXPECT_EQ(TypeParam{0}, vector_constructed_from_std_vector[0]);
+
+  rosidl_runtime_cpp::Vector<TypeParam>
+  vector_assigned_to_std_vector;
+  vector_assigned_to_std_vector = std_vector;
+  EXPECT_EQ(TypeParam{0}, vector_assigned_to_std_vector[0]);
+
+  rosidl_runtime_cpp::Vector<TypeParam> vector{{TypeParam{1}}};
+
+  std::vector<TypeParam> std_vector_constructed_from_vector{vector};
+  EXPECT_EQ(TypeParam{1}, std_vector_constructed_from_vector[0]);
+
+  std::vector<TypeParam> std_vector_assigned_to_vector;
+  std_vector_assigned_to_vector = vector;
+  EXPECT_EQ(TypeParam{1}, std_vector_assigned_to_vector[0]);
+}
+
+}  // namespace

--- a/rosidl_runtime_cpp/test/test_vector.cpp
+++ b/rosidl_runtime_cpp/test/test_vector.cpp
@@ -56,20 +56,24 @@ TYPED_TEST(VectorTest, CanInteractWithStdVector) {
   rosidl_runtime_cpp::Vector<TypeParam>
   vector_constructed_from_std_vector{std_vector};
   EXPECT_EQ(TypeParam{0}, vector_constructed_from_std_vector[0]);
+  EXPECT_EQ(std_vector, vector_constructed_from_std_vector);
 
   rosidl_runtime_cpp::Vector<TypeParam>
   vector_assigned_to_std_vector;
   vector_assigned_to_std_vector = std_vector;
   EXPECT_EQ(TypeParam{0}, vector_assigned_to_std_vector[0]);
+  EXPECT_EQ(std_vector, vector_assigned_to_std_vector);
 
   rosidl_runtime_cpp::Vector<TypeParam> vector{{TypeParam{1}}};
 
   std::vector<TypeParam> std_vector_constructed_from_vector{vector};
   EXPECT_EQ(TypeParam{1}, std_vector_constructed_from_vector[0]);
+  EXPECT_EQ(vector, std_vector_constructed_from_vector);
 
   std::vector<TypeParam> std_vector_assigned_to_vector;
   std_vector_assigned_to_vector = vector;
   EXPECT_EQ(TypeParam{1}, std_vector_assigned_to_vector[0]);
+  EXPECT_EQ(vector, std_vector_assigned_to_vector);
 }
 
 }  // namespace

--- a/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
+++ b/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
@@ -119,56 +119,57 @@ void @(function_prefix)__@(message.structure.namespaced_type.name)_fini_function
 }
 
 @[for member in message.structure.members]@
-@[  if isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, NamespacedType)]@
-size_t @(function_prefix)__size_function__@(member.type.value_type.name)__@(member.name)(
+@[  if isinstance(member.type, AbstractNestedType)]@
+@{from rosidl_generator_c import basetype_to_c, idl_type_to_c}@
+size_t @(function_prefix)__size_function__@(message.structure.namespaced_type.name)__@(member.name)(
   const void * untyped_member)
 {
 @[    if isinstance(member.type, Array)]@
   (void)untyped_member;
   return @(member.type.size);
 @[    else]@
-  const @('__'.join(member.type.value_type.namespaced_name()))__Sequence * member =
-    (const @('__'.join(member.type.value_type.namespaced_name()))__Sequence *)(untyped_member);
+  const @(idl_type_to_c(member.type)) * member =
+    (const @(idl_type_to_c(member.type)) *)(untyped_member);
   return member->size;
 @[    end if]@
 }
 
-const void * @(function_prefix)__get_const_function__@(member.type.value_type.name)__@(member.name)(
+const void * @(function_prefix)__get_const_function__@(message.structure.namespaced_type.name)__@(member.name)(
   const void * untyped_member, size_t index)
 {
 @[    if isinstance(member.type, Array)]@
-  const @('__'.join(member.type.value_type.namespaced_name())) * member =
-    (const @('__'.join(member.type.value_type.namespaced_name())) *)(untyped_member);
+  const @(basetype_to_c(member.type.value_type)) * member =
+    (const @(basetype_to_c(member.type.value_type)) *)(untyped_member);
   return &member[index];
 @[    else]@
-  const @('__'.join(member.type.value_type.namespaced_name()))__Sequence * member =
-    (const @('__'.join(member.type.value_type.namespaced_name()))__Sequence *)(untyped_member);
+  const @(idl_type_to_c(member.type)) * member =
+    (const @(idl_type_to_c(member.type)) *)(untyped_member);
   return &member->data[index];
 @[    end if]@
 }
 
-void * @(function_prefix)__get_function__@(member.type.value_type.name)__@(member.name)(
+void * @(function_prefix)__get_function__@(message.structure.namespaced_type.name)__@(member.name)(
   void * untyped_member, size_t index)
 {
 @[    if isinstance(member.type, Array)]@
-  @('__'.join(member.type.value_type.namespaced_name())) * member =
-    (@('__'.join(member.type.value_type.namespaced_name())) *)(untyped_member);
+  @(basetype_to_c(member.type.value_type)) * member =
+    (@(basetype_to_c(member.type.value_type)) *)(untyped_member);
   return &member[index];
 @[    else]@
-  @('__'.join(member.type.value_type.namespaced_name()))__Sequence * member =
-    (@('__'.join(member.type.value_type.namespaced_name()))__Sequence *)(untyped_member);
+  @(idl_type_to_c(member.type)) * member =
+    (@(idl_type_to_c(member.type)) *)(untyped_member);
   return &member->data[index];
 @[    end if]@
 }
 
 @[    if isinstance(member.type, AbstractSequence)]@
-bool @(function_prefix)__resize_function__@(member.type.value_type.name)__@(member.name)(
+bool @(function_prefix)__resize_function__@(message.structure.namespaced_type.name)__@(member.name)(
   void * untyped_member, size_t size)
 {
-  @('__'.join(member.type.value_type.namespaced_name()))__Sequence * member =
-    (@('__'.join(member.type.value_type.namespaced_name()))__Sequence *)(untyped_member);
-  @('__'.join(member.type.value_type.namespaced_name()))__Sequence__fini(member);
-  return @('__'.join(member.type.value_type.namespaced_name()))__Sequence__init(member, size);
+  @(idl_type_to_c(member.type)) * member =
+    (@(idl_type_to_c(member.type)) *)(untyped_member);
+  @(idl_type_to_c(member.type))__fini(member);
+  return @(idl_type_to_c(member.type))__init(member, size);
 }
 
 @[    end if]@
@@ -222,7 +223,7 @@ for index, member in enumerate(message.structure.members):
     # void * default_value_
     print('    NULL,  // default value')  # TODO default value to be set
 
-    function_suffix = ('%s__%s' % (member.type.value_type.name, member.name)) if isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, NamespacedType) else None
+    function_suffix = ('%s__%s' % (message.structure.namespaced_type.name, member.name)) if isinstance(member.type, AbstractNestedType) else None
 
     # size_t(const void *) size_function
     print('    %s,  // size() function pointer' % ('%s__size_function__%s' % (function_prefix, function_suffix) if function_suffix else 'NULL'))


### PR DESCRIPTION
Precisely what the title says. While working on typesupport introspection tests, I discovered that (a) the API for basic type arrays' introspection in C was completely missing (#598), and (b) the API for bool arrays' introspection in C++ was missing (and arguably broken due to `std::vector<bool>` quirks). 

This patch amends this by, among other things, introducing an `std::vector` subclass with its own specialization for `bool`. Note that since `std::vector<bool>` does not necessarily use contiguous storage, it makes type erased access to its elements via `void *` outright impossible (and that's exactly what introspection APIs do).