### PR TITLE
Add enum support to ROSIDL

### DIFF
--- a/rosidl_generator_c/CMakeLists.txt
+++ b/rosidl_generator_c/CMakeLists.txt
@@ -45,6 +45,7 @@ if(BUILD_TESTING)
 
   rosidl_generate_interfaces(${PROJECT_NAME}_interfaces
     ${test_interface_files_MSG_FILES}
+    ${test_interface_files_IDL_FILES}
     ADD_LINTER_TESTS
     SKIP_INSTALL
   )

--- a/rosidl_generator_c/resource/msg__functions.h.em
+++ b/rosidl_generator_c/resource/msg__functions.h.em
@@ -1,5 +1,7 @@
 @# Included from rosidl_generator_c/resource/idl__functions.h.em
 @{
+from rosidl_generator_c import idl_enumeration_type_sequence_to_c_typename
+from rosidl_generator_c import idl_enumeration_type_to_c_typename
 from rosidl_generator_c import idl_structure_type_sequence_to_c_typename
 from rosidl_generator_c import idl_structure_type_to_c_typename
 from rosidl_generator_c import interface_path_to_string
@@ -165,3 +167,60 @@ bool
 @(array_typename)__copy(
   const @(array_typename) * input,
   @(array_typename) * output);
+
+@#######################################################################
+@# message enums functions
+@#######################################################################
+@[for enum in message.enumerations]@
+@{
+__enum_typename = idl_enumeration_type_to_c_typename(enum.enumeration_type)
+__enum_sequence_typename = idl_enumeration_type_sequence_to_c_typename(enum.enumeration_type)
+}@
+/// Initialize sequence of @(__enum_typename).
+/**
+ * It allocates the memory for the number of elements.
+ * \param[in,out] sequence The allocated sequence pointer.
+ * \param[in] size The size / capacity of the sequence.
+ * \return true if initialization was successful, otherwise false
+ * If the sequence pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_@(package_name)
+bool
+@(__enum_sequence_typename)__init(@(__enum_sequence_typename) * sequence, size_t size);
+
+/// Finalize sequence of @(__enum_typename).
+/**
+ * \param[in,out] sequence The allocated sequence pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_@(package_name)
+void
+@(__enum_sequence_typename)__fini(@(__enum_sequence_typename) * sequence);
+
+/// Check for @(__enum_typename) array equality.
+/**
+ * \param[in] lhs The array on the left hand side of the equality operator.
+ * \param[in] rhs The array on the right hand side of the equality operator.
+ * \return true if message arrays are equal in size and content, otherwise false.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_@(package_name)
+bool
+@(__enum_sequence_typename)__are_equal(const @(__enum_sequence_typename) * lhs, const @(__enum_sequence_typename) * rhs);
+
+/// Copy an array of @(__enum_typename).
+/**
+ * This function performs a deep copy, as opposed to the shallow copy that
+ * plain assignment yields.
+ *
+ * \param[in] input The source array pointer.
+ * \param[out] output The target array pointer, which must
+ *   have been initialized before calling this function.
+ * \return true if successful, or false if either pointer
+ *   is null or memory allocation fails.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_@(package_name)
+bool
+@(__enum_sequence_typename)__copy(
+  const @(__enum_sequence_typename) * input,
+  @(__enum_sequence_typename) * output);
+@[  end for]@

--- a/rosidl_generator_c/resource/msg__struct.h.em
+++ b/rosidl_generator_c/resource/msg__struct.h.em
@@ -9,12 +9,15 @@ from rosidl_parser.definition import BasicType
 from rosidl_parser.definition import BOOLEAN_TYPE
 from rosidl_parser.definition import BoundedSequence
 from rosidl_parser.definition import CHARACTER_TYPES
+from rosidl_parser.definition import EnumerationType
 from rosidl_parser.definition import FLOATING_POINT_TYPES
 from rosidl_parser.definition import INTEGER_TYPES
 from rosidl_parser.definition import NamespacedType
 from rosidl_parser.definition import OCTET_TYPE
 from rosidl_generator_c import basetype_to_c
 from rosidl_generator_c import idl_declaration_to_c
+from rosidl_generator_c import idl_enumeration_type_to_c_typename
+from rosidl_generator_c import idl_enumeration_type_sequence_to_c_typename
 from rosidl_generator_c import idl_structure_type_sequence_to_c_typename
 from rosidl_generator_c import idl_structure_type_to_c_include_prefix
 from rosidl_generator_c import idl_structure_type_to_c_typename
@@ -138,6 +141,30 @@ enum
 };
 @[  end for]@
 @[end if]@
+@#>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+
+
+@#<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+// Enums defined in the message
+@[for enum in message.enumerations]@
+// Enum defined in @(interface_path_to_string(interface_path)) in the package @(package_name).
+typedef enum @(idl_enumeration_type_to_c_typename(enum.enumeration_type))
+{
+@[for enumerator in enum.enumerators]@
+  @(enumerator),
+@[end for]@
+} @(idl_enumeration_type_to_c_typename(enum.enumeration_type));
+
+// Struct for a sequence of @(idl_enumeration_type_to_c_typename(enum.enumeration_type)).
+typedef struct @(idl_enumeration_type_sequence_to_c_typename(enum.enumeration_type))
+{
+  @(idl_enumeration_type_to_c_typename(enum.enumeration_type)) * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} @(idl_enumeration_type_sequence_to_c_typename(enum.enumeration_type));
+@[  end for]@
 @#>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 @#<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<

--- a/rosidl_generator_c/rosidl_generator_c/__init__.py
+++ b/rosidl_generator_c/rosidl_generator_c/__init__.py
@@ -22,6 +22,7 @@ from rosidl_parser.definition import AbstractWString
 from rosidl_parser.definition import Array
 from rosidl_parser.definition import BasicType
 from rosidl_parser.definition import CHARACTER_TYPES
+from rosidl_parser.definition import EnumerationType
 from rosidl_parser.definition import NamespacedType
 from rosidl_parser.definition import OCTET_TYPE
 
@@ -67,6 +68,14 @@ BASIC_IDL_TYPES_TO_C = {
     'uint64': 'uint64_t',
     'int64': 'int64_t',
 }
+
+
+def idl_enumeration_type_to_c_typename(enumeration_type):
+    return '__'.join(enumeration_type.namespaced_name())
+
+
+def idl_enumeration_type_sequence_to_c_typename(enumeration_type):
+    return idl_enumeration_type_to_c_typename(enumeration_type) + '__Sequence'
 
 
 def idl_structure_type_to_c_include_prefix(namespaced_type, subdirectory=None):
@@ -148,6 +157,8 @@ def basetype_to_c(basetype):
         return 'rosidl_runtime_c__U16String'
     if isinstance(basetype, NamespacedType):
         return idl_structure_type_to_c_typename(basetype)
+    if isinstance(basetype, EnumerationType):
+        return idl_enumeration_type_to_c_typename(basetype)
     assert False, str(basetype)
 
 
@@ -160,6 +171,9 @@ def value_to_c(type_, value):
 
     if isinstance(type_, AbstractWString):
         return 'u"%s"' % escape_wstring(value)
+
+    if isinstance(type_, EnumerationType):
+        return '%s' % value
 
     return basic_value_to_c(type_, value)
 

--- a/rosidl_generator_c/test/test_interfaces.c
+++ b/rosidl_generator_c/test/test_interfaces.c
@@ -25,6 +25,7 @@
 #include "rosidl_runtime_c/string_functions.h"
 #include "rosidl_runtime_c/u16string_functions.h"
 
+#include "rosidl_generator_c/idl/enums_message.h"
 #include "rosidl_generator_c/msg/arrays.h"
 #include "rosidl_generator_c/msg/defaults.h"
 #include "rosidl_generator_c/msg/constants.h"
@@ -89,6 +90,11 @@ int test_nested(void);
 int test_strings(void);
 int test_unbounded_sequences(void);
 int test_wstrings(void);
+int test_enum(void);
+int test_enum_default_value(void);
+int test_enum_static_array(void);
+int test_enum_bounded_array(void);
+int test_enum_dynamic_array(void);
 
 int main(void)
 {
@@ -141,6 +147,56 @@ int main(void)
   printf("Testing rosidl_generator_c multi_nested type\n");
   if (test_multi_nested()) {
     fprintf(stderr, "test_multi_nested() FAILED\n");
+    rc++;
+  }
+  printf("Testing enum...\n");
+  if (test_enum()) {
+    fprintf(stderr, "test_enum() FAILED\n");
+    rc++;
+  }
+  printf("Testing enum default value...\n");
+  if (test_enum_default_value()) {
+    fprintf(stderr, "test_enum_default_value() FAILED\n");
+    rc++;
+  }
+  printf("Testing enum static array...\n");
+  if (test_enum_static_array()) {
+    fprintf(stderr, "test_enum_static_array() FAILED\n");
+    rc++;
+  }
+  printf("Testing enum bounded array...\n");
+  if (test_enum_bounded_array()) {
+    fprintf(stderr, "test_enum_bounded_array() FAILED\n");
+    rc++;
+  }
+  printf("Testing enum dynamic array...\n");
+  if (test_enum_dynamic_array()) {
+    fprintf(stderr, "test_enum_dynamic_array() FAILED\n");
+    rc++;
+  }
+  printf("Testing enum...\n");
+  if (test_enum()) {
+    fprintf(stderr, "test_enum() FAILED\n");
+    rc++;
+  }
+  printf("Testing enum default value...\n");
+  if (test_enum_default_value()) {
+    fprintf(stderr, "test_enum_default_value() FAILED\n");
+    rc++;
+  }
+  printf("Testing enum static array...\n");
+  if (test_enum_static_array()) {
+    fprintf(stderr, "test_enum_static_array() FAILED\n");
+    rc++;
+  }
+  printf("Testing enum bounded array...\n");
+  if (test_enum_bounded_array()) {
+    fprintf(stderr, "test_enum_bounded_array() FAILED\n");
+    rc++;
+  }
+  printf("Testing enum dynamic array...\n");
+  if (test_enum_dynamic_array()) {
+    fprintf(stderr, "test_enum_dynamic_array() FAILED\n");
     rc++;
   }
   if (rc != 0) {
@@ -1296,5 +1352,137 @@ int test_arrays()
   rosidl_generator_c__msg__Arrays__destroy(arr_copy);
 
   rosidl_generator_c__msg__Arrays__destroy(arr);
+  return 0;
+}
+
+/**
+ * Test message with enum type.
+ */
+int test_enum(void)
+{
+  // expected enumerators
+  (void)ENUMERATOR1;
+  (void)ENUMERATOR2;
+
+  test_msgs__idl__EnumsMessage msg;
+  msg.enum_value = ENUMERATOR2;
+  EXPECT_EQ(ENUMERATOR2, msg.enum_value);
+
+  return 0;
+}
+
+/**
+ * Test enum default value.
+ */
+int test_enum_default_value(void)
+{
+  test_msgs__idl__EnumsMessage * msg = NULL;
+
+  msg = test_msgs__idl__EnumsMessage__create();
+  EXPECT_NE(msg, NULL);
+
+  EXPECT_EQ(ENUMERATOR2, msg->enum_default_value);
+
+  test_msgs__idl__EnumsMessage__destroy(msg);
+
+  return 0;
+}
+
+/**
+ * Test enum static array.
+ */
+int test_enum_static_array(void)
+{
+  int i;
+  test_msgs__idl__EnumsMessage * arrays = NULL;
+  arrays = test_msgs__idl__EnumsMessage__create();
+  EXPECT_NE(NULL, arrays);
+
+  for (i = 0; i < ARR_SIZE; i++) {
+    if (0 == (i % 2)) {
+      arrays->static_array_values[i] = ENUMERATOR1;
+    } else {
+      arrays->static_array_values[i] = ENUMERATOR2;
+    }
+  }
+  for (i = 0; i < ARR_SIZE; i++) {
+    if (0 == (i % 2)) {
+      EXPECT_EQ(ENUMERATOR1, arrays->static_array_values[i]);
+    } else {
+      EXPECT_EQ(ENUMERATOR2, arrays->static_array_values[i]);
+    }
+  }
+
+  test_msgs__idl__EnumsMessage__destroy(arrays);
+
+  return 0;
+}
+
+/**
+ * Test enum bounded array.
+ */
+int test_enum_bounded_array(void)
+{
+  int res;
+  int i;
+  test_msgs__idl__EnumsMessage * arrays = NULL;
+  arrays = test_msgs__idl__EnumsMessage__create();
+  EXPECT_NE(NULL, arrays);
+
+  res = test_msgs__idl__EnumsMessage__SomeEnum__Sequence__init(
+    &arrays->bounded_array_values, ARR_SIZE);
+  EXPECT_EQ(true, res);
+  for (i = 0; i < ARR_SIZE; i++) {
+    if (0 == (i % 2)) {
+      arrays->bounded_array_values.data[i] = ENUMERATOR1;
+    } else {
+      arrays->bounded_array_values.data[i] = ENUMERATOR2;
+    }
+  }
+  for (i = 0; i < ARR_SIZE; i++) {
+    if (0 == (i % 2)) {
+      EXPECT_EQ(ENUMERATOR1, arrays->bounded_array_values.data[i]);
+    } else {
+      EXPECT_EQ(ENUMERATOR2, arrays->bounded_array_values.data[i]);
+    }
+  }
+
+  test_msgs__idl__EnumsMessage__destroy(arrays);
+
+  return 0;
+}
+
+/**
+ * Test enum dynamic array.
+ */
+int test_enum_dynamic_array(void)
+{
+  int res;
+  int i;
+  test_msgs__idl__EnumsMessage * arrays = NULL;
+  arrays = test_msgs__idl__EnumsMessage__create();
+  EXPECT_NE(NULL, arrays);
+
+  // dynamic array
+  res = test_msgs__idl__EnumsMessage__SomeEnum__Sequence__init(
+    &arrays->dynamic_array_values, ARR_SIZE);
+  EXPECT_EQ(true, res);
+  for (i = 0; i < ARR_SIZE; i++) {
+    if (0 == (i % 2)) {
+      arrays->dynamic_array_values.data[i] = ENUMERATOR1;
+    } else {
+      arrays->dynamic_array_values.data[i] = ENUMERATOR2;
+    }
+  }
+  for (i = 0; i < ARR_SIZE; i++) {
+    if (0 == (i % 2)) {
+      EXPECT_EQ(ENUMERATOR1, arrays->dynamic_array_values.data[i]);
+    } else {
+      EXPECT_EQ(ENUMERATOR2, arrays->dynamic_array_values.data[i]);
+    }
+  }
+
+  test_msgs__idl__EnumsMessage__destroy(arrays);
+
   return 0;
 }

--- a/rosidl_generator_cpp/CMakeLists.txt
+++ b/rosidl_generator_cpp/CMakeLists.txt
@@ -29,6 +29,7 @@ if(BUILD_TESTING)
 
   rosidl_generate_interfaces(${PROJECT_NAME}
     ${test_interface_files_MSG_FILES}
+    ${test_interface_files_IDL_FILES}
     ${test_interface_files_SRV_FILES}
     ADD_LINTER_TESTS
     SKIP_INSTALL

--- a/rosidl_generator_cpp/resource/msg__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.em
@@ -234,6 +234,16 @@ non_defaulted_zero_initialized_members = [
 @[end if]@
   }
 
+  // enums
+@[for enum in message.enumerations]@
+  enum class @(enum.enumeration_type.name)
+  {
+@[  for enumerator in enum.enumerators]@
+    @(enumerator),
+@[  end for]@
+  };
+@[end for]@
+
   // field types and members
 @[for member in message.structure.members]@
   using _@(member.name)_type =

--- a/rosidl_generator_cpp/resource/msg__traits.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__traits.hpp.em
@@ -8,6 +8,7 @@ from rosidl_parser.definition import AbstractGenericString
 from rosidl_parser.definition import BasicType
 from rosidl_parser.definition import BoundedSequence
 from rosidl_parser.definition import EMPTY_STRUCTURE_REQUIRED_MEMBER_NAME
+from rosidl_parser.definition import EnumerationType
 from rosidl_parser.definition import NamespacedType
 from rosidl_parser.definition import AbstractSequence
 from rosidl_parser.definition import UnboundedSequence
@@ -91,6 +92,10 @@ inline void to_flow_style_yaml(
 @[    elif isinstance(member.type, AbstractGenericString)]@
     out << "@(member.name): ";
     rosidl_generator_traits::value_to_yaml(msg.@(member.name), out);
+@[    elif isinstance(member.type, EnumerationType)]@
+    out << "@(member.name): ";
+    // TODO(r7vme): create value_to_yaml
+    out << static_cast<int>(msg.@(member.name));
 @[    elif isinstance(member.type, NamespacedType)]@
     out << "@(member.name): ";
     to_flow_style_yaml(msg.@(member.name), out);
@@ -109,6 +114,9 @@ inline void to_flow_style_yaml(
 @[        end if]@
 @[      elif isinstance(member.type.value_type, AbstractGenericString)]@
         rosidl_generator_traits::value_to_yaml(item, out);
+@[      elif isinstance(member.type.value_type, EnumerationType)]@
+        // TODO(r7vme): create value_to_yaml
+        out << static_cast<int>(item);
 @[      elif isinstance(member.type.value_type, NamespacedType)]@
         to_flow_style_yaml(item, out);
 @[      end if]@
@@ -158,6 +166,11 @@ inline void to_block_style_yaml(
     out << "@(member.name): ";
     rosidl_generator_traits::value_to_yaml(msg.@(member.name), out);
     out << "\n";
+@[    elif isinstance(member.type, EnumerationType)]@
+    out << "@(member.name): ";
+    // TODO(r7vme): create value_to_yaml
+    out << static_cast<int>(msg.@(member.name));
+    out << "\n";
 @[    elif isinstance(member.type, NamespacedType)]@
     out << "@(member.name):\n";
     to_block_style_yaml(msg.@(member.name), out, indentation + 2);
@@ -181,6 +194,11 @@ inline void to_block_style_yaml(
 @[      elif isinstance(member.type.value_type, AbstractGenericString)]@
         out << "- ";
         rosidl_generator_traits::value_to_yaml(item, out);
+        out << "\n";
+@[      elif isinstance(member.type.value_type, EnumerationType)]@
+        out << "- ";
+        // TODO(r7vme): create value_to_yaml
+        out << static_cast<int>(item);
         out << "\n";
 @[      elif isinstance(member.type.value_type, NamespacedType)]@
         out << "-\n";

--- a/rosidl_generator_cpp/test/test_interfaces.cpp
+++ b/rosidl_generator_cpp/test/test_interfaces.cpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include "test_array_generator.hpp"
 
+#include "rosidl_generator_cpp/idl/enums_message.hpp"
 #include "rosidl_generator_cpp/msg/arrays.hpp"
 #include "rosidl_generator_cpp/msg/basic_types.hpp"
 #include "rosidl_generator_cpp/msg/bounded_sequences.hpp"
@@ -536,4 +537,59 @@ TEST(Test_messages, Test_string_array_static) {
   TEST_STATIC_ARRAY_STRING(
     message, string_values_default, std::string, ARRAY_SIZE, \
     0, UINT32_MAX, 0, UINT16_MAX)
+}
+
+TEST(Test_messages, test_message_with_enumeration) {
+  using MsgType = test_msgs::idl::EnumsMessage;
+  MsgType msg;
+  msg.enum_value = MsgType::SomeEnum::ENUMERATOR2;
+
+  ASSERT_EQ(msg.enum_value, MsgType::SomeEnum::ENUMERATOR2);
+}
+
+TEST(Test_messages, test_enum_default_value) {
+  test_msgs::idl::EnumsMessage msg;
+  auto expected_value = test_msgs::idl::EnumsMessage::SomeEnum::ENUMERATOR2;
+
+  ASSERT_EQ(expected_value, msg.enum_default_value);
+}
+
+TEST(Test_messages, test_bounded_enum_array) {
+  using MsgType = test_msgs::idl::EnumsMessage;
+  using EnumType = MsgType::SomeEnum;
+
+  MsgType msg;
+  rosidl_runtime_cpp::BoundedVector<EnumType, ARRAY_SIZE> expected_array;
+  expected_array.resize(ARRAY_SIZE);
+  std::fill(expected_array.begin(), expected_array.end(), EnumType::ENUMERATOR2);
+  msg.bounded_array_values.resize(ARRAY_SIZE);
+  std::copy_n(expected_array.begin(), ARRAY_SIZE, msg.bounded_array_values.begin());
+
+  EXPECT_EQ(expected_array, msg.bounded_array_values);
+}
+
+TEST(Test_messages, test_unbounded_enum_array) {
+  using MsgType = test_msgs::idl::EnumsMessage;
+  using EnumType = MsgType::SomeEnum;
+
+  MsgType msg;
+  std::vector<EnumType> expected_array;
+  expected_array.resize(ARRAY_SIZE);
+  std::fill(expected_array.begin(), expected_array.end(), EnumType::ENUMERATOR2);
+  msg.dynamic_array_values.resize(ARRAY_SIZE);
+  std::copy_n(expected_array.begin(), ARRAY_SIZE, msg.dynamic_array_values.begin());
+
+  EXPECT_EQ(expected_array, msg.dynamic_array_values);
+}
+
+TEST(Test_messages, test_static_enum_array) {
+  using MsgType = test_msgs::idl::EnumsMessage;
+  using EnumType = MsgType::SomeEnum;
+
+  MsgType msg;
+  std::array<EnumType, ARRAY_SIZE> expected_array;
+  std::fill(expected_array.begin(), expected_array.end(), EnumType::ENUMERATOR2);
+  std::copy_n(expected_array.begin(), ARRAY_SIZE, msg.static_array_values.begin());
+
+  EXPECT_EQ(expected_array, msg.static_array_values);
 }

--- a/rosidl_parser/test/msg/MyMessage.idl
+++ b/rosidl_parser/test/msg/MyMessage.idl
@@ -13,6 +13,14 @@ module rosidl_parser {
       const string EMPTY_STRING_CONSTANT = "";
     };
 
+    module MyMessage_Enums {
+      enum MyEnum {
+        ENUMERATOR1,
+        ENUMERATOR2,
+        ENUMERATOR3
+      };
+    };
+
     @verbatim ( language="comment", text="Documentation of MyMessage." "Adjacent string literal." )
     @transfer_mode(SHMEM_REF)
     struct MyMessage {
@@ -81,6 +89,14 @@ module rosidl_parser {
       float fixed_frac_only;
       @default ( value=7d )
       float fixed_int_only;
+
+      // Tests for enumerations
+      MyEnum enum_value;
+      MyEnum static_array_enum_values[3];
+      sequence<MyEnum> dynamic_array_enum_values;
+      sequence<MyEnum, 3> bounded_array_enum_values;
+      @default (value="ENUMERATOR1")
+      MyEnum enum_default_value;
     };
   };
 };

--- a/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/field_types.h
+++ b/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/field_types.h
@@ -64,6 +64,8 @@ enum rosidl_typesupport_introspection_c_field_types
 
   /// An embedded message type.
   rosidl_typesupport_introspection_c__ROS_TYPE_MESSAGE = 18,
+  /// An embedded enumeration type.
+  rosidl_typesupport_introspection_c__ROS_TYPE_ENUM = 19,
 
   /// For backward compatibility only.
   rosidl_typesupport_introspection_c__ROS_TYPE_FLOAT32 = 1,

--- a/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
+++ b/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
@@ -10,6 +10,7 @@ from rosidl_parser.definition import AbstractWString
 from rosidl_parser.definition import Array
 from rosidl_parser.definition import BasicType
 from rosidl_parser.definition import BoundedSequence
+from rosidl_parser.definition import EnumerationType
 from rosidl_parser.definition import NamespacedType
 
 include_parts = [package_name] + list(interface_path.parents[0].parts) + [
@@ -225,6 +226,13 @@ for index, member in enumerate(message.structure.members):
             assert False, 'Unknown type: ' + str(type_)
         # size_t string_upper_bound
         print('    %u,  // upper bound of string' % (type_.maximum_size if type_.has_maximum_size() else 0))
+        # const rosidl_generator_c::MessageTypeSupportHandle * members_
+        print('    NULL,  // members of sub message')
+    elif isinstance(type_, EnumerationType):
+        # uint8_t type_id_
+        print('    rosidl_typesupport_introspection_c__ROS_TYPE_ENUM,  // type')
+        # size_t string_upper_bound
+        print('    0,  // upper bound of string')
         # const rosidl_generator_c::MessageTypeSupportHandle * members_
         print('    NULL,  // members of sub message')
     else:

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/field_types.hpp
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/field_types.hpp
@@ -61,6 +61,8 @@ const uint8_t ROS_TYPE_WSTRING = rosidl_typesupport_introspection_c__ROS_TYPE_WS
 
 /// An embedded message type.
 const uint8_t ROS_TYPE_MESSAGE = rosidl_typesupport_introspection_c__ROS_TYPE_MESSAGE;
+/// An embedded enumeration type.
+const uint8_t ROS_TYPE_ENUM = rosidl_typesupport_introspection_c__ROS_TYPE_ENUM;
 
 /// For backward compatibility only.
 const uint8_t ROS_TYPE_BOOL = rosidl_typesupport_introspection_c__ROS_TYPE_BOOL;

--- a/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
@@ -8,6 +8,7 @@ from rosidl_parser.definition import AbstractWString
 from rosidl_parser.definition import Array
 from rosidl_parser.definition import BasicType
 from rosidl_parser.definition import BoundedSequence
+from rosidl_parser.definition import EnumerationType
 from rosidl_parser.definition import NamespacedType
 from rosidl_cmake import convert_camel_case_to_lower_case_underscore
 
@@ -77,7 +78,7 @@ elif isinstance(member.type.value_type, AbstractString):
     type_ = 'std::string'
 elif isinstance(member.type.value_type, AbstractWString):
     type_ = 'std::u16string'
-elif isinstance(member.type.value_type, NamespacedType):
+elif isinstance(member.type.value_type, (NamespacedType, EnumerationType)):
     type_ = '::'.join(member.type.value_type.namespaced_name())
 }@
 size_t size_function__@(message.structure.namespaced_type.name)__@(member.name)(const void * untyped_member)
@@ -190,6 +191,13 @@ for index, member in enumerate(message.structure.members):
             assert False, 'Unknown type: ' + str(type_)
         # size_t string_upper_bound
         print('    %u,  // upper bound of string' % (type_.maximum_size if type_.has_maximum_size() else 0))
+        # const rosidl_generator_c::MessageTypeSupportHandle * members_
+        print('    nullptr,  // members of sub message')
+    elif isinstance(type_, EnumerationType):
+        # uint8_t type_id_
+        print('    rosidl_typesupport_introspection_c__ROS_TYPE_ENUM,  // type')
+        # size_t string_upper_bound
+        print('    0,  // upper bound of string')
         # const rosidl_generator_c::MessageTypeSupportHandle * members_
         print('    nullptr,  // members of sub message')
     else:


### PR DESCRIPTION
Adds support for enums into ROSIDL. Only `.idl` files supported.

Example

```idl
module test_msgs {
  module idl {
    typedef SomeEnum SomeEnum__3[3];

    module EnumsMessage_Enums {
      enum SomeEnum {
        ENUMERATOR1,
        ENUMERATOR2
      };
    };

    struct EnumsMessage {
      SomeEnum enum_value;

      @default (value="ENUMERATOR2")
      SomeEnum enum_default_value;

      SomeEnum__3 static_array_values;

      sequence<SomeEnum, 3> bounded_array_values;

      sequence<SomeEnum> dynamic_array_values;
    };
  };
};
```

Fixes https://github.com/ros2/rosidl/issues/260

### List of related pull requests

https://github.com/ros2/test_interface_files/pull/20
https://github.com/ros2/rosidl_python/pull/170
https://github.com/ros2/rosidl_dds/pull/58
https://github.com/ros2/rosidl_typesupport_fastrtps/pull/89

### TODO

- Add support to non-default RMWs
- Design document and documentation