### PR TITLE
Fix build export dependencies in C introspection package

### DIFF
--- a/rosidl_typesupport_introspection_c/CMakeLists.txt
+++ b/rosidl_typesupport_introspection_c/CMakeLists.txt
@@ -16,9 +16,7 @@ find_package(ament_cmake_ros REQUIRED)
 
 ament_export_dependencies(rosidl_cmake)
 ament_export_dependencies(rosidl_runtime_c)
-# The reason the impl folder is exported is that it contains the implementation
-# for the get_*_type_support_handle functions and defines the opensplice
-# specific version of these functions.
+ament_export_dependencies(rosidl_typesupport_interface)
 
 ament_python_install_package(${PROJECT_NAME})
 

--- a/rosidl_typesupport_introspection_c/cmake/rosidl_typesupport_introspection_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_introspection_c/cmake/rosidl_typesupport_introspection_c_generate_interfaces.cmake
@@ -18,6 +18,10 @@ if(NOT TARGET ${rosidl_generate_interfaces_TARGET}__rosidl_generator_c)
     "'rosidl_typesupport_introspection_c' extension.")
 endif()
 
+find_package(rosidl_runtime_c REQUIRED)
+find_package(rosidl_typesupport_interface REQUIRED)
+find_package(rosidl_typesupport_introspection_c REQUIRED)
+
 set(_output_path
   "${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_introspection_c/${PROJECT_NAME}")
 set(_generated_header_files "")
@@ -121,6 +125,8 @@ target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix} PUBL
   ${rosidl_generate_interfaces_TARGET}__rosidl_generator_c)
 
 target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix} PUBLIC
+  rosidl_runtime_c::rosidl_runtime_c
+  rosidl_typesupport_interface::rosidl_typesupport_interface
   rosidl_typesupport_introspection_c::rosidl_typesupport_introspection_c)
 
 foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})

--- a/rosidl_typesupport_introspection_c/package.xml
+++ b/rosidl_typesupport_introspection_c/package.xml
@@ -19,6 +19,7 @@
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
 
   <build_export_depend>rosidl_runtime_c</build_export_depend>
+  <build_export_depend>rosidl_typesupport_interface</build_export_depend>
 
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>rosidl_cli</exec_depend>


### PR DESCRIPTION
The generated code depends on headers from rosidl_runtime_c and rosidl_typesupport_interface.
Add appropriate build export logic to the CMake code and package.xml.

Removed an obsolete comment from the CMakeLists.txt.