### PR TITLE
Fix bug where rosidl_runtime_cpp wasn't depended upon

### DIFF
--- a/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_interfaces.cmake
+++ b/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_interfaces.cmake
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+find_package(rosidl_runtime_cpp REQUIRED)
+
 set(_output_path
   "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp/${PROJECT_NAME}")
 set(_generated_headers "")
@@ -115,7 +118,7 @@ foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
 endforeach()
 target_link_libraries(
   ${rosidl_generate_interfaces_TARGET}${_target_suffix} INTERFACE
-  ${rosidl_runtime_cpp_TARGETS})
+  rosidl_runtime_cpp::rosidl_runtime_cpp)
 
 if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
   if(NOT _generated_headers STREQUAL "")


### PR DESCRIPTION
The `rosidl_runtime_cpp_TARGETS` variable was empty because the `rosidl_runtime_cpp` package hadn't been found yet. This fixes that and uses the target name so it won't happen again.