### PR TITLE
Add option to rosidl_generate_interfaces to skip dependency export.

### DIFF
--- a/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
@@ -47,14 +47,12 @@
 # :param ADD_LINTER_TESTS: if set lint the interface files using
 #   the ``ament_lint`` package
 # :type ADD_LINTER_TESTS: option
-# :param SKIP_EXPORT_DEPENDENCIES: if set don't ament export the dependencies listed
-# :type SKIP_EXPORT_DEPENDENCIES: option
 #
 # @public
 #
 macro(rosidl_generate_interfaces target)
   cmake_parse_arguments(_ARG
-    "ADD_LINTER_TESTS;SKIP_INSTALL;SKIP_GROUP_MEMBERSHIP_CHECK;SKIP_EXPORT_DEPENDENCIES"
+    "ADD_LINTER_TESTS;SKIP_INSTALL;SKIP_GROUP_MEMBERSHIP_CHECK"
     "LIBRARY_NAME" "DEPENDENCIES"
     ${ARGN})
   if(NOT _ARG_UNPARSED_ARGUMENTS)
@@ -68,7 +66,7 @@ macro(rosidl_generate_interfaces target)
   endif()
 
   _rosidl_cmake_register_package_hook()
-  if(NOT _ARG_SKIP_EXPORT_DEPENDENCIES)
+  if(NOT _ARG_SKIP_INSTALL)
     ament_export_dependencies(${_ARG_DEPENDENCIES})
   endif()
 

--- a/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
@@ -41,18 +41,20 @@
 # :type LIBRARY_NAME: string
 # :param SKIP_INSTALL: if set skip installing the interface files
 # :type SKIP_INSTALL: option
-# :param SKIP_GROUP_MEMBERSHIP_CHECK: if set, skip enforcing the appartenance
-#   to the rosidl_interface_packages group
+# :param SKIP_GROUP_MEMBERSHIP_CHECK: if set, skip enforcing membership in the
+#   rosidl_interface_packages group
 # :type SKIP_GROUP_MEMBERSHIP_CHECK: option
 # :param ADD_LINTER_TESTS: if set lint the interface files using
 #   the ``ament_lint`` package
 # :type ADD_LINTER_TESTS: option
+# :param SKIP_EXPORT_DEPENDENCIES: if set don't ament export the dependencies listed
+# :type SKIP_EXPORT_DEPENDENCIES: option
 #
 # @public
 #
 macro(rosidl_generate_interfaces target)
   cmake_parse_arguments(_ARG
-    "ADD_LINTER_TESTS;SKIP_INSTALL;SKIP_GROUP_MEMBERSHIP_CHECK"
+    "ADD_LINTER_TESTS;SKIP_INSTALL;SKIP_GROUP_MEMBERSHIP_CHECK;SKIP_EXPORT_DEPENDENCIES"
     "LIBRARY_NAME" "DEPENDENCIES"
     ${ARGN})
   if(NOT _ARG_UNPARSED_ARGUMENTS)
@@ -66,7 +68,9 @@ macro(rosidl_generate_interfaces target)
   endif()
 
   _rosidl_cmake_register_package_hook()
-  ament_export_dependencies(${_ARG_DEPENDENCIES})
+  if(NOT _ARG_SKIP_EXPORT_DEPENDENCIES)
+    ament_export_dependencies(${_ARG_DEPENDENCIES})
+  endif()
 
   # check that passed interface files exist
   # a tuple with an absolute base and a relative path is returned as is


### PR DESCRIPTION
When a dependency is declared in rosidl_generate_interfaces(), ament_export_dependencies() for that dependency is automatically called.  That is the correct default behavior, but it isn't always the behavior that is wanted.  In particular, if a package has messages that are only used for tests, we don't want to export those dependencies downstream.  Add an option to skip dependency export for rosidl_generate_interfaces.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This came out of https://github.com/ros-tooling/libstatistics_collector/pull/54 , and `libstatistics_collector` will be the first user of it.