### PR TITLE
Fix IWYU for clangd in C and C++

### DIFF
--- a/rosidl_generator_c/resource/idl__functions.h.em
+++ b/rosidl_generator_c/resource/idl__functions.h.em
@@ -1,7 +1,7 @@
 // generated from rosidl_generator_c/resource/idl__functions.h.em
 // with input from @(package_name):@(interface_path)
 // generated code does not contain a copyright notice
-@{from rosidl_cmake import convert_camel_case_to_lower_case_underscore}
+@{from rosidl_pycommon import convert_camel_case_to_lower_case_underscore}
 // IWYU pragma: private, include "@(package_name)/@(interface_path.parent)/@(convert_camel_case_to_lower_case_underscore(interface_path.stem)).h"
 
 @

--- a/rosidl_generator_c/resource/idl__functions.h.em
+++ b/rosidl_generator_c/resource/idl__functions.h.em
@@ -1,6 +1,9 @@
 // generated from rosidl_generator_c/resource/idl__functions.h.em
 // with input from @(package_name):@(interface_path)
 // generated code does not contain a copyright notice
+@{from rosidl_cmake import convert_camel_case_to_lower_case_underscore}
+// IWYU pragma: private, include "@(package_name)/@(interface_path.parent)/@(convert_camel_case_to_lower_case_underscore(interface_path.stem)).h"
+
 @
 @#######################################################################
 @# EmPy template for generating <idl>__struct.h files

--- a/rosidl_generator_c/resource/idl__struct.h.em
+++ b/rosidl_generator_c/resource/idl__struct.h.em
@@ -1,7 +1,7 @@
 // generated from rosidl_generator_c/resource/idl__struct.h.em
 // with input from @(package_name):@(interface_path)
 // generated code does not contain a copyright notice
-@{from rosidl_cmake import convert_camel_case_to_lower_case_underscore}
+@{from rosidl_pycommon import convert_camel_case_to_lower_case_underscore}
 // IWYU pragma: private, include "@(package_name)/@(interface_path.parent)/@(convert_camel_case_to_lower_case_underscore(interface_path.stem)).h"
 
 @

--- a/rosidl_generator_c/resource/idl__struct.h.em
+++ b/rosidl_generator_c/resource/idl__struct.h.em
@@ -1,6 +1,9 @@
 // generated from rosidl_generator_c/resource/idl__struct.h.em
 // with input from @(package_name):@(interface_path)
 // generated code does not contain a copyright notice
+@{from rosidl_cmake import convert_camel_case_to_lower_case_underscore}
+// IWYU pragma: private, include "@(package_name)/@(interface_path.parent)/@(convert_camel_case_to_lower_case_underscore(interface_path.stem)).h"
+
 @
 @#######################################################################
 @# EmPy template for generating <idl>__struct.h files

--- a/rosidl_generator_c/resource/idl__type_support.h.em
+++ b/rosidl_generator_c/resource/idl__type_support.h.em
@@ -1,7 +1,7 @@
 // generated from rosidl_generator_c/resource/idl__type_support.h.em
 // with input from @(package_name):@(interface_path)
 // generated code does not contain a copyright notice
-@{from rosidl_cmake import convert_camel_case_to_lower_case_underscore}
+@{from rosidl_pycommon import convert_camel_case_to_lower_case_underscore}
 // IWYU pragma: private, include "@(package_name)/@(interface_path.parent)/@(convert_camel_case_to_lower_case_underscore(interface_path.stem)).h"
 
 @

--- a/rosidl_generator_c/resource/idl__type_support.h.em
+++ b/rosidl_generator_c/resource/idl__type_support.h.em
@@ -1,6 +1,9 @@
 // generated from rosidl_generator_c/resource/idl__type_support.h.em
 // with input from @(package_name):@(interface_path)
 // generated code does not contain a copyright notice
+@{from rosidl_cmake import convert_camel_case_to_lower_case_underscore}
+// IWYU pragma: private, include "@(package_name)/@(interface_path.parent)/@(convert_camel_case_to_lower_case_underscore(interface_path.stem)).h"
+
 @
 @#######################################################################
 @# EmPy template for generating <idl>__struct.h files

--- a/rosidl_generator_cpp/resource/idl__builder.hpp.em
+++ b/rosidl_generator_cpp/resource/idl__builder.hpp.em
@@ -1,7 +1,7 @@
 // generated from rosidl_generator_cpp/resource/idl__builder.hpp.em
 // with input from @(package_name):@(interface_path)
 // generated code does not contain a copyright notice
-@{from rosidl_cmake import convert_camel_case_to_lower_case_underscore}
+@{from rosidl_pycommon import convert_camel_case_to_lower_case_underscore}
 // IWYU pragma: private, include "@(package_name)/@(interface_path.parent)/@(convert_camel_case_to_lower_case_underscore(interface_path.stem)).hpp"
 
 @

--- a/rosidl_generator_cpp/resource/idl__builder.hpp.em
+++ b/rosidl_generator_cpp/resource/idl__builder.hpp.em
@@ -1,6 +1,9 @@
 // generated from rosidl_generator_cpp/resource/idl__builder.hpp.em
 // with input from @(package_name):@(interface_path)
 // generated code does not contain a copyright notice
+@{from rosidl_cmake import convert_camel_case_to_lower_case_underscore}
+// IWYU pragma: private, include "@(package_name)/@(interface_path.parent)/@(convert_camel_case_to_lower_case_underscore(interface_path.stem)).hpp"
+
 @
 @#######################################################################
 @# EmPy template for generating <idl>__builder.hpp files

--- a/rosidl_generator_cpp/resource/idl__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/idl__struct.hpp.em
@@ -1,6 +1,9 @@
 // generated from rosidl_generator_cpp/resource/idl__struct.hpp.em
 // with input from @(package_name):@(interface_path)
 // generated code does not contain a copyright notice
+@{from rosidl_cmake import convert_camel_case_to_lower_case_underscore}
+// IWYU pragma: private, include "@(package_name)/@(interface_path.parent)/@(convert_camel_case_to_lower_case_underscore(interface_path.stem)).hpp"
+
 @
 @#######################################################################
 @# EmPy template for generating <idl>__struct.hpp files

--- a/rosidl_generator_cpp/resource/idl__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/idl__struct.hpp.em
@@ -1,7 +1,7 @@
 // generated from rosidl_generator_cpp/resource/idl__struct.hpp.em
 // with input from @(package_name):@(interface_path)
 // generated code does not contain a copyright notice
-@{from rosidl_cmake import convert_camel_case_to_lower_case_underscore}
+@{from rosidl_pycommon import convert_camel_case_to_lower_case_underscore}
 // IWYU pragma: private, include "@(package_name)/@(interface_path.parent)/@(convert_camel_case_to_lower_case_underscore(interface_path.stem)).hpp"
 
 @

--- a/rosidl_generator_cpp/resource/idl__traits.hpp.em
+++ b/rosidl_generator_cpp/resource/idl__traits.hpp.em
@@ -1,7 +1,7 @@
 // generated from rosidl_generator_cpp/resource/idl__traits.hpp.em
 // with input from @(package_name):@(interface_path)
 // generated code does not contain a copyright notice
-@{from rosidl_cmake import convert_camel_case_to_lower_case_underscore}
+@{from rosidl_pycommon import convert_camel_case_to_lower_case_underscore}
 // IWYU pragma: private, include "@(package_name)/@(interface_path.parent)/@(convert_camel_case_to_lower_case_underscore(interface_path.stem)).hpp"
 
 @

--- a/rosidl_generator_cpp/resource/idl__traits.hpp.em
+++ b/rosidl_generator_cpp/resource/idl__traits.hpp.em
@@ -1,6 +1,9 @@
 // generated from rosidl_generator_cpp/resource/idl__traits.hpp.em
 // with input from @(package_name):@(interface_path)
 // generated code does not contain a copyright notice
+@{from rosidl_cmake import convert_camel_case_to_lower_case_underscore}
+// IWYU pragma: private, include "@(package_name)/@(interface_path.parent)/@(convert_camel_case_to_lower_case_underscore(interface_path.stem)).hpp"
+
 @
 @#######################################################################
 @# EmPy template for generating <idl>__traits.hpp files


### PR DESCRIPTION
## Description

When using `clangd` with [`iwyu` (Include What You Use)](https://clangd.llvm.org/design/include-cleaner), using a C or C++ struct will add automagically (nice) the internal implementation header (sad) of the message.

This adds the following text to all implementation details headers.

```
// IWYU pragma: private, include "package_name/type/msg_name.hpp"
```

This is based out of ~Galactic~ Rolling.

## Impact

Whenever IWYU is called, it will include the top level headers instead of the detail implementation. As they are implemented as comments, this should have no other impact than being handled by IWYU. 

## Alternative

I tried simpler alternatives without success:
- `IWYU pragma: exports_begin/exports_end` in the `idl.hpp.em` 
- `IWYU pragma: private` without the explicit include
