### PR TITLE
rosidl_adapter/cmake/rosidl_adapt_interfaces.cmake: Make ament free

### DIFF
--- a/rosidl_adapter/cmake/rosidl_adapt_interfaces.cmake
+++ b/rosidl_adapter/cmake/rosidl_adapt_interfaces.cmake
@@ -37,13 +37,11 @@ function(rosidl_adapt_interfaces idl_var arguments_file)
       "arguments: ${ARG_UNPARSED_ARGUMENTS}")
   endif()
 
-  find_package(ament_cmake_core REQUIRED)  # for get_executable_path
   find_package(Python3 REQUIRED COMPONENTS Interpreter)
-  get_executable_path(python_interpreter Python3::Interpreter CONFIGURE)
 
   set(idl_output "${CMAKE_CURRENT_BINARY_DIR}/rosidl_adapter/${ARG_TARGET}.idls")
   set(cmd
-    "${python_interpreter}" -m rosidl_adapter
+    "${Python3_EXECUTABLE}" -m rosidl_adapter
     --package-name ${PROJECT_NAME}
     --arguments-file "${arguments_file}"
     --output-dir "${CMAKE_CURRENT_BINARY_DIR}/rosidl_adapter/${PROJECT_NAME}"


### PR DESCRIPTION
The module FindPython3 already provides the interpreter executable path via Python3_EXECUTABLE.  No need to use ament.

Less loaded module means faster execution.  And easier for out of tree build system to reuse this function.

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>