### PR TITLE
Fix deprecation warnings for message constants

### DIFF
--- a/rosidl_generator_cpp/resource/msg__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.em
@@ -377,8 +377,11 @@ template<typename ContainerAllocator>
 const @(MSG_TYPE_TO_CPP['wstring'])
 @(message.structure.namespaced_type.name)_<ContainerAllocator>::@(c.name) = u"@(escape_wstring(c.value))";
 @[ else ]@
+#if __cplusplus < 201703L
+// static constexpr member variable definitions are only needed in C++14 and below, deprecated in C++17
 template<typename ContainerAllocator>
 constexpr @(MSG_TYPE_TO_CPP[c.type.typename]) @(message.structure.namespaced_type.name)_<ContainerAllocator>::@(c.name);
+#endif  // __cplusplus < 201703L
 @[ end if]@
 @[ if c.name in msvc_common_macros]@
 #if defined(_WIN32)

--- a/rosidl_typesupport_introspection_cpp/cmake/rosidl_typesupport_introspection_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_introspection_cpp/cmake/rosidl_typesupport_introspection_cpp_generate_interfaces.cmake
@@ -100,11 +100,12 @@ if(rosidl_generate_interfaces_LIBRARY_NAME)
 endif()
 set_property(TARGET ${rosidl_generate_interfaces_TARGET}${_target_suffix}
   PROPERTY DEFINE_SYMBOL "ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_BUILDING_DLL")
+set_property(TARGET ${rosidl_generate_interfaces_TARGET}${_target_suffix}
+  PROPERTY CXX_STANDARD 17)
+
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix} PROPERTIES
-    CXX_STANDARD 17
-    COMPILE_OPTIONS -Wall -Wextra -Wpedantic
-  )
+  target_compile_options(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    PRIVATE -Wall -Wextra -Wpedantic)
 endif()
 
 target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}


### PR DESCRIPTION
Fixes https://github.com/ros2/rosidl/issues/743

This patch fixes two issues:
1. Code generation for `rosidl_typesupport_introspection_cpp` was overriding user-provided compile definitons, hiding the `-Wdeprecated` warnings in generated code, that users did see in `rosidl_typesupport_fastrtps_cpp`, which was not overriding those compile flags. This inconsistent result confused the issue of why we were seeing deprecation warnings in some portion of the build but not others
1. `#ifdef`s out a variable definition for message constant members that is now deprecated in C++17. In C++14 it was still necessary to define a `static constexpr` member variable outside the class, but as of C++17 those `static constexpr` vars are now automatically inlined so the declaration and definiton are the same line, making the external definition redundant.