### PR TITLE
Doxygen comments for generated C++ structs

### DIFF
--- a/rosidl_generator_cpp/resource/msg__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.em
@@ -238,6 +238,13 @@ non_defaulted_zero_initialized_members = [
 @[for member in message.structure.members]@
   using _@(member.name)_type =
     @(msg_type_to_cpp(member.type));
+  @[for line in member.get_comment_lines()]@
+  @[  if line]@
+  /// @(line)
+  @[  else]@
+  ///
+  @[  end if]@
+  @[end for]@
   _@(member.name)_type @(member.name);
 @[end for]@
 


### PR DESCRIPTION
I noticed that the `.msg` to `.idl` conversion preserves comments, and while the template for C structs includes those as doxygen comments ([here](https://github.com/ros2/rosidl/blob/master/rosidl_generator_c/resource/msg__struct.h.em#L160-L166)), the C++ template is still missing those.

This PR intends to add the same comments to the C++ template.

I just copied over the code from the C template, which seems to work. I am not sure however how i can test this in my local workspace with a package containing message definitions and another package containing C++ nodes using those messages... I found the `rosidl generate` command, but i am not sure how i can use the modified `rosidl_generator_cpp` when building my messages-package...
