### PR TITLE
Always include whitespace in string literals

### DIFF
--- a/rosidl_parser/rosidl_parser/grammar.lark
+++ b/rosidl_parser/rosidl_parser/grammar.lark
@@ -17,6 +17,14 @@
 %import common.WS
 %ignore WS
 
+// Copied from lark-parser instead of imported so wide string doesn't match: `L   "white space between L and quote"`
+// https://github.com/lark-parser/lark/blob/953171821ed307f700fddf27f3fcb9483346bd46/lark/grammars/common.lark#L26-L29
+_STRING_INNER: /.*?/
+_STRING_ESC_INNER: _STRING_INNER /(?<!\\)(\\\\)*?/
+
+ESCAPED_STRING : "\"" _STRING_ESC_INNER "\""
+ESCAPED_WIDE_STRING: "L\"" _STRING_ESC_INNER "\""
+
 
 // 7.2.2 Comments
 COMMENT: "//" /[^\n]/*
@@ -71,11 +79,8 @@ _ESCAPE_SEQUENCES: "\\n" | "\\t" | "\\v" | "\\b" | "\\r" | "\\f" | "\\a" | "\\\\
 // adjacent string literals are concatenated
 string_literals: string_literal+
 wide_string_literals: wide_string_literal+
-// string_literal: "\"" CHAR* "\""
-// wide_string_literal:  "L\"" CHAR* "\""
-// replace precise rules based on the spec with regex for parsing performance
-string_literal: "\"\"" | "\"" /(\\\"|[^"])+/ "\""
-wide_string_literal: "L\"\"" | "L\"" /(\\\"|[^"])+/ "\""
+string_literal: ESCAPED_STRING
+wide_string_literal: ESCAPED_WIDE_STRING
 
 // 7.2.6.4 Floating-point Literals
 floating_pt_literal: FLOAT

--- a/rosidl_parser/rosidl_parser/parser.py
+++ b/rosidl_parser/rosidl_parser/parser.py
@@ -628,6 +628,16 @@ def get_string_literal_value(string_literal, *, allow_unicode=False):
     assert isinstance(child, Token)
     value = child.value
 
+    assert child.type in ('ESCAPED_STRING', 'ESCAPED_WIDE_STRING')
+    if 'ESCAPED_WIDE_STRING' == child.type:
+        assert len(value) >= 3
+        # Get rid of leading L" and trailing "
+        value = value[2:-1]
+    else:
+        assert len(value) >= 2
+        # Get rid of leading " and trailing "
+        value = value[1:-1]
+
     regex = _get_escape_sequences_regex(allow_unicode=allow_unicode)
     value = regex.sub(_decode_escape_sequence, value)
     # unescape double quote and backslash if preceeded by a backslash

--- a/rosidl_parser/test/test_parser.py
+++ b/rosidl_parser/test/test_parser.py
@@ -30,6 +30,8 @@ from rosidl_parser.definition import Service
 from rosidl_parser.definition import UnboundedSequence
 from rosidl_parser.definition import UnboundedString
 from rosidl_parser.definition import UnboundedWString
+from rosidl_parser.parser import get_ast_from_idl_string
+from rosidl_parser.parser import get_string_literals_value
 from rosidl_parser.parser import parse_idl_file
 
 MESSAGE_IDL_LOCATOR = IdlLocator(
@@ -43,6 +45,38 @@ ACTION_IDL_LOCATOR = IdlLocator(
 @pytest.fixture(scope='module')
 def message_idl_file():
     return parse_idl_file(MESSAGE_IDL_LOCATOR)
+
+
+def test_whitespace_at_start_of_string():
+    # Repeat to check ros2/rosidl#676
+    for _ in range(10):
+        ast = get_ast_from_idl_string('const string foo = " e";')
+        token = next(ast.find_pred(lambda t: 'string_literals' == t.data))
+        assert ' e' == get_string_literals_value(token)
+
+
+def test_whitespace_at_start_of_wide_string():
+    # Repeat to check ros2/rosidl#676
+    for _ in range(10):
+        ast = get_ast_from_idl_string('const wstring foo = L" e";')
+        token = next(ast.find_pred(lambda t: 'wide_string_literals' == t.data))
+        assert ' e' == get_string_literals_value(token, allow_unicode=True)
+
+
+def test_whitespace_at_end_of_string():
+    # Repeat to check ros2/rosidl#676
+    for _ in range(10):
+        ast = get_ast_from_idl_string('const string foo = "e ";')
+        token = next(ast.find_pred(lambda t: 'string_literals' == t.data))
+        assert 'e ' == get_string_literals_value(token)
+
+
+def test_whitespace_at_end_of_wide_string():
+    # Repeat to check ros2/rosidl#676
+    for _ in range(10):
+        ast = get_ast_from_idl_string('const wstring foo = L"e ";')
+        token = next(ast.find_pred(lambda t: 'wide_string_literals' == t.data))
+        assert 'e ' == get_string_literals_value(token, allow_unicode=True)
 
 
 def test_message_parser(message_idl_file):


### PR DESCRIPTION
Alternative to #677 
Fixes #676 

`rosidl_parser` randomly ignores whitespace at the start of string literals. This example matches the string literal as `Token('__ANON_6', '    e')` or `Token('__ANON_6', 'e')` when run multiple times; however, stripping the whitespace is incorrect.

```python3
from rosidl_parser.parser import get_ast_from_idl_string

idl_str ='''module MRE {
const string foo = "    e";
};'''
print(get_ast_from_idl_string(idl_str))
```

I think the cause is a combination of ignoring whitespace

https://github.com/ros2/rosidl/blob/0250ae85e442485fd438451f88f60cbcf65088fd/rosidl_parser/rosidl_parser/grammar.lark#L18

and the way the `string_literal` rule is constructed

https://github.com/ros2/rosidl/blob/0250ae85e442485fd438451f88f60cbcf65088fd/rosidl_parser/rosidl_parser/grammar.lark#L77

The `string_literal` rule has two parts. The first part matches an empty string `""`, and the second part matches a non-empty string. The second part says to match three things. First match a quote `"`. Next match at least one of: an escaped quote `\"`, or a character that is not a quote. Finally match another quote `"`.  I think the problem is the second rule being divided into three parts. It ambiguous if the parser should ignore the whitespace between the first quote and the string content, or if it should include the whitespace via the not-a-quote regex.

Lark has a built in rule for exactly this situation: https://github.com/lark-parser/lark/blob/953171821ed307f700fddf27f3fcb9483346bd46/lark/grammars/common.lark#L26-L29

We could `%import common.ESCAPED_STRING` for `string_literal`, but `whide_string_literal` probably has the same problem. If I defined `wide_string_literal` as `"L" ESCAPED_STRING` then it would also match `L     "white space between L and first quote"`, which is also incorrect. I've chosen to copy the rules from lark into our grammar instead.

There's a stackoverlow post explaining how lark's `ESCAPED_STRING` rule works: https://stackoverflow.com/a/61374198