### PR TITLE
Set maybe_placeholders to False for lark 1.+ compatibility

### DIFF
--- a/rosidl_parser/rosidl_parser/parser.py
+++ b/rosidl_parser/rosidl_parser/parser.py
@@ -85,7 +85,7 @@ def parse_idl_string(idl_string, png_file=None):
 def get_ast_from_idl_string(idl_string):
     global _parser
     if _parser is None:
-        _parser = Lark(grammar, start='specification')
+        _parser = Lark(grammar, start='specification', maybe_placeholders=False)
     return _parser.parse(idl_string)
 
 


### PR DESCRIPTION
Fixes #663


This set's `maybe_placeholders` to `False`. It's default value changed to [`True` in lark-parser 1.0](https://github.com/lark-parser/lark/blob/27a224e24f0f3c0d5593f1282ca9e83448cafa62/CHANGELOG.md).

In the grammar annotation applications are given as

```
annotation_appl: "@" scoped_name [ "(" annotation_appl_params ")" ]
```

The square brackets `[ ... ]`  say "maybe there will be parentheses with parameters for the annotation application". If `maybe_placeholders` is set to `True`, then the AST will contain the value `None` when there aren't any parentheses or parameters. This sets it to `False` so that the AST does not contain anything in that case.