### PR TITLE
Add missing test dependency to package.xml file

### DIFF
--- a/rosidl_generator_c/package.xml
+++ b/rosidl_generator_c/package.xml
@@ -26,6 +26,7 @@
   <exec_depend>rosidl_parser</exec_depend>
   <exec_depend>rcutils</exec_depend>
 
+  <test_depend>ament_cmake_cppcheck</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
This should fix the build regressions in the `ros2_gazebo_pkgs-ci-default_rolling-focal-amd64` jobs of the buildfarm:

https://build.osrfoundation.org/job/ros2_gazebo_pkgs-ci-default_rolling-focal-amd64/96/

With error:

```
-- Found trajectory_msgs: 4.0.0 (/opt/ros/rolling/share/trajectory_msgs/cmake)
-- Found rosidl_default_generators: 1.1.1 (/opt/ros/rolling/share/rosidl_default_generators/cmake)
CMake Error at /opt/ros/rolling/share/rosidl_generator_c/cmake/rosidl_generator_c_generate_interfaces.cmake:174 (find_package):
  By not providing "Findament_cmake_cppcheck.cmake" in CMAKE_MODULE_PATH this
  project has asked CMake to find a package configuration file provided by
  "ament_cmake_cppcheck", but CMake did not find one.

  Could not find a package configuration file provided by
  "ament_cmake_cppcheck" with any of the following names:

    ament_cmake_cppcheckConfig.cmake
    ament_cmake_cppcheck-config.cmake

  Add the installation prefix of "ament_cmake_cppcheck" to CMAKE_PREFIX_PATH
  or set "ament_cmake_cppcheck_DIR" to a directory containing one of the
  above files.  If "ament_cmake_cppcheck" provides a separate development
  package or SDK, be sure it has been installed.
Call Stack (most recent call first):
  /opt/ros/rolling/share/ament_cmake_core/cmake/core/ament_execute_extensions.cmake:48 (include)
  /opt/ros/rolling/share/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake:286 (ament_execute_extensions)
  CMakeLists.txt:71 (rosidl_generate_interfaces)

```



Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>