### PR TITLE
Convert ROSIDL char to IDL char

### DIFF
--- a/rosidl_adapter/rosidl_adapter/msg/__init__.py
+++ b/rosidl_adapter/rosidl_adapter/msg/__init__.py
@@ -43,7 +43,7 @@ def convert_msg_to_idl(package_dir, package_name, input_file, output_dir):
 MSG_TYPE_TO_IDL = {
     'bool': 'boolean',
     'byte': 'octet',
-    'char': 'uint8',
+    'char': 'char',
     'int8': 'int8',
     'uint8': 'uint8',
     'int16': 'int16',

--- a/rosidl_adapter/test/data/action/Test.expected.idl
+++ b/rosidl_adapter/test/data/action/Test.expected.idl
@@ -20,7 +20,7 @@ module test_msgs {
       @verbatim (language="comment", text=
         "asd" "\n"
         "bsd")
-      uint8 char_value;
+      char char_value;
 
       float float32_value;
 

--- a/rosidl_adapter/test/data/msg/Test.expected.idl
+++ b/rosidl_adapter/test/data/msg/Test.expected.idl
@@ -19,7 +19,7 @@ module test_msgs {
       @verbatim (language="comment", text=
         "combined styles" "\n"
         "combined styles, part 2")
-      uint8 char_value;
+      char char_value;
 
       float float32_value;
 

--- a/rosidl_adapter/test/data/srv/Test.expected.idl
+++ b/rosidl_adapter/test/data/srv/Test.expected.idl
@@ -20,7 +20,7 @@ module test_msgs {
       @verbatim (language="comment", text=
         "5" "\n"
         "6")
-      uint8 char_value;
+      char char_value;
 
       float float32_value;
 


### PR DESCRIPTION
A *char* is clearly defined in IDL, and the conversion from IDL->python, IDL->C++, IDL->C for a char all seems to exist, yet currently char is converted to uint8 in rosidl_adapter. Is there a reason for this conversion?

Currently:
* rosidl_adapter: ``char`` -> ``uint8`` then,
* C / C++: ``uint8`` -> ``uint8_t``
* Python: ``uint8`` -> ``int``

But to me what makes sense, would be:
* rosidl_adapter: ``char`` -> ``char`` then,
* C / C++: ``char`` -> ``char`` (``char8_t`` in c++20, but ``uint8_t`` if we want to really specify 8 bit usage) 
* Python: ``char`` -> ``str`` with length 1

The design docs will have to be updated if these change.

---

UPDATE:

I just realised that ``char`` has been deprecated since ROS 1, and the conversion is somewhat justified - quoting [ROS 1 msg](http://wiki.ros.org/msg#Field_Types): 

> Deprecated:
> 
> char: deprecated alias for uint8
> byte: deprecated alias for int8

and in [ROS2 design](https://design.ros2.org/articles/legacy_interface_definition.html), it mentions:

> While byte and char are deprecated in ROS 1 they are still part of this definition to ease migration.

Is this deprecation ongoing, and would it be possible to add a deprecation notice somewhere during compilation?

Separate point - ``byte`` doesn't seem like an alias for ``int8`` as explained in the quotes above, it maps to ``unsigned char`` for C++...