### PR TITLE
Install headers to include/${PROJECT_NAME}

### DIFF
--- a/rosidl_runtime_c/CMakeLists.txt
+++ b/rosidl_runtime_c/CMakeLists.txt
@@ -25,7 +25,7 @@ add_library(${PROJECT_NAME}
 )
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>")
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 ament_target_dependencies(${PROJECT_NAME}
   "rcutils"
   "rosidl_typesupport_interface")
@@ -43,8 +43,12 @@ if(BUILD_TESTING AND NOT RCUTILS_DISABLE_FAULT_INJECTION)
 endif()
 
 ament_export_dependencies(rcutils rosidl_typesupport_interface)
-ament_export_include_directories(include)
+
+# Export old-style CMake variables
+ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
+
+# Export modern CMake targets
 ament_export_targets(${PROJECT_NAME})
 
 ament_index_register_resource("rosidl_runtime_packages")
@@ -68,13 +72,11 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_message_type_support test/test_message_type_support.cpp)
   if(TARGET test_message_type_support)
-    target_include_directories(test_message_type_support PUBLIC include)
     target_link_libraries(test_message_type_support ${PROJECT_NAME})
   endif()
 
   ament_add_gtest(test_primitives_sequence_functions test/test_primitives_sequence_functions.cpp)
   if(TARGET test_primitives_sequence_functions)
-    target_include_directories(test_primitives_sequence_functions PUBLIC include)
     target_link_libraries(test_primitives_sequence_functions ${PROJECT_NAME})
   endif()
 
@@ -82,40 +84,35 @@ if(BUILD_TESTING)
   if(TARGET test_sequence_bound)
     ament_target_dependencies(test_sequence_bound
       "rosidl_typesupport_interface")
-    target_include_directories(test_sequence_bound PUBLIC include)
     target_link_libraries(test_sequence_bound ${PROJECT_NAME})
   endif()
 
   ament_add_gtest(test_service_type_support test/test_service_type_support.cpp)
   if(TARGET test_service_type_support)
-    target_include_directories(test_service_type_support PUBLIC include)
     target_link_libraries(test_service_type_support ${PROJECT_NAME})
   endif()
 
   ament_add_gtest(test_string_functions test/test_string_functions.cpp)
   if(TARGET test_string_functions)
-    target_include_directories(test_string_functions PUBLIC include)
     target_link_libraries(test_string_functions ${PROJECT_NAME})
     target_compile_definitions(test_string_functions PUBLIC RCUTILS_ENABLE_FAULT_INJECTION)
   endif()
 
   ament_add_gtest(test_u16string_functions test/test_u16string_functions.cpp)
   if(TARGET test_u16string_functions)
-    target_include_directories(test_u16string_functions PUBLIC include)
     target_link_libraries(test_u16string_functions ${PROJECT_NAME})
     target_compile_definitions(test_u16string_functions PUBLIC RCUTILS_ENABLE_FAULT_INJECTION)
   endif()
 
   add_performance_test(benchmark_string_conversion test/benchmark/benchmark_string_conversion.cpp)
   if(TARGET benchmark_string_conversion)
-    target_include_directories(benchmark_string_conversion PUBLIC include)
     target_link_libraries(benchmark_string_conversion ${PROJECT_NAME})
   endif()
 endif()
 
 install(
   DIRECTORY include/
-  DESTINATION include
+  DESTINATION include/${PROJECT_NAME}
 )
 install(
   TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}

--- a/rosidl_runtime_cpp/CMakeLists.txt
+++ b/rosidl_runtime_cpp/CMakeLists.txt
@@ -7,14 +7,17 @@ find_package(ament_cmake REQUIRED)
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(${PROJECT_NAME} INTERFACE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>")
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 
 if(MSVC)
   target_compile_definitions(${PROJECT_NAME} INTERFACE
   _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING)
 endif()
 
-ament_export_include_directories(include)
+# Export old-style CMake variables
+ament_export_include_directories("include/${PROJECT_NAME}")
+
+# Export modern CMake targets
 ament_export_targets(${PROJECT_NAME})
 
 ament_index_register_resource("rosidl_runtime_packages")
@@ -41,7 +44,7 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_bounded_vector test/test_bounded_vector.cpp)
   if(TARGET test_bounded_vector)
-    target_include_directories(test_bounded_vector PUBLIC include)
+    target_link_libraries(test_bounded_vector ${PROJECT_NAME})
   endif()
 
   add_performance_test(benchmark_bounded_vector test/benchmark/benchmark_bounded_vector.cpp)
@@ -52,7 +55,7 @@ endif()
 
 install(
   DIRECTORY include/
-  DESTINATION include
+  DESTINATION include/${PROJECT_NAME}
 )
 install(
   TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}

--- a/rosidl_typesupport_interface/CMakeLists.txt
+++ b/rosidl_typesupport_interface/CMakeLists.txt
@@ -6,9 +6,13 @@ find_package(ament_cmake REQUIRED)
 
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(${PROJECT_NAME} INTERFACE
-  "$<INSTALL_INTERFACE:include>")
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 
-ament_export_include_directories(include)
+# Export old-style CMake variables
+ament_export_include_directories("include/${PROJECT_NAME}")
+
+# Export modern CMake targets
 ament_export_targets(${PROJECT_NAME})
 
 if(BUILD_TESTING)
@@ -34,7 +38,7 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_macros test/test_macros.cpp)
   if(TARGET test_macros)
-    target_include_directories(test_macros PUBLIC include)
+    target_link_libraries(test_macros ${PROJECT_NAME})
   endif()
 
 endif()
@@ -43,7 +47,7 @@ ament_package()
 
 install(
   DIRECTORY include/
-  DESTINATION include
+  DESTINATION include/${PROJECT_NAME}
 )
 install(
   TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}

--- a/rosidl_typesupport_introspection_c/CMakeLists.txt
+++ b/rosidl_typesupport_introspection_c/CMakeLists.txt
@@ -20,8 +20,6 @@ ament_export_dependencies(rosidl_runtime_c)
 # for the get_*_type_support_handle functions and defines the opensplice
 # specific version of these functions.
 
-ament_export_include_directories(include)
-
 ament_python_install_package(${PROJECT_NAME})
 
 add_library(${PROJECT_NAME} src/identifier.c)
@@ -31,8 +29,13 @@ if(WIN32)
 endif()
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>")
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+
+# Export old-style CMake variables
+ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
+
+# Export modern CMake targets
 ament_export_targets(${PROJECT_NAME})
 
 ament_index_register_resource("rosidl_typesupport_c")
@@ -63,7 +66,7 @@ install(
 )
 install(
   DIRECTORY include/
-  DESTINATION include
+  DESTINATION include/${PROJECT_NAME}
 )
 install(
   TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}

--- a/rosidl_typesupport_introspection_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_introspection_cpp/CMakeLists.txt
@@ -22,7 +22,6 @@ ament_export_dependencies(rosidl_runtime_cpp)
 ament_export_dependencies(rosidl_typesupport_interface)
 ament_export_dependencies(rosidl_typesupport_introspection_c)
 
-ament_export_include_directories(include)
 
 ament_python_install_package(${PROJECT_NAME})
 
@@ -33,11 +32,16 @@ if(WIN32)
 endif()
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>")
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 ament_target_dependencies(${PROJECT_NAME}
   rosidl_runtime_cpp
   rosidl_typesupport_introspection_c)
+
+# Export old-style CMake variables
+ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
+
+# Export modern CMake targets
 ament_export_targets(${PROJECT_NAME})
 
 ament_index_register_resource("rosidl_typesupport_cpp")
@@ -68,7 +72,7 @@ install(
 )
 install(
   DIRECTORY include/
-  DESTINATION include
+  DESTINATION include/${PROJECT_NAME}
 )
 install(
   TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}


### PR DESCRIPTION
Part of https://github.com/ros2/ros2/issues/1150 - this installs resource_retriever's header files to a unique directory in a merged workspace.

This only installs headers from rosidl projects to unique directories. I did not yet tackle making the headers generated by these packages install to a unique directory.