### PR TITLE
fix: Generate correct code for nested arrays of own type

### DIFF
--- a/rosidl_generator_c/resource/full__description.c.em
+++ b/rosidl_generator_c/resource/full__description.c.em
@@ -77,8 +77,16 @@ static const rosidl_type_hash_t @(c_typename)__EXPECTED_HASH = @(type_hash_to_c_
 
 @#<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 @# Names for all types
+@{
+added_itype_names = set()
+}@
 @[for itype_description in all_type_descriptions]@
+@[  if itype_description['type_name'] not in added_itype_names]@
 static char @(typename_to_c(itype_description['type_name']))__TYPE_NAME[] = "@(itype_description['type_name'])";
+@{
+added_itype_names.add(itype_description['type_name'])
+}@
+@[  end if]@
 @[end for]@
 @#>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 

--- a/rosidl_generator_c/resource/msg__struct.h.em
+++ b/rosidl_generator_c/resource/msg__struct.h.em
@@ -151,6 +151,22 @@ enum
 @#>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 @#<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+@# We must define the sequence type before the type itself
+@# for the special case, that the type contains a sequence
+@# of the type itself.
+// forward declare type
+struct @(idl_structure_type_to_c_typename(message.structure.namespaced_type));
+// Struct for a sequence of @(idl_structure_type_to_c_typename(message.structure.namespaced_type)).
+typedef struct @(idl_structure_type_sequence_to_c_typename(message.structure.namespaced_type))
+{
+  struct @(idl_structure_type_to_c_typename(message.structure.namespaced_type)) * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} @(idl_structure_type_sequence_to_c_typename(message.structure.namespaced_type));
+
+@#<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 /// Struct defined in @(interface_path_to_string(interface_path)) in the package @(package_name).
 @{comments = message.structure.get_comment_lines()}@
 @[if comments]@
@@ -179,13 +195,3 @@ typedef struct @(idl_structure_type_to_c_typename(message.structure.namespaced_t
 } @(idl_structure_type_to_c_typename(message.structure.namespaced_type));
 @#>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
-@#<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-// Struct for a sequence of @(idl_structure_type_to_c_typename(message.structure.namespaced_type)).
-typedef struct @(idl_structure_type_sequence_to_c_typename(message.structure.namespaced_type))
-{
-  @(idl_structure_type_to_c_typename(message.structure.namespaced_type)) * data;
-  /// The number of valid items in data
-  size_t size;
-  /// The number of allocated items in data
-  size_t capacity;
-} @(idl_structure_type_sequence_to_c_typename(message.structure.namespaced_type));

--- a/rosidl_generator_type_description/rosidl_generator_type_description/__init__.py
+++ b/rosidl_generator_type_description/rosidl_generator_type_description/__init__.py
@@ -471,7 +471,7 @@ def calculate_type_hash(serialized_type_description):
         del field['default_value']
     for referenced_td in hashable_dict['referenced_type_descriptions']:
         for field in referenced_td['fields']:
-            del field['default_value']
+            field.pop('defaut_value', None)
 
     hashable_repr = json.dumps(
         hashable_dict,

--- a/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
@@ -19,6 +19,9 @@ include_parts = [package_name] + list(interface_path.parents[0].parts) + [
     'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
 include_base = '/'.join(include_parts)
 
+message_namespace = '::'.join([package_name] + list(interface_path.parents[0].parts))
+message_namespaced_name = '::'.join([message_namespace, message.structure.namespaced_type.name])
+
 header_files = [
     'array',
     'cstddef',  # providing offsetof()
@@ -45,6 +48,19 @@ header_files = [
 @[    end if]@
 #include "@(header_file)"
 @[end for]@
+
+
+namespace rosidl_typesupport_introspection_cpp
+{
+
+// forward declare template, as it may be used in MessageMember
+template<>
+ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC
+const rosidl_message_type_support_t *
+get_message_type_support_handle<@(message_namespaced_name)>();
+
+}  // namespace rosidl_typesupport_introspection_cpp
+
 @[for ns in message.structure.namespaced_type.namespaces]@
 
 namespace @(ns)
@@ -57,12 +73,12 @@ namespace rosidl_typesupport_introspection_cpp
 void @(message.structure.namespaced_type.name)_init_function(
   void * message_memory, rosidl_runtime_cpp::MessageInitialization _init)
 {
-  new (message_memory) @('::'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))(_init);
+  new (message_memory) @(message_namespaced_name)(_init);
 }
 
 void @(message.structure.namespaced_type.name)_fini_function(void * message_memory)
 {
-  auto typed_message = static_cast<@('::'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name])) *>(message_memory);
+  auto typed_message = static_cast<@(message_namespaced_name) *>(message_memory);
   typed_message->~@(message.structure.namespaced_type.name)();
 }
 
@@ -241,7 +257,7 @@ static const ::rosidl_typesupport_introspection_cpp::MessageMembers @(message.st
   "@('::'.join([package_name] + list(interface_path.parents[0].parts)))",  // message namespace
   "@(message.structure.namespaced_type.name)",  // message name
   @(len(message.structure.members)),  // number of fields
-  sizeof(@('::'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))),
+  sizeof(@(message_namespaced_name)),
   @(message.structure.namespaced_type.name)_message_member_array,  // message members
   @(message.structure.namespaced_type.name)_init_function,  // function to initialize message memory (memory has to be allocated)
   @(message.structure.namespaced_type.name)_fini_function  // function to terminate message instance (will not free memory)
@@ -269,7 +285,7 @@ namespace rosidl_typesupport_introspection_cpp
 template<>
 ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC
 const rosidl_message_type_support_t *
-get_message_type_support_handle<@('::'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]))>()
+get_message_type_support_handle<@(message_namespaced_name)>()
 {
   return &::@('::'.join([package_name] + list(interface_path.parents[0].parts)))::rosidl_typesupport_introspection_cpp::@(message.structure.namespaced_type.name)_message_type_support_handle;
 }


### PR DESCRIPTION
Part of https://github.com/ros2/ros2/issues/1445

This fixes the code generation for the case that you have a message 
A :
A[] arrayOfA