### PR TITLE
export for the event type support function

### DIFF
--- a/rosidl_generator_cpp/resource/srv__type_support.hpp.em
+++ b/rosidl_generator_cpp/resource/srv__type_support.hpp.em
@@ -37,3 +37,9 @@ TEMPLATE(
     include_directives=include_directives)
 }@
 
+@{
+TEMPLATE(
+    'msg__type_support.hpp.em',
+    package_name=package_name, message=service.event_message,
+    include_directives=include_directives)
+}@


### PR DESCRIPTION
There is no reason to ignore `event_message`.

Please see https://github.com/ros2/rosidl/blob/a63f32e7c425da1a8ea300227ac82fb7b3a0bd28/rosidl_generator_c/resource/srv__type_support.h.em#L19