### PR TITLE
humble - fix conversion to ‘std::streamsize’ from ‘size_t’ 

### DIFF
--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/traits.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/traits.hpp
@@ -17,6 +17,7 @@
 
 #include <codecvt>
 #include <iomanip>
+#include <iosfwd>
 #include <string>
 #include <type_traits>
 
@@ -114,7 +115,7 @@ inline void value_to_yaml(const std::string & value, std::ostream & out)
     if (pos == std::string::npos) {
       pos = value.size();
     }
-    out.write(&value[index], pos - index);
+    out.write(&value[index], static_cast<std::streamsize>(pos - index));
     if (pos >= value.size()) {
       break;
     }


### PR DESCRIPTION
Cherry-pick for humble of https://github.com/ros2/rosidl/pull/715

fix conversion to ‘std::streamsize’ {aka ‘long int’} from ‘size_t’ {aka ‘long unsigned int’} may change the sign of the result

Fix for warning:
```
In file included from /opt/ros/humble/include/builtin_interfaces/builtin_interfaces/msg/detail/duration__traits.hpp:15,
                 from /opt/ros/humble/include/builtin_interfaces/builtin_interfaces/msg/duration.hpp:9,
                 from /opt/ros/humble/include/rclcpp/rclcpp/duration.hpp:20,
                 from /opt/ros/humble/include/rclcpp/rclcpp/qos.hpp:20,
                 from /opt/ros/humble/include/rclcpp/rclcpp/node_interfaces/node_graph_interface.hpp:32,
                 from /opt/ros/humble/include/rclcpp/rclcpp/client.hpp:42,
                 from /opt/ros/humble/include/rclcpp/rclcpp/callback_group.hpp:23,
                 from /opt/ros/humble/include/rclcpp/rclcpp/any_executable.hpp:20,
                 from /opt/ros/humble/include/rclcpp/rclcpp/memory_strategy.hpp:25,
                 from /opt/ros/humble/include/rclcpp/rclcpp/memory_strategies.hpp:18,
                 from /opt/ros/humble/include/rclcpp/rclcpp/executor_options.hpp:20,
                 from /opt/ros/humble/include/rclcpp/rclcpp/executor.hpp:37,
                 from /opt/ros/humble/include/rclcpp/rclcpp/executors/multi_threaded_executor.hpp:25,
                 from /opt/ros/humble/include/rclcpp/rclcpp/executors.hpp:21,
                 from /opt/ros/humble/include/rclcpp/rclcpp/rclcpp.hpp:155,
                 from 
                 from /as_drive/ws/src/as_drive_nodes/planning/as_lanelet_map_provider/src/lanelet_map_provider_node.cpp:4:
/opt/ros/humble/include/rosidl_runtime_cpp/rosidl_runtime_cpp/traits.hpp: In function ‘void rosidl_generator_traits::value_to_yaml(const string&, std::ostream&)’:
/opt/ros/humble/include/rosidl_runtime_cpp/rosidl_runtime_cpp/traits.hpp:117:34: error: conversion to ‘std::streamsize’ {aka ‘long int’} from ‘size_t’ {aka ‘long unsigned int’} may change the sign of the result [-Werror=sign-conversion]
  117 |     out.write(&value[index], pos - index);
```
