### PR TITLE
rosidl_generator_cpp: Initial changes for cpp17 features, ie std::optional

### DIFF
--- a/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
+++ b/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
@@ -53,7 +53,7 @@ def prefix_with_bom_if_necessary(content):
 
 MSG_TYPE_TO_CPP = {
     'boolean': 'bool',
-    'octet': 'unsigned char',  # TODO change to std::byte with C++17
+    'octet': 'std::byte',
     'char': 'unsigned char',
     'wchar': 'char16_t',
     'float': 'float',
@@ -120,6 +120,8 @@ def msg_type_to_cpp(type_):
                 ('std::vector<%s, typename std::allocator_traits<ContainerAllocator>::template ' +
                  'rebind_alloc<%s>>') % (cpp_type, cpp_type)
         elif isinstance(type_, BoundedSequence):
+            if type_.maximum_size == 1:
+                return 'std::optional<%s>' % (cpp_type)
             return \
                 ('rosidl_runtime_cpp::BoundedVector<%s, %u, typename std::allocator_traits' +
                  '<ContainerAllocator>::template rebind_alloc<%s>>') % (cpp_type,


### PR DESCRIPTION
Based off discussion https://discourse.ros.org/t/optional-fields-in-message/991/16 As per [REP-2000](https://www.ros.org/reps/rep-2000.html), versions Galactic+ have minimum language requirements of C++17. This commit begins re-discussions on supporting std::optional through msg types of BoundedSequence, max size 1. `type[<=1]`.