### PR TITLE
Return reference from BoundedVector::emplace_back

### DIFF
--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/bounded_vector.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/bounded_vector.hpp
@@ -474,7 +474,7 @@ public:
    * \param args Arguments to be forwarded to the constructor of Tp
    */
   template<typename ... Args>
-  auto
+  typename Base::reference
   emplace_back(Args && ... args)
   {
     if (size() >= UpperBound) {

--- a/rosidl_runtime_cpp/test/test_bounded_vector.cpp
+++ b/rosidl_runtime_cpp/test/test_bounded_vector.cpp
@@ -43,7 +43,8 @@ TEST(rosidl_generator_cpp, bounded_vector_rvalue) {
   ASSERT_EQ(v.size(), 0u);
   ASSERT_EQ(v.max_size(), 2u);
   v.emplace_back(1);
-  v.emplace_back(2);
+  auto & value = v.emplace_back(2);
+  ASSERT_EQ(value, 2);
   ASSERT_THROW(v.emplace_back(3), std::length_error);
   ASSERT_EQ(v.size(), 2u);
   // move assignment


### PR DESCRIPTION
Using `auto` made `BoundedVector::emplace_back()` return a copy instead of a reference. Code such as the following would not compile in that case:
```
auto & value = bounded_vector.emplace_back();
```
Due to the `auto` usage an rvalue was returned which couldn't be bound to an lvalue reference.