### PR TITLE
Fix comment in camel case conversion function

### DIFF
--- a/rosidl_cmake/rosidl_cmake/__init__.py
+++ b/rosidl_cmake/rosidl_cmake/__init__.py
@@ -26,7 +26,7 @@ from rosidl_parser.parser import parse_idl_file
 
 def convert_camel_case_to_lower_case_underscore(value):
     # insert an underscore before any upper case letter
-    # which is not followed by another upper case letter
+    # which is followed by a lower case letter
     value = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', value)
     # insert an underscore before any upper case letter
     # which is preseded by a lower case letter or number


### PR DESCRIPTION
This fixes a comment in `convert_camel_case_to_lower_case_underscore`. I reimplemented this function in bazel based on the comment and had a bug. In my bazel function `ColorRGBA.msg` became `color_rgb_a.msg` because `.` isn't an upper case letter. The correct result is `color_rgba.msg`.