### PR TITLE
Enable document generation using rosdoc2 for ament_python pkgs

### DIFF
--- a/rosidl_cli/rosidl_cli/command/helpers.py
+++ b/rosidl_cli/rosidl_cli/command/helpers.py
@@ -52,11 +52,12 @@ def interface_path_as_tuple(path):
     An interface definition file path is a relative path, optionally prefixed
     by a path against which to resolve the former followed by a colon ':'.
     Thus, this function applies following logic:
+
     - If a given path follows this pattern, it is split at the colon ':'
     - If a given path is prefixed by a relative path, it is resolved
-      relative to the current working directory.
+        relative to the current working directory.
     - If a given path has no prefix, the current working directory is
-      used as prefix.
+        used as prefix.
     """
     path_as_string = str(path)
     if ':' not in path_as_string:

--- a/rosidl_cli/rosidl_cli/entry_points.py
+++ b/rosidl_cli/rosidl_cli/entry_points.py
@@ -68,7 +68,7 @@ def load_entry_points(group_name, *, strict=False, **kwargs):
     """
     Load entry points for a specific group.
 
-    See :py:function:`get_entry_points` for further reference on
+    See :py:meth:`get_entry_points` for further reference on
     additional keyword arguments.
 
     :param str group_name: the name of the entry point group

--- a/rosidl_cli/rosidl_cli/extensions.py
+++ b/rosidl_cli/rosidl_cli/extensions.py
@@ -70,7 +70,7 @@ def load_extensions(group_name, *, specs=None, strict=False):
 
     :param str group_name: the name of the extension group
     :param list specs: an optional collection of extension specs
-      (see :py:function:`parse_extension_specification` for spec format)
+      (see :py:meth:`parse_extension_specification` for spec format)
     :param bool strict: whether to raise or warn on error
     :returns: a list of :py:class:`Extension` instances
     :rtype: list


### PR DESCRIPTION
Fix docstrings to generate documentation without any warnings using `autodoc`