### PR TITLE
Make rosidl_get_typesupport_target return -NOTFOUND instead of FATAL_ERROR

### DIFF
--- a/rosidl_cmake/cmake/rosidl_get_typesupport_target.cmake
+++ b/rosidl_cmake/cmake/rosidl_get_typesupport_target.cmake
@@ -33,7 +33,8 @@ function(rosidl_get_typesupport_target var generate_interfaces_target typesuppor
   set(output_target "${generate_interfaces_target}__${typesupport_name}")
 
   if(NOT TARGET ${output_target})
-    message(FATAL_ERROR "${output_target} is not a CMake target - maybe the typesupport '${typesupport_name}' doesn't exist?")
+    # CMake if() evaluates strings ending in `-NOTFOUND` as false
+    set(output_target "${output_target}-NOTFOUND")
   endif()
 
   set("${var}" "${output_target}" PARENT_SCOPE)


### PR DESCRIPTION
This is in support of conditionally using typesupport targets: https://github.com/ros2/common_interfaces/pull/183

It allows using `rosidl_get_typesupport_target` even if the target doesn't exist. If it doesn't, the function sets the output variable to the expected target name ending in `-NOTFOUND`. That allows it to be checked with [if()](https://cmake.org/cmake/help/latest/command/if.html) which evaluates any string ending with that suffix as a false constant.