### PR TITLE
Add missing dependency on rosidl_runtime_c

### DIFF
--- a/rosidl_runtime_cpp/CMakeLists.txt
+++ b/rosidl_runtime_cpp/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.5)
 project(rosidl_runtime_cpp)
 
 find_package(ament_cmake REQUIRED)
+find_package(rosidl_runtime_c REQUIRED)
 
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(${PROJECT_NAME} INTERFACE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(${PROJECT_NAME} INTERFACE
+  rosidl_runtime_c::rosidl_runtime_c)
 
 if(MSVC)
   target_compile_definitions(${PROJECT_NAME} INTERFACE
@@ -21,6 +24,8 @@ ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_targets(${PROJECT_NAME})
 
 ament_index_register_resource("rosidl_runtime_packages")
+
+ament_export_dependencies(rosidl_runtime_c)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/rosidl_runtime_cpp/package.xml
+++ b/rosidl_runtime_cpp/package.xml
@@ -14,6 +14,8 @@
 
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
 
+  <depend>rosidl_runtime_c</depend>
+
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
This adds a missing dependency that `rosidl_runtime_cpp` has on `rosidl_runtime_c`

It's used in the headers it installs.

https://github.com/ros2/rosidl/blob/917a40d79143230b4833f14e18b80cfe0930a09f/rosidl_runtime_cpp/include/rosidl_runtime_cpp/action_type_support_decl.hpp#L18

