### PR TITLE
Set the output size unconditionally when copying sequences

### DIFF
--- a/rosidl_generator_c/resource/msg__functions.c.em
+++ b/rosidl_generator_c/resource/msg__functions.c.em
@@ -482,9 +482,9 @@ bool
       }
     }
     output->data = data;
-    output->size = input->size;
     output->capacity = input->size;
   }
+  output->size = input->size;
   for (size_t i = 0; i < input->size; ++i) {
     if (!@(message_typename)__copy(
         &(input->data[i]), &(output->data[i])))

--- a/rosidl_runtime_c/src/string_functions.c
+++ b/rosidl_runtime_c/src/string_functions.c
@@ -254,9 +254,9 @@ rosidl_runtime_c__String__Sequence__copy(
       }
     }
     output->data = data;
-    output->size = input->size;
     output->capacity = input->size;
   }
+  output->size = input->size;
   for (size_t i = 0; i < input->size; ++i) {
     if (!rosidl_runtime_c__String__copy(
         &(input->data[i]), &(output->data[i])))

--- a/rosidl_runtime_c/src/u16string_functions.c
+++ b/rosidl_runtime_c/src/u16string_functions.c
@@ -298,9 +298,9 @@ rosidl_runtime_c__U16String__Sequence__copy(
       }
     }
     output->data = data;
-    output->size = input->size;
     output->capacity = input->size;
   }
+  output->size = input->size;
   for (size_t i = 0; i < input->size; ++i) {
     if (!rosidl_runtime_c__U16String__copy(
         &(input->data[i]), &(output->data[i])))


### PR DESCRIPTION
Fixes the bug mentioned in https://github.com/ros2/rosidl/pull/667#discussion_r822925405

Signed-off-by: Nikolai Morin <nnmmgit@gmail.com>