### PR TITLE
Add #ifndef NDEBUG to asserts

### DIFF
--- a/rosidl_generator_c/resource/full__description.c.em
+++ b/rosidl_generator_c/resource/full__description.c.em
@@ -150,7 +150,9 @@ const rosidl_runtime_c__type_description__TypeDescription *
 c_typename = typename_to_c(ref_td['type_name'])
 }@
 @[    if ref_td['type_name'] not in full_type_names]@
+    #ifndef NDEBUG
     assert(0 == memcmp(&@(c_typename)__EXPECTED_HASH, @(c_typename)__@(GET_HASH_FUNC)(NULL), sizeof(rosidl_type_hash_t)));
+    #endif
 @[    end if]@
     description.referenced_type_descriptions.data[@(idx)].fields = @(c_typename)__@(GET_DESCRIPTION_FUNC)(NULL)->type_description.fields;
 @[  end for]@

--- a/rosidl_runtime_c/src/type_description/field__description.c
+++ b/rosidl_runtime_c/src/type_description/field__description.c
@@ -100,9 +100,9 @@ rosidl_runtime_c__type_description__Field__get_type_description(
   if (!constructed) {
     #ifndef NDEBUG
     assert(0 == memcmp(&rosidl_runtime_c__type_description__FieldType__EXPECTED_HASH, rosidl_runtime_c__type_description__FieldType__get_type_hash(NULL), sizeof(rosidl_type_hash_t)));
+    #endif
     description.referenced_type_descriptions.data[0].fields = rosidl_runtime_c__type_description__FieldType__get_type_description(NULL)->type_description.fields;
     constructed = true;
-    #endif
   }
   return &description;
 }

--- a/rosidl_runtime_c/src/type_description/field__description.c
+++ b/rosidl_runtime_c/src/type_description/field__description.c
@@ -98,9 +98,11 @@ rosidl_runtime_c__type_description__Field__get_type_description(
     {rosidl_runtime_c__type_description__Field__REFERENCED_TYPE_DESCRIPTIONS, 1, 1},
   };
   if (!constructed) {
+    #ifndef NDEBUG
     assert(0 == memcmp(&rosidl_runtime_c__type_description__FieldType__EXPECTED_HASH, rosidl_runtime_c__type_description__FieldType__get_type_hash(NULL), sizeof(rosidl_type_hash_t)));
     description.referenced_type_descriptions.data[0].fields = rosidl_runtime_c__type_description__FieldType__get_type_description(NULL)->type_description.fields;
     constructed = true;
+    #endif
   }
   return &description;
 }

--- a/rosidl_runtime_c/src/type_description/individual_type_description__description.c
+++ b/rosidl_runtime_c/src/type_description/individual_type_description__description.c
@@ -101,11 +101,11 @@ rosidl_runtime_c__type_description__IndividualTypeDescription__get_type_descript
   if (!constructed) {
     #ifndef NDEBUG
     assert(0 == memcmp(&rosidl_runtime_c__type_description__Field__EXPECTED_HASH, rosidl_runtime_c__type_description__Field__get_type_hash(NULL), sizeof(rosidl_type_hash_t)));
+    assert(0 == memcmp(&rosidl_runtime_c__type_description__FieldType__EXPECTED_HASH, rosidl_runtime_c__type_description__FieldType__get_type_hash(NULL), sizeof(rosidl_type_hash_t)));#endif
+    #endif
     description.referenced_type_descriptions.data[0].fields = rosidl_runtime_c__type_description__Field__get_type_description(NULL)->type_description.fields;
-    assert(0 == memcmp(&rosidl_runtime_c__type_description__FieldType__EXPECTED_HASH, rosidl_runtime_c__type_description__FieldType__get_type_hash(NULL), sizeof(rosidl_type_hash_t)));
     description.referenced_type_descriptions.data[1].fields = rosidl_runtime_c__type_description__FieldType__get_type_description(NULL)->type_description.fields;
     constructed = true;
-    #endif
   }
   return &description;
 }

--- a/rosidl_runtime_c/src/type_description/individual_type_description__description.c
+++ b/rosidl_runtime_c/src/type_description/individual_type_description__description.c
@@ -99,11 +99,13 @@ rosidl_runtime_c__type_description__IndividualTypeDescription__get_type_descript
     {rosidl_runtime_c__type_description__IndividualTypeDescription__REFERENCED_TYPE_DESCRIPTIONS, 2, 2},
   };
   if (!constructed) {
+    #ifndef NDEBUG
     assert(0 == memcmp(&rosidl_runtime_c__type_description__Field__EXPECTED_HASH, rosidl_runtime_c__type_description__Field__get_type_hash(NULL), sizeof(rosidl_type_hash_t)));
     description.referenced_type_descriptions.data[0].fields = rosidl_runtime_c__type_description__Field__get_type_description(NULL)->type_description.fields;
     assert(0 == memcmp(&rosidl_runtime_c__type_description__FieldType__EXPECTED_HASH, rosidl_runtime_c__type_description__FieldType__get_type_hash(NULL), sizeof(rosidl_type_hash_t)));
     description.referenced_type_descriptions.data[1].fields = rosidl_runtime_c__type_description__FieldType__get_type_description(NULL)->type_description.fields;
     constructed = true;
+    #endif
   }
   return &description;
 }

--- a/rosidl_runtime_c/src/type_description/type_description__description.c
+++ b/rosidl_runtime_c/src/type_description/type_description__description.c
@@ -111,6 +111,7 @@ rosidl_runtime_c__type_description__TypeDescription__get_type_description(
     {rosidl_runtime_c__type_description__TypeDescription__REFERENCED_TYPE_DESCRIPTIONS, 3, 3},
   };
   if (!constructed) {
+    #ifndef NDEBUG
     assert(0 == memcmp(&rosidl_runtime_c__type_description__Field__EXPECTED_HASH, rosidl_runtime_c__type_description__Field__get_type_hash(NULL), sizeof(rosidl_type_hash_t)));
     description.referenced_type_descriptions.data[0].fields = rosidl_runtime_c__type_description__Field__get_type_description(NULL)->type_description.fields;
     assert(0 == memcmp(&rosidl_runtime_c__type_description__FieldType__EXPECTED_HASH, rosidl_runtime_c__type_description__FieldType__get_type_hash(NULL), sizeof(rosidl_type_hash_t)));
@@ -118,6 +119,7 @@ rosidl_runtime_c__type_description__TypeDescription__get_type_description(
     assert(0 == memcmp(&rosidl_runtime_c__type_description__IndividualTypeDescription__EXPECTED_HASH, rosidl_runtime_c__type_description__IndividualTypeDescription__get_type_hash(NULL), sizeof(rosidl_type_hash_t)));
     description.referenced_type_descriptions.data[2].fields = rosidl_runtime_c__type_description__IndividualTypeDescription__get_type_description(NULL)->type_description.fields;
     constructed = true;
+    #endif
   }
   return &description;
 }

--- a/rosidl_runtime_c/src/type_description/type_description__description.c
+++ b/rosidl_runtime_c/src/type_description/type_description__description.c
@@ -113,13 +113,13 @@ rosidl_runtime_c__type_description__TypeDescription__get_type_description(
   if (!constructed) {
     #ifndef NDEBUG
     assert(0 == memcmp(&rosidl_runtime_c__type_description__Field__EXPECTED_HASH, rosidl_runtime_c__type_description__Field__get_type_hash(NULL), sizeof(rosidl_type_hash_t)));
-    description.referenced_type_descriptions.data[0].fields = rosidl_runtime_c__type_description__Field__get_type_description(NULL)->type_description.fields;
     assert(0 == memcmp(&rosidl_runtime_c__type_description__FieldType__EXPECTED_HASH, rosidl_runtime_c__type_description__FieldType__get_type_hash(NULL), sizeof(rosidl_type_hash_t)));
-    description.referenced_type_descriptions.data[1].fields = rosidl_runtime_c__type_description__FieldType__get_type_description(NULL)->type_description.fields;
     assert(0 == memcmp(&rosidl_runtime_c__type_description__IndividualTypeDescription__EXPECTED_HASH, rosidl_runtime_c__type_description__IndividualTypeDescription__get_type_hash(NULL), sizeof(rosidl_type_hash_t)));
+    #endif
+    description.referenced_type_descriptions.data[0].fields = rosidl_runtime_c__type_description__Field__get_type_description(NULL)->type_description.fields;
+    description.referenced_type_descriptions.data[1].fields = rosidl_runtime_c__type_description__FieldType__get_type_description(NULL)->type_description.fields;
     description.referenced_type_descriptions.data[2].fields = rosidl_runtime_c__type_description__IndividualTypeDescription__get_type_description(NULL)->type_description.fields;
     constructed = true;
-    #endif
   }
   return &description;
 }


### PR DESCRIPTION

This PR disables assertions with undefined variables on Release mode:

- The `#ifndef NDEBUG` guards are messing with the build process with some assert implementations: 
https://github.com/ros2/rosidl/blob/7cbb1161e8d3fa9aff29a481bce0e6c2b56715b5/rosidl_runtime_c/src/type_description/field__description.c#L29-L37

- And the later assert, which should not use the variable if `NDEBUG` is defined:
https://github.com/ros2/rosidl/blob/7cbb1161e8d3fa9aff29a481bce0e6c2b56715b5/rosidl_runtime_c/src/type_description/field__description.c#L101

### A little explanation

This behaviour should be OK on all platforms, but some assert implementations still use the variable when they are dissabled, as its happening on our cross-compiled systems:
```
src/rosidl/rosidl_runtime_c/src/type_description/individual_type_description__description.c:104:25: error: 'rosidl_runtime_c__type_description__FieldType__EXPECTED_HASH' undeclared (first use in this function); did you mean 'rosidl_runtime_c__type_description__FieldType__TYPE_NAME'?
     assert(0 == memcmp(&rosidl_runtime_c__type_description__FieldType__EXPECTED_HASH, rosidl_runtime_c__type_description__FieldType__get_type_hash(NULL), sizeof(rosidl_type_hash_t)));
```

You can check what is happening on the assert implementation we are forces to use : [assert.h](https://github.com/espressif/esp-idf/blob/master/components/newlib/platform_include/assert.h).

If `NDEBUG` is defined, the assert macro still uses the variable and cast it to void, leading to the variable undefined error:
`#define assert(__e) ((void)(__e))`
