### PR TITLE
Mark _ in benchmark tests as unused.

### DIFF
--- a/rosidl_runtime_c/test/benchmark/benchmark_string_conversion.cpp
+++ b/rosidl_runtime_c/test/benchmark/benchmark_string_conversion.cpp
@@ -38,6 +38,7 @@ BENCHMARK_DEFINE_F(PerformanceTest, string_assign)(benchmark::State & st)
   reset_heap_counters();
 
   for (auto _ : st) {
+    (void)_;
     rosidl_runtime_c__String__assignn(&s, data.c_str(), len);
   }
 
@@ -64,6 +65,7 @@ BENCHMARK_DEFINE_F(PerformanceTest, string_resize_assign)(benchmark::State & st)
   reset_heap_counters();
 
   for (auto _ : st) {
+    (void)_;
     rosidl_runtime_c__String__assignn(&s, data.c_str(), len);
     rosidl_runtime_c__String__assignn(&s, data.c_str(), 0);
   }
@@ -90,6 +92,7 @@ BENCHMARK_DEFINE_F(PerformanceTest, u16string_assign)(benchmark::State & st)
   reset_heap_counters();
 
   for (auto _ : st) {
+    (void)_;
     rosidl_runtime_c__U16String__assignn_from_char(&s, data.c_str(), len);
   }
 
@@ -115,6 +118,7 @@ BENCHMARK_DEFINE_F(PerformanceTest, u16string_resize_assign)(benchmark::State & 
   reset_heap_counters();
 
   for (auto _ : st) {
+    (void)_;
     rosidl_runtime_c__U16String__assignn_from_char(&s, data.c_str(), len);
     rosidl_runtime_c__U16String__resize(&s, 0);
   }


### PR DESCRIPTION
This helps clang static analysis.