### PR TITLE
Fix error handling when copying C sequence messages

### DIFF
--- a/rosidl_generator_c/resource/msg__functions.c.em
+++ b/rosidl_generator_c/resource/msg__functions.c.em
@@ -471,17 +471,16 @@ bool
     if (!data) {
       return false;
     }
+    output->data = data;
     for (size_t i = output->capacity; i < input->size; ++i) {
-      if (!@(message_typename)__init(&data[i])) {
+      if (!@(message_typename)__init(&output->data[i])) {
         /* free currently allocated and return false */
         for (; i-- > output->capacity; ) {
-          @(message_typename)__fini(&data[i]);
+          @(message_typename)__fini(&output->data[i]);
         }
-        allocator.deallocate(data, allocator.state);
         return false;
       }
     }
-    output->data = data;
     output->capacity = input->size;
   }
   output->size = input->size;

--- a/rosidl_generator_c/resource/msg__functions.c.em
+++ b/rosidl_generator_c/resource/msg__functions.c.em
@@ -471,10 +471,14 @@ bool
     if (!data) {
       return false;
     }
+    // If reallocation succeeded, memory may or may not have been moved
+    // to fulfill the allocation request, invalidating output->data.
     output->data = data;
     for (size_t i = output->capacity; i < input->size; ++i) {
       if (!@(message_typename)__init(&output->data[i])) {
-        /* free currently allocated and return false */
+        // If initialization of any new item fails, roll back
+        // all previously initialized items. Existing items
+        // in output are to be left unmodified.
         for (; i-- > output->capacity; ) {
           @(message_typename)__fini(&output->data[i]);
         }

--- a/rosidl_runtime_c/src/string_functions.c
+++ b/rosidl_runtime_c/src/string_functions.c
@@ -243,17 +243,16 @@ rosidl_runtime_c__String__Sequence__copy(
     if (!data) {
       return false;
     }
+    output->data = data;
     for (size_t i = output->capacity; i < input->size; ++i) {
-      if (!rosidl_runtime_c__String__init(&data[i])) {
+      if (!rosidl_runtime_c__String__init(&output->data[i])) {
         /* free currently allocated and return false */
         for (; i-- > output->capacity; ) {
-          rosidl_runtime_c__String__fini(&data[i]);
+          rosidl_runtime_c__String__fini(&output->data[i]);
         }
-        allocator.deallocate(data, allocator.state);
         return false;
       }
     }
-    output->data = data;
     output->capacity = input->size;
   }
   output->size = input->size;

--- a/rosidl_runtime_c/src/string_functions.c
+++ b/rosidl_runtime_c/src/string_functions.c
@@ -243,10 +243,14 @@ rosidl_runtime_c__String__Sequence__copy(
     if (!data) {
       return false;
     }
+    // If reallocation succeeded, memory may or may not have been moved
+    // to fulfill the allocation request, invalidating output->data.
     output->data = data;
     for (size_t i = output->capacity; i < input->size; ++i) {
       if (!rosidl_runtime_c__String__init(&output->data[i])) {
-        /* free currently allocated and return false */
+        // If initialization of any new item fails, roll back all
+        // previously initialized items. Existing items in output
+        // are to be left unmodified.
         for (; i-- > output->capacity; ) {
           rosidl_runtime_c__String__fini(&output->data[i]);
         }

--- a/rosidl_runtime_c/src/u16string_functions.c
+++ b/rosidl_runtime_c/src/u16string_functions.c
@@ -287,10 +287,14 @@ rosidl_runtime_c__U16String__Sequence__copy(
     if (!data) {
       return false;
     }
+    // If reallocation succeeded, memory may or may not have been moved
+    // to fulfill the allocation request, invalidating output->data.
     output->data = data;
     for (size_t i = output->capacity; i < input->size; ++i) {
       if (!rosidl_runtime_c__U16String__init(&output->data[i])) {
-        /* free currently allocated and return false */
+        // If initialization of any new items fails, roll back all
+        // previously initialized items. Existing items in output
+        // are to be left unmodified.
         for (; i-- > output->capacity; ) {
           rosidl_runtime_c__U16String__fini(&output->data[i]);
         }

--- a/rosidl_runtime_c/src/u16string_functions.c
+++ b/rosidl_runtime_c/src/u16string_functions.c
@@ -287,17 +287,16 @@ rosidl_runtime_c__U16String__Sequence__copy(
     if (!data) {
       return false;
     }
+    output->data = data;
     for (size_t i = output->capacity; i < input->size; ++i) {
-      if (!rosidl_runtime_c__U16String__init(&data[i])) {
+      if (!rosidl_runtime_c__U16String__init(&output->data[i])) {
         /* free currently allocated and return false */
         for (; i-- > output->capacity; ) {
-          rosidl_runtime_c__U16String__fini(&data[i]);
+          rosidl_runtime_c__U16String__fini(&output->data[i]);
         }
-        allocator.deallocate(data, allocator.state);
         return false;
       }
     }
-    output->data = data;
     output->capacity = input->size;
   }
   output->size = input->size;


### PR DESCRIPTION
This is an issue I spotted while reviewing #669. We shouldn't hold reallocated (i.e. invalidated) data pointers if any new sequence item initialization fails. It's quite hard to run into this problem (e.g. RAM exhaustion), but it is theoretically possible.

CI up to `rosidl_generator_c` and `rosidl_runtime_c`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=16390)](http://ci.ros2.org/job/ci_linux/16390/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=10999)](http://ci.ros2.org/job/ci_linux-aarch64/10999/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=16762)](http://ci.ros2.org/job/ci_windows/16762/)
