### PR TITLE
Make sure to add the event message to typesupport introspection cpp.

### DIFF
--- a/rosidl_typesupport_introspection_cpp/resource/srv__rosidl_typesupport_introspection_cpp.hpp.em
+++ b/rosidl_typesupport_introspection_cpp/resource/srv__rosidl_typesupport_introspection_cpp.hpp.em
@@ -14,6 +14,13 @@ TEMPLATE(
 }@
 
 @{
+TEMPLATE(
+    'msg__rosidl_typesupport_introspection_cpp.hpp.em',
+    package_name=package_name, interface_path=interface_path, message=service.event_message,
+    include_directives=include_directives)
+}@
+
+@{
 header_files = [
     'rosidl_runtime_c/service_type_support_struct.h',
     'rosidl_typesupport_interface/macros.h',


### PR DESCRIPTION
This is needed for the RMWs that use introspection, rather than statically generated code.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Along with https://github.com/ros2/rosidl_typesupport/pull/132, this should fix the error mentioned in https://github.com/ros2/ros2/issues/1285#issuecomment-1419791566