### PR TITLE
Bump `rosidl_typesupport_introspection_tests` coverage

### DIFF
--- a/rosidl_typesupport_introspection_tests/CMakeLists.txt
+++ b/rosidl_typesupport_introspection_tests/CMakeLists.txt
@@ -18,6 +18,11 @@ if(BUILD_TESTING)
   find_package(rosidl_typesupport_introspection_cpp REQUIRED)
   find_package(test_interface_files REQUIRED)
 
+  # Drop BoundedPlainSequences as BoundedSequences
+  # already encompasses all the same member types
+  list(
+    FILTER test_interface_files_MSG_FILES
+    EXCLUDE REGEX ".*BoundedPlainSequences.*")
   rosidl_generate_interfaces(${PROJECT_NAME}
     ${test_interface_files_MSG_FILES}
     ${test_interface_files_SRV_FILES}

--- a/rosidl_typesupport_introspection_tests/include/rosidl_typesupport_introspection_tests/api.hpp
+++ b/rosidl_typesupport_introspection_tests/include/rosidl_typesupport_introspection_tests/api.hpp
@@ -303,7 +303,41 @@ int get_member_base_type(const MemberDescriptorT * member_descriptor)
   return member_descriptor->type_id_;
 }
 
-/// Fetch the `ith` item value of a type erased, iterable
+/// Check if a member supports direct memory access
+/// (ie. get operations) given its `member_descriptor`.
+template<typename MemberDescriptorT>
+bool has_support_for_direct_memory_access(
+  const MemberDescriptorT * member_descriptor)
+{
+  return member_descriptor->get_const_function != nullptr &&
+         member_descriptor->get_function != nullptr;
+}
+
+/// Get a reference to the `i`th item of a type erased,
+/// constant, iterable `member` given its `member_descriptor`.
+template<typename ItemT, typename MemberDescriptorT>
+const ItemT & get_member_item(
+  const void * member,
+  const MemberDescriptorT * member_descriptor,
+  const size_t i)
+{
+  return *reinterpret_cast<const ItemT *>(
+    member_descriptor->get_const_function(member, i));
+}
+
+/// Get a reference to the `i`th item of a type erased,
+/// iterable `member` given its `member_descriptor`.
+template<typename ItemT, typename MemberDescriptorT>
+ItemT & get_member_item(
+  void * member,
+  const MemberDescriptorT * member_descriptor,
+  const size_t i)
+{
+  return *reinterpret_cast<ItemT *>(
+    member_descriptor->get_function(member, i));
+}
+
+/// Fetch the `i`th item value of a type erased, iterable
 /// `member` given its `member_descriptor`.
 template<typename ItemT, typename MemberDescriptorT>
 ItemT fetch_member_item(
@@ -316,7 +350,7 @@ ItemT fetch_member_item(
   return value;
 }
 
-/// Assign a `value` to the `ith` item of a type erased,
+/// Assign a `value` to the `i`th item of a type erased,
 /// iterable `member` given its `member_descriptor`.
 template<typename ItemT, typename MemberDescriptorT>
 void assign_member_item(

--- a/rosidl_typesupport_introspection_tests/include/rosidl_typesupport_introspection_tests/api.hpp
+++ b/rosidl_typesupport_introspection_tests/include/rosidl_typesupport_introspection_tests/api.hpp
@@ -255,6 +255,18 @@ bool is_string_member(
          member_descriptor->string_upper_bound_ == upper_bound;
 }
 
+/// Check if a member is of wstring type, optionally bounded to `upper_bound`
+/// characters, given its `member_descriptor`.
+template<typename MemberDescriptorT>
+bool is_wstring_member(
+  const MemberDescriptorT * member_descriptor,
+  const size_t upper_bound = 0u)
+{
+  return member_descriptor->type_id_ == ROS_TYPE_WSTRING &&
+         member_descriptor->members_ == nullptr &&
+         member_descriptor->string_upper_bound_ == upper_bound;
+}
+
 /// Get an immutable type erased reference to a member
 /// from a type erased message given its `member_descriptor`.
 template<typename MemberDescriptorT>

--- a/rosidl_typesupport_introspection_tests/include/rosidl_typesupport_introspection_tests/gtest/macros.hpp
+++ b/rosidl_typesupport_introspection_tests/include/rosidl_typesupport_introspection_tests/gtest/macros.hpp
@@ -38,7 +38,12 @@
     for (size_t i = 0u; i < size; ++i) { \
       const auto item = fetch_member_item<member_base_type>( \
         type_erased_member, member_descriptor, i); \
-      ASSERT_EQ(item, getitem(message.member_name, i)); \
+      EXPECT_EQ(item, getitem(message.member_name, i)); \
+      if (has_support_for_direct_memory_access(member_descriptor)) { \
+        const auto & item_reference = get_member_item<member_base_type>( \
+          type_erased_member, member_descriptor, i); \
+        EXPECT_EQ(item_reference, getitem(message.member_name, i)); \
+      } \
     } \
   }
 
@@ -68,6 +73,11 @@
       assign_member_item<member_base_type>( \
         type_erased_member, member_descriptor, \
         i, deepcopy(message.member_name[i])); \
+      if (has_support_for_direct_memory_access(member_descriptor)) { \
+        auto & item_reference = get_member_item<member_base_type>( \
+          type_erased_member, member_descriptor, i); \
+        EXPECT_EQ(item_reference, message.member_name[i]); \
+      } \
     } \
   }
 
@@ -88,6 +98,11 @@
       assign_member_item<member_base_type>( \
         type_erased_member, member_descriptor, \
         i, deepcopy(getitem(message.member_name, i))); \
+      if (has_support_for_direct_memory_access(member_descriptor)) { \
+        auto & item_reference = get_member_item<member_base_type>( \
+          type_erased_member, member_descriptor, i); \
+        EXPECT_EQ(item_reference, getitem(message.member_name, i)); \
+      } \
     } \
   }
 

--- a/rosidl_typesupport_introspection_tests/include/rosidl_typesupport_introspection_tests/helpers.hpp
+++ b/rosidl_typesupport_introspection_tests/include/rosidl_typesupport_introspection_tests/helpers.hpp
@@ -203,6 +203,7 @@ getitem(const std::array<T, N> & array, const size_t index)
 
 // Extra C++ APIs to homogeneize access to rosidl_runtime_c primitives
 DEFINE_CXX_API_FOR_C_MESSAGE_MEMBER(rosidl_runtime_c__String)
+DEFINE_CXX_API_FOR_C_MESSAGE_MEMBER(rosidl_runtime_c__U16String)
 DEFINE_CXX_API_FOR_C_MESSAGE_SEQUENCE_MEMBER(rosidl_runtime_c__float__Sequence)
 DEFINE_CXX_API_FOR_C_MESSAGE_SEQUENCE_MEMBER(rosidl_runtime_c__double__Sequence)
 DEFINE_CXX_API_FOR_C_MESSAGE_SEQUENCE_MEMBER(rosidl_runtime_c__long_double__Sequence)
@@ -219,5 +220,6 @@ DEFINE_CXX_API_FOR_C_MESSAGE_SEQUENCE_MEMBER(rosidl_runtime_c__int32__Sequence)
 DEFINE_CXX_API_FOR_C_MESSAGE_SEQUENCE_MEMBER(rosidl_runtime_c__uint64__Sequence)
 DEFINE_CXX_API_FOR_C_MESSAGE_SEQUENCE_MEMBER(rosidl_runtime_c__int64__Sequence)
 DEFINE_CXX_API_FOR_C_MESSAGE_SEQUENCE_MEMBER(rosidl_runtime_c__String__Sequence)
+DEFINE_CXX_API_FOR_C_MESSAGE_SEQUENCE_MEMBER(rosidl_runtime_c__U16String__Sequence)
 
 #endif  // ROSIDL_TYPESUPPORT_INTROSPECTION_TESTS__HELPERS_HPP_

--- a/rosidl_typesupport_introspection_tests/test/introspection_libraries_under_test.hpp
+++ b/rosidl_typesupport_introspection_tests/test/introspection_libraries_under_test.hpp
@@ -352,15 +352,39 @@ struct Example<rosidl_typesupport_introspection_tests__msg__BoundedSequences>
     ReturnT message{new rosidl_typesupport_introspection_tests__msg__BoundedSequences, deleter};
     if (
       !rosidl_typesupport_introspection_tests__msg__BoundedSequences__init(message.get()) ||
-      !rosidl_runtime_c__boolean__Sequence__init(&message->bool_values, 1) ||
-      !rosidl_runtime_c__double__Sequence__init(&message->float64_values, 1) ||
-      !rosidl_runtime_c__int64__Sequence__init(&message->int64_values, 1))
+      !rosidl_runtime_c__boolean__Sequence__init(&message->bool_values, 1u) ||
+      !rosidl_runtime_c__byte__Sequence__init(&message->byte_values, 1u) ||
+      !rosidl_runtime_c__uint8__Sequence__init(&message->char_values, 1u) ||
+      !rosidl_runtime_c__float__Sequence__init(&message->float32_values, 1u) ||
+      !rosidl_runtime_c__double__Sequence__init(&message->float64_values, 1u) ||
+      !rosidl_runtime_c__int8__Sequence__init(&message->int8_values, 1u) ||
+      !rosidl_runtime_c__uint8__Sequence__init(&message->uint8_values, 1u) ||
+      !rosidl_runtime_c__int16__Sequence__init(&message->int16_values, 1u) ||
+      !rosidl_runtime_c__uint16__Sequence__init(&message->uint16_values, 1u) ||
+      !rosidl_runtime_c__int32__Sequence__init(&message->int32_values, 1u) ||
+      !rosidl_runtime_c__uint32__Sequence__init(&message->uint32_values, 1u) ||
+      !rosidl_runtime_c__int64__Sequence__init(&message->int64_values, 1u) ||
+      !rosidl_runtime_c__uint64__Sequence__init(&message->uint64_values, 1u) ||
+      !rosidl_runtime_c__String__Sequence__init(&message->string_values, 1u))
     {
       throw std::runtime_error(rcutils_get_error_string().str);
     }
     message->bool_values.data[0] = true;
+    message->byte_values.data[0] = 0x1B;
+    message->char_values.data[0] = 'z';
+    message->float32_values.data[0] = 12.34f;
     message->float64_values.data[0] = 1.234;
-    message->int64_values.data[0] = 12341234ul;
+    message->int8_values.data[0] = -64;
+    message->uint8_values.data[0] = 64u;
+    message->int16_values.data[0] = -512;
+    message->uint16_values.data[0] = 512u;
+    message->int32_values.data[0] = -262144;
+    message->uint32_values.data[0] = 262144u;
+    message->int64_values.data[0] = -12341234l;
+    message->uint64_values.data[0] = 12341234ul;
+    if (!rosidl_runtime_c__String__assign(&message->string_values.data[0], "foo")) {
+      throw std::runtime_error(rcutils_get_error_string().str);
+    }
     return message;
   }
 };
@@ -405,12 +429,22 @@ struct Example<rosidl_typesupport_introspection_tests__msg__MultiNested>
       throw std::runtime_error(rcutils_get_error_string().str);
     }
     message->array_of_arrays[1].int32_values[0] = -1234;
-    if (!rosidl_typesupport_introspection_tests__msg__Arrays__Sequence__init(
-        &message->unbounded_sequence_of_arrays, 1u))
+    if (
+      !rosidl_typesupport_introspection_tests__msg__Arrays__Sequence__init(
+        &message->bounded_sequence_of_arrays, 1u) ||
+      !rosidl_typesupport_introspection_tests__msg__BoundedSequences__Sequence__init(
+        &message->bounded_sequence_of_bounded_sequences, 1u) ||
+      !rosidl_typesupport_introspection_tests__msg__UnboundedSequences__Sequence__init(
+        &message->bounded_sequence_of_unbounded_sequences, 1u) ||
+      !rosidl_typesupport_introspection_tests__msg__Arrays__Sequence__init(
+        &message->unbounded_sequence_of_arrays, 1u) ||
+      !rosidl_typesupport_introspection_tests__msg__BoundedSequences__Sequence__init(
+        &message->unbounded_sequence_of_bounded_sequences, 1u) ||
+      !rosidl_typesupport_introspection_tests__msg__UnboundedSequences__Sequence__init(
+        &message->unbounded_sequence_of_unbounded_sequences, 1u))
     {
       throw std::runtime_error(rcutils_get_error_string().str);
     }
-    message->unbounded_sequence_of_arrays.data[0].char_values[2] = 'a';
     return message;
   }
 };
@@ -477,15 +511,39 @@ struct Example<rosidl_typesupport_introspection_tests__msg__UnboundedSequences>
     ReturnT message{new rosidl_typesupport_introspection_tests__msg__UnboundedSequences, deleter};
     if (
       !rosidl_typesupport_introspection_tests__msg__UnboundedSequences__init(message.get()) ||
-      !rosidl_runtime_c__boolean__Sequence__init(&message->bool_values, 1) ||
-      !rosidl_runtime_c__double__Sequence__init(&message->float64_values, 1) ||
-      !rosidl_runtime_c__int64__Sequence__init(&message->int64_values, 1))
+      !rosidl_runtime_c__boolean__Sequence__init(&message->bool_values, 1u) ||
+      !rosidl_runtime_c__byte__Sequence__init(&message->byte_values, 1u) ||
+      !rosidl_runtime_c__uint8__Sequence__init(&message->char_values, 1u) ||
+      !rosidl_runtime_c__float__Sequence__init(&message->float32_values, 1u) ||
+      !rosidl_runtime_c__double__Sequence__init(&message->float64_values, 1u) ||
+      !rosidl_runtime_c__int8__Sequence__init(&message->int8_values, 1u) ||
+      !rosidl_runtime_c__uint8__Sequence__init(&message->uint8_values, 1u) ||
+      !rosidl_runtime_c__int16__Sequence__init(&message->int16_values, 1u) ||
+      !rosidl_runtime_c__uint16__Sequence__init(&message->uint16_values, 1u) ||
+      !rosidl_runtime_c__int32__Sequence__init(&message->int32_values, 1u) ||
+      !rosidl_runtime_c__uint32__Sequence__init(&message->uint32_values, 1u) ||
+      !rosidl_runtime_c__int64__Sequence__init(&message->int64_values, 1u) ||
+      !rosidl_runtime_c__uint64__Sequence__init(&message->uint64_values, 1u) ||
+      !rosidl_runtime_c__String__Sequence__init(&message->string_values, 1u))
     {
       throw std::runtime_error(rcutils_get_error_string().str);
     }
     message->bool_values.data[0] = true;
+    message->byte_values.data[0] = 0x1B;
+    message->char_values.data[0] = 'z';
+    message->float32_values.data[0] = 12.34f;
     message->float64_values.data[0] = 1.234;
-    message->int64_values.data[0] = 12341234ul;
+    message->int8_values.data[0] = -64;
+    message->uint8_values.data[0] = 64u;
+    message->int16_values.data[0] = -512;
+    message->uint16_values.data[0] = 512u;
+    message->int32_values.data[0] = -262144;
+    message->uint32_values.data[0] = 262144u;
+    message->int64_values.data[0] = -12341234l;
+    message->uint64_values.data[0] = 12341234ul;
+    if (!rosidl_runtime_c__String__assign(&message->string_values.data[0], "foo")) {
+      throw std::runtime_error(rcutils_get_error_string().str);
+    }
     return message;
   }
 };
@@ -861,8 +919,22 @@ struct Example<rosidl_typesupport_introspection_tests::msg::BoundedSequences>
     auto message =
       std::make_unique<rosidl_typesupport_introspection_tests::msg::BoundedSequences>();
     message->bool_values.push_back(true);
+    message->byte_values.push_back(0x1B);
+    message->char_values.push_back('z');
+    message->float32_values.push_back(12.34f);
     message->float64_values.push_back(1.234);
-    message->int64_values.push_back(12341234ul);
+    message->int8_values.push_back(-64);
+    message->uint8_values.push_back(64u);
+    message->int16_values.push_back(-512);
+    message->uint16_values.push_back(512u);
+    message->int32_values.push_back(-262144);
+    message->uint32_values.push_back(262144u);
+    message->int64_values.push_back(-12341234l);
+    message->uint64_values.push_back(12341234ul);
+    message->string_values.push_back("foo");
+    message->basic_types_values.emplace_back();
+    message->constants_values.emplace_back();
+    message->defaults_values.emplace_back();
     return message;
   }
 };
@@ -893,6 +965,12 @@ struct Example<rosidl_typesupport_introspection_tests::msg::MultiNested>
     message->array_of_arrays[1].int32_values[0] = -1234;
     message->unbounded_sequence_of_arrays.emplace_back();
     message->unbounded_sequence_of_arrays[0].char_values[2] = 'a';
+    message->bounded_sequence_of_arrays.emplace_back();
+    message->bounded_sequence_of_bounded_sequences.emplace_back();
+    message->bounded_sequence_of_unbounded_sequences.emplace_back();
+    message->unbounded_sequence_of_arrays.emplace_back();
+    message->unbounded_sequence_of_bounded_sequences.emplace_back();
+    message->unbounded_sequence_of_unbounded_sequences.emplace_back();
     return message;
   }
 };
@@ -935,8 +1013,22 @@ struct Example<rosidl_typesupport_introspection_tests::msg::UnboundedSequences>
     auto message =
       std::make_unique<rosidl_typesupport_introspection_tests::msg::UnboundedSequences>();
     message->bool_values.push_back(true);
+    message->byte_values.push_back(0x1B);
+    message->char_values.push_back('z');
+    message->float32_values.push_back(12.34f);
     message->float64_values.push_back(1.234);
-    message->int64_values.push_back(12341234ul);
+    message->int8_values.push_back(-64);
+    message->uint8_values.push_back(64u);
+    message->int16_values.push_back(-512);
+    message->uint16_values.push_back(512u);
+    message->int32_values.push_back(-262144);
+    message->uint32_values.push_back(262144u);
+    message->int64_values.push_back(-12341234l);
+    message->uint64_values.push_back(12341234ul);
+    message->string_values.push_back("foo");
+    message->basic_types_values.emplace_back();
+    message->constants_values.emplace_back();
+    message->defaults_values.emplace_back();
     return message;
   }
 };

--- a/rosidl_typesupport_introspection_tests/test/introspection_libraries_under_test.hpp
+++ b/rosidl_typesupport_introspection_tests/test/introspection_libraries_under_test.hpp
@@ -33,8 +33,10 @@
 #include "rosidl_typesupport_introspection_tests/msg/defaults.h"
 #include "rosidl_typesupport_introspection_tests/msg/empty.h"
 #include "rosidl_typesupport_introspection_tests/msg/multi_nested.h"
+#include "rosidl_typesupport_introspection_tests/msg/nested.h"
 #include "rosidl_typesupport_introspection_tests/msg/strings.h"
 #include "rosidl_typesupport_introspection_tests/msg/unbounded_sequences.h"
+#include "rosidl_typesupport_introspection_tests/msg/w_strings.h"
 #include "rosidl_typesupport_introspection_tests/srv/arrays.h"
 #include "rosidl_typesupport_introspection_tests/srv/basic_types.h"
 #include "rosidl_typesupport_introspection_tests/srv/empty.h"
@@ -46,7 +48,9 @@
 #include "rosidl_typesupport_introspection_tests/msg/defaults.hpp"
 #include "rosidl_typesupport_introspection_tests/msg/empty.hpp"
 #include "rosidl_typesupport_introspection_tests/msg/multi_nested.hpp"
+#include "rosidl_typesupport_introspection_tests/msg/nested.hpp"
 #include "rosidl_typesupport_introspection_tests/msg/strings.hpp"
+#include "rosidl_typesupport_introspection_tests/msg/w_strings.hpp"
 #include "rosidl_typesupport_introspection_tests/msg/unbounded_sequences.hpp"
 #include "rosidl_typesupport_introspection_tests/srv/arrays.hpp"
 #include "rosidl_typesupport_introspection_tests/srv/basic_types.hpp"
@@ -65,7 +69,9 @@ DEFINE_CXX_API_FOR_C_MESSAGE(rosidl_typesupport_introspection_tests, msg, Consta
 DEFINE_CXX_API_FOR_C_MESSAGE(rosidl_typesupport_introspection_tests, msg, Defaults)
 DEFINE_CXX_API_FOR_C_MESSAGE(rosidl_typesupport_introspection_tests, msg, Empty)
 DEFINE_CXX_API_FOR_C_MESSAGE(rosidl_typesupport_introspection_tests, msg, MultiNested)
+DEFINE_CXX_API_FOR_C_MESSAGE(rosidl_typesupport_introspection_tests, msg, Nested)
 DEFINE_CXX_API_FOR_C_MESSAGE(rosidl_typesupport_introspection_tests, msg, Strings)
+DEFINE_CXX_API_FOR_C_MESSAGE(rosidl_typesupport_introspection_tests, msg, WStrings)
 DEFINE_CXX_API_FOR_C_MESSAGE(rosidl_typesupport_introspection_tests, msg, UnboundedSequences)
 DEFINE_CXX_API_FOR_C_SERVICE(rosidl_typesupport_introspection_tests, srv, Arrays)
 DEFINE_CXX_API_FOR_C_SERVICE(rosidl_typesupport_introspection_tests, srv, BasicTypes)
@@ -125,7 +131,13 @@ struct IntrospectionCTypeSupportTestLibrary
       rosidl_typesupport_introspection_tests, msg, MultiNested),
     MESSAGE_TYPESUPPORT_SYMBOL_RECORD(
       rosidl_typesupport_introspection_c,
-      rosidl_typesupport_introspection_tests, msg, UnboundedSequences)
+      rosidl_typesupport_introspection_tests, msg, Nested),
+    MESSAGE_TYPESUPPORT_SYMBOL_RECORD(
+      rosidl_typesupport_introspection_c,
+      rosidl_typesupport_introspection_tests, msg, UnboundedSequences),
+    MESSAGE_TYPESUPPORT_SYMBOL_RECORD(
+      rosidl_typesupport_introspection_c,
+      rosidl_typesupport_introspection_tests, msg, WStrings)
   };
   static constexpr const ServiceTypeSupportSymbolRecord services[] = {
     SERVICE_TYPESUPPORT_SYMBOL_RECORD(
@@ -212,6 +224,15 @@ struct introspection_traits<rosidl_typesupport_introspection_tests__msg__MultiNe
 };
 
 template<>
+struct introspection_traits<rosidl_typesupport_introspection_tests__msg__Nested>
+{
+  static constexpr const MessageTypeSupportSymbolRecord typesupport =
+    MESSAGE_TYPESUPPORT_SYMBOL_RECORD(
+    rosidl_typesupport_introspection_c, rosidl_typesupport_introspection_tests, msg, Nested);
+  using TypeSupportLibraryT = IntrospectionCTypeSupportTestLibrary;
+};
+
+template<>
 struct introspection_traits<rosidl_typesupport_introspection_tests__msg__Strings>
 {
   static constexpr const MessageTypeSupportSymbolRecord typesupport =
@@ -227,6 +248,15 @@ struct introspection_traits<rosidl_typesupport_introspection_tests__msg__Unbound
     MESSAGE_TYPESUPPORT_SYMBOL_RECORD(
     rosidl_typesupport_introspection_c, rosidl_typesupport_introspection_tests, msg,
     UnboundedSequences);
+  using TypeSupportLibraryT = IntrospectionCTypeSupportTestLibrary;
+};
+
+template<>
+struct introspection_traits<rosidl_typesupport_introspection_tests__msg__WStrings>
+{
+  static constexpr const MessageTypeSupportSymbolRecord typesupport =
+    MESSAGE_TYPESUPPORT_SYMBOL_RECORD(
+    rosidl_typesupport_introspection_c, rosidl_typesupport_introspection_tests, msg, WStrings);
   using TypeSupportLibraryT = IntrospectionCTypeSupportTestLibrary;
 };
 
@@ -336,6 +366,29 @@ struct Example<rosidl_typesupport_introspection_tests__msg__BoundedSequences>
 };
 
 template<>
+struct Example<rosidl_typesupport_introspection_tests__msg__Defaults>
+{
+  static auto Make()
+  {
+    using ReturnT = std::unique_ptr<
+      rosidl_typesupport_introspection_tests__msg__Defaults,
+      std::function<void (rosidl_typesupport_introspection_tests__msg__Defaults *)>>;
+    auto deleter = [](rosidl_typesupport_introspection_tests__msg__Defaults * message) {
+        rosidl_typesupport_introspection_tests__msg__Defaults__fini(message);
+        delete message;
+      };
+    ReturnT message{new rosidl_typesupport_introspection_tests__msg__Defaults, deleter};
+    if (!rosidl_typesupport_introspection_tests__msg__Defaults__init(message.get())) {
+      throw std::runtime_error(rcutils_get_error_string().str);
+    }
+    message->bool_value = !message->bool_value;
+    message->uint32_value = message->uint32_value / 2u;
+    message->float64_value = -message->float64_value;
+    return message;
+  }
+};
+
+template<>
 struct Example<rosidl_typesupport_introspection_tests__msg__MultiNested>
 {
   static auto Make()
@@ -358,6 +411,29 @@ struct Example<rosidl_typesupport_introspection_tests__msg__MultiNested>
       throw std::runtime_error(rcutils_get_error_string().str);
     }
     message->unbounded_sequence_of_arrays.data[0].char_values[2] = 'a';
+    return message;
+  }
+};
+
+template<>
+struct Example<rosidl_typesupport_introspection_tests__msg__Nested>
+{
+  static auto Make()
+  {
+    using ReturnT = std::unique_ptr<
+      rosidl_typesupport_introspection_tests__msg__Nested,
+      std::function<void (rosidl_typesupport_introspection_tests__msg__Nested *)>>;
+    auto deleter = [](rosidl_typesupport_introspection_tests__msg__Nested * message) {
+        rosidl_typesupport_introspection_tests__msg__Nested__fini(message);
+        delete message;
+      };
+    ReturnT message{new rosidl_typesupport_introspection_tests__msg__Nested, deleter};
+    if (!rosidl_typesupport_introspection_tests__msg__Nested__init(message.get())) {
+      throw std::runtime_error(rcutils_get_error_string().str);
+    }
+    message->basic_types_value.bool_value = true;
+    message->basic_types_value.char_value = 'x';
+    message->basic_types_value.int16_value = -4321;
     return message;
   }
 };
@@ -410,6 +486,31 @@ struct Example<rosidl_typesupport_introspection_tests__msg__UnboundedSequences>
     message->bool_values.data[0] = true;
     message->float64_values.data[0] = 1.234;
     message->int64_values.data[0] = 12341234ul;
+    return message;
+  }
+};
+
+template<>
+struct Example<rosidl_typesupport_introspection_tests__msg__WStrings>
+{
+  static auto Make()
+  {
+    using ReturnT = std::unique_ptr<
+      rosidl_typesupport_introspection_tests__msg__WStrings,
+      std::function<void (rosidl_typesupport_introspection_tests__msg__WStrings *)>>;
+    auto deleter = [](rosidl_typesupport_introspection_tests__msg__WStrings * message) {
+        rosidl_typesupport_introspection_tests__msg__WStrings__fini(message);
+        delete message;
+      };
+
+    ReturnT message{new rosidl_typesupport_introspection_tests__msg__WStrings, deleter};
+    const uint16_t wstring_value[] = {50097u, 117u, 0u};
+    if (
+      !rosidl_typesupport_introspection_tests__msg__WStrings__init(message.get()) ||
+      !rosidl_runtime_c__U16String__assign(&message->wstring_value, wstring_value))
+    {
+      throw std::runtime_error(rcutils_get_error_string().str);
+    }
     return message;
   }
 };
@@ -550,10 +651,16 @@ struct IntrospectionCppTypeSupportTestLibrary
       rosidl_typesupport_introspection_tests, msg, MultiNested),
     MESSAGE_TYPESUPPORT_SYMBOL_RECORD(
       rosidl_typesupport_introspection_cpp,
+      rosidl_typesupport_introspection_tests, msg, Nested),
+    MESSAGE_TYPESUPPORT_SYMBOL_RECORD(
+      rosidl_typesupport_introspection_cpp,
       rosidl_typesupport_introspection_tests, msg, Strings),
     MESSAGE_TYPESUPPORT_SYMBOL_RECORD(
       rosidl_typesupport_introspection_cpp,
-      rosidl_typesupport_introspection_tests, msg, UnboundedSequences)
+      rosidl_typesupport_introspection_tests, msg, UnboundedSequences),
+    MESSAGE_TYPESUPPORT_SYMBOL_RECORD(
+      rosidl_typesupport_introspection_cpp,
+      rosidl_typesupport_introspection_tests, msg, WStrings)
   };
   static constexpr const ServiceTypeSupportSymbolRecord services[] = {
     SERVICE_TYPESUPPORT_SYMBOL_RECORD(
@@ -645,6 +752,16 @@ struct introspection_traits<rosidl_typesupport_introspection_tests::msg::MultiNe
 };
 
 template<>
+struct introspection_traits<rosidl_typesupport_introspection_tests::msg::Nested>
+{
+  static constexpr const MessageTypeSupportSymbolRecord typesupport =
+    MESSAGE_TYPESUPPORT_SYMBOL_RECORD(
+    rosidl_typesupport_introspection_cpp,
+    rosidl_typesupport_introspection_tests, msg, Nested);
+  using TypeSupportLibraryT = IntrospectionCppTypeSupportTestLibrary;
+};
+
+template<>
 struct introspection_traits<rosidl_typesupport_introspection_tests::msg::Strings>
 {
   static constexpr const MessageTypeSupportSymbolRecord typesupport =
@@ -661,6 +778,16 @@ struct introspection_traits<rosidl_typesupport_introspection_tests::msg::Unbound
     MESSAGE_TYPESUPPORT_SYMBOL_RECORD(
     rosidl_typesupport_introspection_cpp,
     rosidl_typesupport_introspection_tests, msg, UnboundedSequences);
+  using TypeSupportLibraryT = IntrospectionCppTypeSupportTestLibrary;
+};
+
+template<>
+struct introspection_traits<rosidl_typesupport_introspection_tests::msg::WStrings>
+{
+  static constexpr const MessageTypeSupportSymbolRecord typesupport =
+    MESSAGE_TYPESUPPORT_SYMBOL_RECORD(
+    rosidl_typesupport_introspection_cpp,
+    rosidl_typesupport_introspection_tests, msg, WStrings);
   using TypeSupportLibraryT = IntrospectionCppTypeSupportTestLibrary;
 };
 
@@ -741,6 +868,21 @@ struct Example<rosidl_typesupport_introspection_tests::msg::BoundedSequences>
 };
 
 template<>
+struct Example<rosidl_typesupport_introspection_tests::msg::Defaults>
+{
+  static
+  std::unique_ptr<rosidl_typesupport_introspection_tests::msg::Defaults> Make()
+  {
+    auto message =
+      std::make_unique<rosidl_typesupport_introspection_tests::msg::Defaults>();
+    message->bool_value = !message->bool_value;
+    message->uint32_value = message->uint32_value / 2u;
+    message->float64_value = -message->float64_value;
+    return message;
+  }
+};
+
+template<>
 struct Example<rosidl_typesupport_introspection_tests::msg::MultiNested>
 {
   static
@@ -751,6 +893,21 @@ struct Example<rosidl_typesupport_introspection_tests::msg::MultiNested>
     message->array_of_arrays[1].int32_values[0] = -1234;
     message->unbounded_sequence_of_arrays.emplace_back();
     message->unbounded_sequence_of_arrays[0].char_values[2] = 'a';
+    return message;
+  }
+};
+
+template<>
+struct Example<rosidl_typesupport_introspection_tests::msg::Nested>
+{
+  static
+  std::unique_ptr<rosidl_typesupport_introspection_tests::msg::Nested> Make()
+  {
+    auto message =
+      std::make_unique<rosidl_typesupport_introspection_tests::msg::Nested>();
+    message->basic_types_value.bool_value = true;
+    message->basic_types_value.char_value = 'x';
+    message->basic_types_value.int16_value = -4321;
     return message;
   }
 };
@@ -780,6 +937,19 @@ struct Example<rosidl_typesupport_introspection_tests::msg::UnboundedSequences>
     message->bool_values.push_back(true);
     message->float64_values.push_back(1.234);
     message->int64_values.push_back(12341234ul);
+    return message;
+  }
+};
+
+template<>
+struct Example<rosidl_typesupport_introspection_tests::msg::WStrings>
+{
+  static
+  std::unique_ptr<rosidl_typesupport_introspection_tests::msg::WStrings> Make()
+  {
+    auto message =
+      std::make_unique<rosidl_typesupport_introspection_tests::msg::WStrings>();
+    message->wstring_value = u"ñu";
     return message;
   }
 };

--- a/rosidl_typesupport_introspection_tests/test/test_arrays_message_introspection.cpp
+++ b/rosidl_typesupport_introspection_tests/test/test_arrays_message_introspection.cpp
@@ -55,6 +55,7 @@ TYPED_TEST(ArraysMessageIntrospectionTest, MessageDescriptorIsCorrect)
     get_message_namespace(message_descriptor),
     TypeSupportLibraryT::messages_namespace);
   EXPECT_STREQ(get_message_name(message_descriptor), "Arrays");
+  EXPECT_EQ(get_message_size(message_descriptor), sizeof(ArraysMessageT));
   ASSERT_EQ(get_member_count(message_descriptor), 32u);
 
   {

--- a/rosidl_typesupport_introspection_tests/test/test_bounded_sequences_message_introspection.cpp
+++ b/rosidl_typesupport_introspection_tests/test/test_bounded_sequences_message_introspection.cpp
@@ -55,6 +55,7 @@ TYPED_TEST(BoundedSequencesMessageIntrospectionTest, MessageDescriptorIsCorrect)
     get_message_namespace(message_descriptor),
     TypeSupportLibraryT::messages_namespace);
   EXPECT_STREQ(get_message_name(message_descriptor), "BoundedSequences");
+  EXPECT_EQ(get_message_size(message_descriptor), sizeof(BoundedSequencesMessageT));
   ASSERT_EQ(get_member_count(message_descriptor), 32u);
 
   {

--- a/rosidl_typesupport_introspection_tests/test/test_constants_message_introspection.cpp
+++ b/rosidl_typesupport_introspection_tests/test/test_constants_message_introspection.cpp
@@ -1,0 +1,61 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "rosidl_typesupport_introspection_tests/gtest/message_introspection_test.hpp"
+#include "rosidl_typesupport_introspection_tests/api.hpp"
+#include "rosidl_typesupport_introspection_tests/type_traits.hpp"
+
+#include "introspection_libraries_under_test.hpp"
+
+namespace rosidl_typesupport_introspection_tests
+{
+namespace testing
+{
+namespace
+{
+
+template<typename ConstantsMessageT>
+class ConstantsMessageIntrospectionTest
+  : public MessageIntrospectionTest<ConstantsMessageT>
+{
+};
+
+using ConstantsMessageTypes = ::testing::Types<
+  rosidl_typesupport_introspection_tests__msg__Constants,
+  rosidl_typesupport_introspection_tests::msg::Constants>;
+TYPED_TEST_SUITE(ConstantsMessageIntrospectionTest, ConstantsMessageTypes);
+
+// NOTE(hidmic): cppcheck complains about gtest macros
+// cppcheck-suppress syntaxError
+TYPED_TEST(ConstantsMessageIntrospectionTest, MessageDescriptorIsCorrect)
+{
+  using ConstantsMessageT = TypeParam;
+  using TypeSupportLibraryT =
+    typename introspection_traits<ConstantsMessageT>::TypeSupportLibraryT;
+  using MessageDescriptorT = typename TypeSupportLibraryT::MessageDescriptorT;
+
+  const MessageDescriptorT * message_descriptor = this->GetMessageDescriptor();
+  EXPECT_STREQ(
+    get_message_namespace(message_descriptor),
+    TypeSupportLibraryT::messages_namespace);
+  EXPECT_STREQ(get_message_name(message_descriptor), "Constants");
+  EXPECT_EQ(get_message_size(message_descriptor), sizeof(ConstantsMessageT));
+  EXPECT_EQ(get_member_count(message_descriptor), 1u);
+}
+
+}  // namespace
+}  // namespace testing
+}  // namespace rosidl_typesupport_introspection_tests

--- a/rosidl_typesupport_introspection_tests/test/test_constants_message_introspection.cpp
+++ b/rosidl_typesupport_introspection_tests/test/test_constants_message_introspection.cpp
@@ -56,6 +56,15 @@ TYPED_TEST(ConstantsMessageIntrospectionTest, MessageDescriptorIsCorrect)
   EXPECT_EQ(get_member_count(message_descriptor), 1u);
 }
 
+TYPED_TEST(ConstantsMessageIntrospectionTest, CanConstructTypeErasedMessage)
+{
+  using ConstantsMessageT = TypeParam;
+  auto type_erased_message = this->MakeTypeErasedMessage();
+  const ConstantsMessageT & message =
+    *reinterpret_cast<ConstantsMessageT *>(type_erased_message.get());
+  EXPECT_EQ(message, message);
+}
+
 }  // namespace
 }  // namespace testing
 }  // namespace rosidl_typesupport_introspection_tests

--- a/rosidl_typesupport_introspection_tests/test/test_defaults_message_introspection.cpp
+++ b/rosidl_typesupport_introspection_tests/test/test_defaults_message_introspection.cpp
@@ -29,33 +29,33 @@ namespace testing
 namespace
 {
 
-template<typename BasicTypesMessageT>
-class BasicTypesMessageIntrospectionTest
-  : public MessageIntrospectionTest<BasicTypesMessageT>
+template<typename DefaultsMessageT>
+class DefaultsMessageIntrospectionTest
+  : public MessageIntrospectionTest<DefaultsMessageT>
 {
 };
 
-using BasicTypesMessageTypes = ::testing::Types<
-  rosidl_typesupport_introspection_tests__msg__BasicTypes,
-  rosidl_typesupport_introspection_tests::msg::BasicTypes>;
-TYPED_TEST_SUITE(BasicTypesMessageIntrospectionTest, BasicTypesMessageTypes);
+using DefaultsMessageTypes = ::testing::Types<
+  rosidl_typesupport_introspection_tests__msg__Defaults,
+  rosidl_typesupport_introspection_tests::msg::Defaults>;
+TYPED_TEST_SUITE(DefaultsMessageIntrospectionTest, DefaultsMessageTypes);
 
 // NOTE(hidmic): cppcheck complains about gtest macros
 // cppcheck-suppress syntaxError
-TYPED_TEST(BasicTypesMessageIntrospectionTest, MessageDescriptorIsCorrect)
+TYPED_TEST(DefaultsMessageIntrospectionTest, MessageDescriptorIsCorrect)
 {
-  using BasicTypesMessageT = TypeParam;
+  using DefaultsMessageT = TypeParam;
 
   using TypeSupportLibraryT =
-    typename introspection_traits<BasicTypesMessageT>::TypeSupportLibraryT;
+    typename introspection_traits<DefaultsMessageT>::TypeSupportLibraryT;
   using MessageDescriptorT = typename TypeSupportLibraryT::MessageDescriptorT;
   const MessageDescriptorT * message_descriptor = this->GetMessageDescriptor();
 
   EXPECT_STREQ(
     get_message_namespace(message_descriptor),
     TypeSupportLibraryT::messages_namespace);
-  EXPECT_STREQ(get_message_name(message_descriptor), "BasicTypes");
-  EXPECT_EQ(get_message_size(message_descriptor), sizeof(BasicTypesMessageT));
+  EXPECT_STREQ(get_message_name(message_descriptor), "Defaults");
+  EXPECT_EQ(get_message_size(message_descriptor), sizeof(DefaultsMessageT));
   ASSERT_EQ(get_member_count(message_descriptor), 13u);
 
   {
@@ -151,16 +151,16 @@ TYPED_TEST(BasicTypesMessageIntrospectionTest, MessageDescriptorIsCorrect)
   }
 }
 
-TYPED_TEST(BasicTypesMessageIntrospectionTest, CanReadTypeErasedMessage)
+TYPED_TEST(DefaultsMessageIntrospectionTest, CanReadTypeErasedMessage)
 {
-  using BasicTypesMessageT = TypeParam;
+  using DefaultsMessageT = TypeParam;
 
-  const auto message_ptr = Example<BasicTypesMessageT>::Make();
-  const BasicTypesMessageT & message = *message_ptr;
+  const auto message_ptr = Example<DefaultsMessageT>::Make();
+  const DefaultsMessageT & message = *message_ptr;
   const void * type_erased_message = message_ptr.get();
 
   using TypeSupportLibraryT =
-    typename introspection_traits<BasicTypesMessageT>::TypeSupportLibraryT;
+    typename introspection_traits<DefaultsMessageT>::TypeSupportLibraryT;
   using MessageDescriptorT = typename TypeSupportLibraryT::MessageDescriptorT;
   const MessageDescriptorT * message_descriptor = this->GetMessageDescriptor();
   ASSERT_EQ(get_member_count(message_descriptor), 13u);
@@ -218,20 +218,20 @@ TYPED_TEST(BasicTypesMessageIntrospectionTest, CanReadTypeErasedMessage)
     get_member_descriptor(message_descriptor, 12u));
 }
 
-TYPED_TEST(BasicTypesMessageIntrospectionTest, CanWriteTypeErasedMessage)
+TYPED_TEST(DefaultsMessageIntrospectionTest, CanWriteTypeErasedMessage)
 {
-  using BasicTypesMessageT = TypeParam;
+  using DefaultsMessageT = TypeParam;
 
-  const auto message_ptr = Example<BasicTypesMessageT>::Make();
-  const BasicTypesMessageT & message = *message_ptr;
+  const auto message_ptr = Example<DefaultsMessageT>::Make();
+  const DefaultsMessageT & message = *message_ptr;
 
   auto type_erased_message_copy = this->MakeTypeErasedMessage();
-  const BasicTypesMessageT & message_copy =
-    *reinterpret_cast<BasicTypesMessageT *>(type_erased_message_copy.get());
+  const DefaultsMessageT & message_copy =
+    *reinterpret_cast<DefaultsMessageT *>(type_erased_message_copy.get());
   EXPECT_NE(message, message_copy);
 
   using TypeSupportLibraryT =
-    typename introspection_traits<BasicTypesMessageT>::TypeSupportLibraryT;
+    typename introspection_traits<DefaultsMessageT>::TypeSupportLibraryT;
   using MessageDescriptorT = typename TypeSupportLibraryT::MessageDescriptorT;
   const MessageDescriptorT * message_descriptor = this->GetMessageDescriptor();
   ASSERT_EQ(get_member_count(message_descriptor), 13u);

--- a/rosidl_typesupport_introspection_tests/test/test_empty_message_introspection.cpp
+++ b/rosidl_typesupport_introspection_tests/test/test_empty_message_introspection.cpp
@@ -56,6 +56,15 @@ TYPED_TEST(EmptyMessageIntrospectionTest, MessageDescriptorIsCorrect)
   EXPECT_EQ(get_member_count(message_descriptor), 1u);
 }
 
+TYPED_TEST(EmptyMessageIntrospectionTest, CanConstructTypeErasedMessage)
+{
+  using EmptyMessageT = TypeParam;
+  auto type_erased_message = this->MakeTypeErasedMessage();
+  const EmptyMessageT & message =
+    *reinterpret_cast<EmptyMessageT *>(type_erased_message.get());
+  EXPECT_EQ(message, message);
+}
+
 }  // namespace
 }  // namespace testing
 }  // namespace rosidl_typesupport_introspection_tests

--- a/rosidl_typesupport_introspection_tests/test/test_empty_service_introspection.cpp
+++ b/rosidl_typesupport_introspection_tests/test/test_empty_service_introspection.cpp
@@ -45,6 +45,8 @@ TYPED_TEST_SUITE(EmptyServiceIntrospectionTest, EmptyServiceTypes);
 TYPED_TEST(EmptyServiceIntrospectionTest, ServiceDescriptorIsCorrect)
 {
   using EmptyServiceT = TypeParam;
+  using RequestMessageT = typename EmptyServiceT::Request;
+  using ResponseMessageT = typename EmptyServiceT::Response;
 
   using TypeSupportLibraryT =
     typename introspection_traits<EmptyServiceT>::TypeSupportLibraryT;
@@ -65,7 +67,7 @@ TYPED_TEST(EmptyServiceIntrospectionTest, ServiceDescriptorIsCorrect)
   EXPECT_STREQ(get_message_name(request_message_descriptor), "Empty_Request");
   EXPECT_EQ(
     get_message_size(request_message_descriptor),
-    sizeof(typename EmptyServiceT::Request));
+    sizeof(RequestMessageT));
   const MessageDescriptorT * response_message_descriptor =
     get_service_response_descriptor(service_descriptor);
   EXPECT_STREQ(
@@ -74,7 +76,33 @@ TYPED_TEST(EmptyServiceIntrospectionTest, ServiceDescriptorIsCorrect)
   EXPECT_STREQ(get_message_name(response_message_descriptor), "Empty_Response");
   EXPECT_EQ(
     get_message_size(response_message_descriptor),
-    sizeof(typename EmptyServiceT::Response));
+    sizeof(ResponseMessageT));
+}
+
+TYPED_TEST(EmptyServiceIntrospectionTest, CanConstructTypeErasedRequestMessage)
+{
+  using EmptyServiceT = TypeParam;
+  using RequestMessageT = typename EmptyServiceT::Request;
+
+  auto type_erased_request_message =
+    this->MakeTypeErasedRequestMessage();
+  const RequestMessageT & request_message =
+    *reinterpret_cast<RequestMessageT *>(
+    type_erased_request_message.get());
+  EXPECT_EQ(request_message, request_message);
+}
+
+TYPED_TEST(EmptyServiceIntrospectionTest, CanConstructTypeErasedResponseMessage)
+{
+  using EmptyServiceT = TypeParam;
+  using ResponseMessageT = typename EmptyServiceT::Response;
+
+  auto type_erased_response_message =
+    this->MakeTypeErasedResponseMessage();
+  const ResponseMessageT & response_message =
+    *reinterpret_cast<ResponseMessageT *>(
+    type_erased_response_message.get());
+  EXPECT_EQ(response_message, response_message);
 }
 
 }  // namespace

--- a/rosidl_typesupport_introspection_tests/test/test_multi_nested_message_introspection.cpp
+++ b/rosidl_typesupport_introspection_tests/test/test_multi_nested_message_introspection.cpp
@@ -55,6 +55,7 @@ TYPED_TEST(MultiNestedMessageIntrospectionTest, MessageDescriptorIsCorrect)
     get_message_namespace(message_descriptor),
     TypeSupportLibraryT::messages_namespace);
   EXPECT_STREQ(get_message_name(message_descriptor), "MultiNested");
+  EXPECT_EQ(get_message_size(message_descriptor), sizeof(MultiNestedMessageT));
   ASSERT_EQ(get_member_count(message_descriptor), 9u);
 
   {

--- a/rosidl_typesupport_introspection_tests/test/test_nested_message_introspection.cpp
+++ b/rosidl_typesupport_introspection_tests/test/test_nested_message_introspection.cpp
@@ -1,0 +1,117 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "rosidl_typesupport_introspection_tests/fixtures.hpp"
+#include "rosidl_typesupport_introspection_tests/gtest/macros.hpp"
+#include "rosidl_typesupport_introspection_tests/gtest/message_introspection_test.hpp"
+#include "rosidl_typesupport_introspection_tests/api.hpp"
+#include "rosidl_typesupport_introspection_tests/type_traits.hpp"
+
+#include "introspection_libraries_under_test.hpp"
+
+namespace rosidl_typesupport_introspection_tests
+{
+namespace testing
+{
+namespace
+{
+
+template<typename NestedMessageT>
+class NestedMessageIntrospectionTest
+  : public MessageIntrospectionTest<NestedMessageT>
+{
+};
+
+using NestedMessageTypes = ::testing::Types<
+  rosidl_typesupport_introspection_tests__msg__Nested,
+  rosidl_typesupport_introspection_tests::msg::Nested>;
+TYPED_TEST_SUITE(NestedMessageIntrospectionTest, NestedMessageTypes);
+
+// NOTE(hidmic): cppcheck complains about gtest macros
+// cppcheck-suppress syntaxError
+TYPED_TEST(NestedMessageIntrospectionTest, MessageDescriptorIsCorrect)
+{
+  using NestedMessageT = TypeParam;
+
+  using TypeSupportLibraryT =
+    typename introspection_traits<NestedMessageT>::TypeSupportLibraryT;
+  using MessageDescriptorT = typename TypeSupportLibraryT::MessageDescriptorT;
+  const MessageDescriptorT * message_descriptor = this->GetMessageDescriptor();
+
+  EXPECT_STREQ(
+    get_message_namespace(message_descriptor),
+    TypeSupportLibraryT::messages_namespace);
+  EXPECT_STREQ(get_message_name(message_descriptor), "Nested");
+  EXPECT_EQ(get_message_size(message_descriptor), sizeof(NestedMessageT));
+  ASSERT_EQ(get_member_count(message_descriptor), 1u);
+
+  {
+    auto * member_descriptor = get_member_descriptor(message_descriptor, 0u);
+    EXPECT_STREQ(get_member_name(member_descriptor), "basic_types_value");
+    using member_base_type =
+      MEMBER_EXPRESSION_TYPE(NestedMessageT, basic_types_value);
+    EXPECT_TRUE(is_message_type_member<member_base_type>(member_descriptor));
+    EXPECT_TRUE(has_simple_structure(member_descriptor));
+  }
+}
+
+TYPED_TEST(NestedMessageIntrospectionTest, CanReadTypeErasedMessage)
+{
+  using NestedMessageT = TypeParam;
+
+  const auto message_ptr = Example<NestedMessageT>::Make();
+  const NestedMessageT & message = *message_ptr;
+  const void * type_erased_message = message_ptr.get();
+
+  using TypeSupportLibraryT =
+    typename introspection_traits<NestedMessageT>::TypeSupportLibraryT;
+  using MessageDescriptorT = typename TypeSupportLibraryT::MessageDescriptorT;
+  const MessageDescriptorT * message_descriptor = this->GetMessageDescriptor();
+  ASSERT_EQ(get_member_count(message_descriptor), 1u);
+
+  EXPECT_MEMBER_EQ(
+    type_erased_message, message, basic_types_value,
+    get_member_descriptor(message_descriptor, 0u));
+}
+
+TYPED_TEST(NestedMessageIntrospectionTest, CanWriteTypeErasedMessage)
+{
+  using NestedMessageT = TypeParam;
+
+  const auto message_ptr = Example<NestedMessageT>::Make();
+  const NestedMessageT & message = *message_ptr;
+
+  auto type_erased_message_copy = this->MakeTypeErasedMessage();
+  const NestedMessageT & message_copy =
+    *reinterpret_cast<NestedMessageT *>(type_erased_message_copy.get());
+  EXPECT_NE(message, message_copy);
+
+  using TypeSupportLibraryT =
+    typename introspection_traits<NestedMessageT>::TypeSupportLibraryT;
+  using MessageDescriptorT = typename TypeSupportLibraryT::MessageDescriptorT;
+  const MessageDescriptorT * message_descriptor = this->GetMessageDescriptor();
+  ASSERT_EQ(get_member_count(message_descriptor), 1u);
+
+  EXPECT_MEMBER_ASSIGNMENT(
+    type_erased_message_copy.get(), message, basic_types_value,
+    get_member_descriptor(message_descriptor, 0u));
+
+  EXPECT_EQ(message, message_copy);
+}
+
+}  // namespace
+}  // namespace testing
+}  // namespace rosidl_typesupport_introspection_tests

--- a/rosidl_typesupport_introspection_tests/test/test_strings_message_introspection.cpp
+++ b/rosidl_typesupport_introspection_tests/test/test_strings_message_introspection.cpp
@@ -55,6 +55,7 @@ TYPED_TEST(StringsMessageIntrospectionTest, MessageDescriptorIsCorrect)
     get_message_namespace(message_descriptor),
     TypeSupportLibraryT::messages_namespace);
   EXPECT_STREQ(get_message_name(message_descriptor), "Strings");
+  EXPECT_EQ(get_message_size(message_descriptor), sizeof(StringsMessageT));
   ASSERT_EQ(get_member_count(message_descriptor), 12u);
 
   {

--- a/rosidl_typesupport_introspection_tests/test/test_unbounded_sequences_message_introspection.cpp
+++ b/rosidl_typesupport_introspection_tests/test/test_unbounded_sequences_message_introspection.cpp
@@ -55,6 +55,9 @@ TYPED_TEST(UnboundedSequencesMessageIntrospectionTest, MessageDescriptorIsCorrec
     get_message_namespace(message_descriptor),
     TypeSupportLibraryT::messages_namespace);
   EXPECT_STREQ(get_message_name(message_descriptor), "UnboundedSequences");
+  EXPECT_EQ(
+    get_message_size(message_descriptor),
+    sizeof(UnboundedSequencesMessageT));
   ASSERT_EQ(get_member_count(message_descriptor), 32u);
 
   {

--- a/rosidl_typesupport_introspection_tests/test/test_wstrings_message_introspection.cpp
+++ b/rosidl_typesupport_introspection_tests/test/test_wstrings_message_introspection.cpp
@@ -1,0 +1,205 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "rosidl_typesupport_introspection_tests/fixtures.hpp"
+#include "rosidl_typesupport_introspection_tests/gtest/macros.hpp"
+#include "rosidl_typesupport_introspection_tests/gtest/message_introspection_test.hpp"
+#include "rosidl_typesupport_introspection_tests/api.hpp"
+#include "rosidl_typesupport_introspection_tests/type_traits.hpp"
+
+#include "introspection_libraries_under_test.hpp"
+
+namespace rosidl_typesupport_introspection_tests
+{
+namespace testing
+{
+namespace
+{
+
+template<typename WStringsMessageT>
+class WStringsMessageIntrospectionTest
+  : public MessageIntrospectionTest<WStringsMessageT>
+{
+};
+
+using WStringsMessageTypes = ::testing::Types<
+  rosidl_typesupport_introspection_tests__msg__WStrings,
+  rosidl_typesupport_introspection_tests::msg::WStrings>;
+TYPED_TEST_SUITE(WStringsMessageIntrospectionTest, WStringsMessageTypes);
+
+// NOTE(hidmic): cppcheck complains about gtest macros
+// cppcheck-suppress syntaxError
+TYPED_TEST(WStringsMessageIntrospectionTest, MessageDescriptorIsCorrect)
+{
+  using WStringsMessageT = TypeParam;
+
+  using TypeSupportLibraryT =
+    typename introspection_traits<WStringsMessageT>::TypeSupportLibraryT;
+  using MessageDescriptorT = typename TypeSupportLibraryT::MessageDescriptorT;
+  const MessageDescriptorT * message_descriptor = this->GetMessageDescriptor();
+
+  EXPECT_STREQ(
+    get_message_namespace(message_descriptor),
+    TypeSupportLibraryT::messages_namespace);
+  EXPECT_STREQ(get_message_name(message_descriptor), "WStrings");
+  EXPECT_EQ(get_message_size(message_descriptor), sizeof(WStringsMessageT));
+  ASSERT_EQ(get_member_count(message_descriptor), 7u);
+
+  {
+    auto * member_descriptor = get_member_descriptor(message_descriptor, 0u);
+    EXPECT_STREQ(get_member_name(member_descriptor), "wstring_value");
+    EXPECT_TRUE(is_wstring_member(member_descriptor));
+    EXPECT_TRUE(has_simple_structure(member_descriptor));
+  }
+
+  {
+    auto * member_descriptor = get_member_descriptor(message_descriptor, 1u);
+    EXPECT_STREQ(get_member_name(member_descriptor), "wstring_value_default1");
+    EXPECT_TRUE(is_wstring_member(member_descriptor));
+    EXPECT_TRUE(has_simple_structure(member_descriptor));
+  }
+
+  {
+    auto * member_descriptor = get_member_descriptor(message_descriptor, 2u);
+    EXPECT_STREQ(get_member_name(member_descriptor), "wstring_value_default2");
+    EXPECT_TRUE(is_wstring_member(member_descriptor));
+    EXPECT_TRUE(has_simple_structure(member_descriptor));
+  }
+
+  {
+    auto * member_descriptor = get_member_descriptor(message_descriptor, 3u);
+    EXPECT_STREQ(get_member_name(member_descriptor), "wstring_value_default3");
+    EXPECT_TRUE(is_wstring_member(member_descriptor));
+    EXPECT_TRUE(has_simple_structure(member_descriptor));
+  }
+
+  {
+    auto * member_descriptor = get_member_descriptor(message_descriptor, 4u);
+    EXPECT_STREQ(get_member_name(member_descriptor), "array_of_wstrings");
+    EXPECT_TRUE(is_wstring_member(member_descriptor));
+    EXPECT_TRUE(has_array_structure(member_descriptor, 3u));
+  }
+
+  {
+    auto * member_descriptor = get_member_descriptor(message_descriptor, 5u);
+    EXPECT_STREQ(get_member_name(member_descriptor), "bounded_sequence_of_wstrings");
+    EXPECT_TRUE(is_wstring_member(member_descriptor));
+    EXPECT_TRUE(has_bounded_sequence_structure(member_descriptor, 3u));
+  }
+
+  {
+    auto * member_descriptor = get_member_descriptor(message_descriptor, 6u);
+    EXPECT_STREQ(get_member_name(member_descriptor), "unbounded_sequence_of_wstrings");
+    EXPECT_TRUE(is_wstring_member(member_descriptor));
+    EXPECT_TRUE(has_sequence_structure(member_descriptor));
+  }
+}
+
+TYPED_TEST(WStringsMessageIntrospectionTest, CanReadTypeErasedMessage)
+{
+  using WStringsMessageT = TypeParam;
+
+  const auto message_ptr = Example<WStringsMessageT>::Make();
+  const WStringsMessageT & message = *message_ptr;
+  const void * type_erased_message = message_ptr.get();
+
+  using TypeSupportLibraryT =
+    typename introspection_traits<WStringsMessageT>::TypeSupportLibraryT;
+  using MessageDescriptorT = typename TypeSupportLibraryT::MessageDescriptorT;
+  const MessageDescriptorT * message_descriptor = this->GetMessageDescriptor();
+  ASSERT_EQ(get_member_count(message_descriptor), 7u);
+
+  EXPECT_MEMBER_EQ(
+    type_erased_message, message, wstring_value,
+    get_member_descriptor(message_descriptor, 0u));
+
+  EXPECT_MEMBER_EQ(
+    type_erased_message, message, wstring_value_default1,
+    get_member_descriptor(message_descriptor, 1u));
+
+  EXPECT_MEMBER_EQ(
+    type_erased_message, message, wstring_value_default2,
+    get_member_descriptor(message_descriptor, 2u));
+
+  EXPECT_MEMBER_EQ(
+    type_erased_message, message, wstring_value_default3,
+    get_member_descriptor(message_descriptor, 3u));
+
+  EXPECT_ITERABLE_MEMBER_EQ(
+    type_erased_message, message, array_of_wstrings,
+    get_member_descriptor(message_descriptor, 4u));
+
+  EXPECT_ITERABLE_MEMBER_EQ(
+    type_erased_message, message, bounded_sequence_of_wstrings,
+    get_member_descriptor(message_descriptor, 5u));
+
+  EXPECT_ITERABLE_MEMBER_EQ(
+    type_erased_message, message, unbounded_sequence_of_wstrings,
+    get_member_descriptor(message_descriptor, 6u));
+}
+
+TYPED_TEST(WStringsMessageIntrospectionTest, CanWriteTypeErasedMessage)
+{
+  using WStringsMessageT = TypeParam;
+
+  const auto message_ptr = Example<WStringsMessageT>::Make();
+  const WStringsMessageT & message = *message_ptr;
+
+  auto type_erased_message_copy = this->MakeTypeErasedMessage();
+  const WStringsMessageT & message_copy =
+    *reinterpret_cast<WStringsMessageT *>(type_erased_message_copy.get());
+  EXPECT_NE(message, message_copy);
+
+  using TypeSupportLibraryT =
+    typename introspection_traits<WStringsMessageT>::TypeSupportLibraryT;
+  using MessageDescriptorT = typename TypeSupportLibraryT::MessageDescriptorT;
+  const MessageDescriptorT * message_descriptor = this->GetMessageDescriptor();
+  ASSERT_EQ(get_member_count(message_descriptor), 7u);
+
+  EXPECT_MEMBER_ASSIGNMENT(
+    type_erased_message_copy.get(), message, wstring_value,
+    get_member_descriptor(message_descriptor, 0u));
+
+  EXPECT_MEMBER_ASSIGNMENT(
+    type_erased_message_copy.get(), message, wstring_value_default1,
+    get_member_descriptor(message_descriptor, 1u));
+
+  EXPECT_MEMBER_ASSIGNMENT(
+    type_erased_message_copy.get(), message, wstring_value_default2,
+    get_member_descriptor(message_descriptor, 2u));
+
+  EXPECT_MEMBER_ASSIGNMENT(
+    type_erased_message_copy.get(), message, wstring_value_default3,
+    get_member_descriptor(message_descriptor, 3u));
+
+  EXPECT_ARRAY_MEMBER_ASSIGNMENT(
+    type_erased_message_copy.get(), message, array_of_wstrings,
+    get_member_descriptor(message_descriptor, 4u));
+
+  EXPECT_SEQUENCE_MEMBER_ASSIGNMENT(
+    type_erased_message_copy.get(), message, bounded_sequence_of_wstrings,
+    get_member_descriptor(message_descriptor, 5u));
+
+  EXPECT_SEQUENCE_MEMBER_ASSIGNMENT(
+    type_erased_message_copy.get(), message, unbounded_sequence_of_wstrings,
+    get_member_descriptor(message_descriptor, 6u));
+
+  EXPECT_EQ(message, message_copy);
+}
+
+}  // namespace
+}  // namespace testing
+}  // namespace rosidl_typesupport_introspection_tests


### PR DESCRIPTION
Precisely what the title says. This patch:
 
- Adds missing message introspection tests
- Ignores redundant interface files
- Adds missing expectations
