### PR TITLE
Fix for incorrect delimiters in relative_input_file on Windows

### DIFF
--- a/rosidl_adapter/rosidl_adapter/action/__init__.py
+++ b/rosidl_adapter/rosidl_adapter/action/__init__.py
@@ -32,7 +32,7 @@ def convert_action_to_idl(package_dir, package_name, input_file, output_dir):
     print(f'Writing output file: {abs_output_file}')
     data = {
         'pkg_name': package_name,
-        'relative_input_file': input_file,
+        'relative_input_file': input_file.as_posix(),
         'action': action,
     }
 

--- a/rosidl_adapter/rosidl_adapter/msg/__init__.py
+++ b/rosidl_adapter/rosidl_adapter/msg/__init__.py
@@ -32,7 +32,7 @@ def convert_msg_to_idl(package_dir, package_name, input_file, output_dir):
     print(f'Writing output file: {abs_output_file}')
     data = {
         'pkg_name': package_name,
-        'relative_input_file': input_file,
+        'relative_input_file': input_file.as_posix(),
         'msg': msg,
     }
 

--- a/rosidl_adapter/rosidl_adapter/srv/__init__.py
+++ b/rosidl_adapter/rosidl_adapter/srv/__init__.py
@@ -32,7 +32,7 @@ def convert_srv_to_idl(package_dir, package_name, input_file, output_dir):
     print(f'Writing output file: {abs_output_file}')
     data = {
         'pkg_name': package_name,
-        'relative_input_file': input_file,
+        'relative_input_file': input_file.as_posix(),
         'srv': srv,
     }
 


### PR DESCRIPTION
- Addressing CI failure described in https://github.com/ros2/rosbag2/pull/1198#issuecomment-1560362070
- Fix for ""// with input from rosbag2_storage_mcap_testdata/msg\\ComplexMsgDependsOnIdl.msg"
- On Windows platform message generator messing up with the input file name ""/msg\\ComplexMsgDependsOnIdl.msg" by inserting double backslashes instead of one forward slash.
- Partial backport from https://github.com/ros2/rosidl/pull/576