### PR TITLE
rosidl_runtime_cpp: add type hash to string utility

### DIFF
--- a/rosidl_runtime_cpp/CMakeLists.txt
+++ b/rosidl_runtime_cpp/CMakeLists.txt
@@ -5,11 +5,11 @@ project(rosidl_runtime_cpp)
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_runtime_c REQUIRED)
 
-add_library(${PROJECT_NAME} INTERFACE)
-target_include_directories(${PROJECT_NAME} INTERFACE
+add_library(${PROJECT_NAME} src/type_hash.cpp)
+target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
-target_link_libraries(${PROJECT_NAME} INTERFACE
+target_link_libraries(${PROJECT_NAME} PUBLIC
   rosidl_runtime_c::rosidl_runtime_c)
 
 if(MSVC)
@@ -75,6 +75,11 @@ if(BUILD_TESTING)
   ament_add_gtest(test_bounded_vector test/test_bounded_vector.cpp)
   if(TARGET test_bounded_vector)
     target_link_libraries(test_bounded_vector ${PROJECT_NAME})
+  endif()
+
+  ament_add_gtest(test_type_hash test/test_type_hash.cpp)
+  if(TARGET test_type_hash)
+    target_link_libraries(test_type_hash ${PROJECT_NAME})
   endif()
 
   add_performance_test(benchmark_bounded_vector test/benchmark/benchmark_bounded_vector.cpp)

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/type_hash.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/type_hash.hpp
@@ -1,0 +1,30 @@
+// Copyright 2023 Foxglove Technologies Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_RUNTIME_CPP__TYPE_HASH_HPP_
+#define ROSIDL_RUNTIME_CPP__TYPE_HASH_HPP_
+
+#include <string>
+#include "rosidl_runtime_c/type_hash.h"
+
+namespace rosidl_runtime_cpp
+{
+
+// returns the REP-2011 specified RIHS string for a type hash struct.
+// returns the empty string for invalid or unset type hash values (identified with a version of 0).
+std::string type_hash_to_string(const rosidl_type_hash_t & type_hash);
+
+}  // namespace rosidl_runtime_cpp
+
+#endif  // ROSIDL_RUNTIME_CPP__TYPE_HASH_HPP_

--- a/rosidl_runtime_cpp/src/type_hash.cpp
+++ b/rosidl_runtime_cpp/src/type_hash.cpp
@@ -1,0 +1,37 @@
+// Copyright 2023 Foxglove Technologies Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <sstream>
+#include <iomanip>
+#include "rosidl_runtime_cpp/type_hash.hpp"
+
+namespace rosidl_runtime_cpp
+{
+
+std::string type_hash_to_string(const rosidl_type_hash_t & type_hash)
+{
+  if (type_hash.version != 1) {
+    return "";
+  }
+
+  std::stringstream ss;
+  ss << "RIHS01_";
+  ss << std::hex;
+  for (int i = 0; i < ROSIDL_TYPE_HASH_SIZE; ++i) {
+    ss << std::setw(2) << std::setfill('0') << static_cast<int>(type_hash.value[i]);
+  }
+  return ss.str();
+}
+
+}  // namespace rosidl_runtime_cpp

--- a/rosidl_runtime_cpp/test/test_type_hash.cpp
+++ b/rosidl_runtime_cpp/test/test_type_hash.cpp
@@ -1,0 +1,36 @@
+// Copyright 2023, Foxglove
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "rosidl_runtime_cpp/type_hash.hpp"
+
+using namespace ::testing;  // NOLINT
+
+TEST(TestTypeHash, unset_behavior) {
+  rosidl_type_hash_t type_hash;
+  type_hash.version = 0;
+  std::string result = rosidl_runtime_cpp::type_hash_to_string(type_hash);
+  EXPECT_EQ("", result);
+}
+
+TEST(TestTypeHash, v1_format) {
+  rosidl_type_hash_t type_hash;
+  type_hash.version = 1;
+  for (int i = 0; i < ROSIDL_TYPE_HASH_SIZE; ++i) {
+    type_hash.value[i] = i;
+  }
+  std::string result = rosidl_runtime_cpp::type_hash_to_string(type_hash);
+  EXPECT_EQ("RIHS01_000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f", result);
+}


### PR DESCRIPTION
Adds a utility function to convert a rosidl_type_hash_t to a printable string, for serialization in JSON and visual comparison.