### PR TITLE
ZSH: fix argcomplete clearing previous registered completions

### DIFF
--- a/rosidl_cli/colcon.pkg
+++ b/rosidl_cli/colcon.pkg
@@ -1,0 +1,6 @@
+{
+    "hooks": [
+        "share/rosidl_cli/environment/rosidl-argcomplete.bash",
+        "share/rosidl_cli/environment/rosidl-argcomplete.zsh"
+    ]
+}

--- a/rosidl_cli/completion/rosidl-argcomplete.zsh
+++ b/rosidl_cli/completion/rosidl-argcomplete.zsh
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-autoload -U +X compinit && compinit
+if (( ! ${+_comps} )); then
+  autoload -U +X compinit && compinit
+fi
 autoload -U +X bashcompinit && bashcompinit
 
 # Get this scripts directory


### PR DESCRIPTION
This is an alternative to https://github.com/ros2/rosidl/pull/702, up for reviews/discussion

More discussion in https://github.com/ros2/ros2cli/issues/534