### PR TITLE
Add ROSIDL_TYPESUPPORT_INTERFACE__LIBRARY_NAME() macro

### DIFF
--- a/rosidl_typesupport_interface/include/rosidl_typesupport_interface/macros.h
+++ b/rosidl_typesupport_interface/include/rosidl_typesupport_interface/macros.h
@@ -17,7 +17,7 @@
 
 /// Declare the typesupport library name.
 #define ROSIDL_TYPESUPPORT_INTERFACE__LIBRARY_NAME( \
-    typesupport_name, package_name)  \
+    typesupport_name, package_name) \
   package_name ## __ ## typesupport_name
 
 /// Declare the typesupport symbol name. Note: this should not be called directly.

--- a/rosidl_typesupport_interface/include/rosidl_typesupport_interface/macros.h
+++ b/rosidl_typesupport_interface/include/rosidl_typesupport_interface/macros.h
@@ -15,6 +15,11 @@
 #ifndef ROSIDL_TYPESUPPORT_INTERFACE__MACROS_H_
 #define ROSIDL_TYPESUPPORT_INTERFACE__MACROS_H_
 
+/// Declare the typesupport library name.
+#define ROSIDL_TYPESUPPORT_INTERFACE__LIBRARY_NAME( \
+    typesupport_name, package_name)  \
+  package_name ## __ ## typesupport_name
+
 /// Declare the typesupport symbol name. Note: this should not be called directly.
 #define ROSIDL_TYPESUPPORT_INTERFACE__SYMBOL_NAME( \
     typesupport_name, function_name, package_name, interface_type, interface_name) \


### PR DESCRIPTION
Precisely what the title says. Code that uses typesupport (generated) APIs often has to be able to find the corresponding shared library. The pattern `<package_name>__<typesupport_name>` is relied on and recreated in several places (in this repository and downstream). This patch amends this.