### PR TITLE
Convert markdown to rosidl msg, srv or action content

### DIFF
--- a/rosidl_adapter/rosidl_adapter/parser.py
+++ b/rosidl_adapter/rosidl_adapter/parser.py
@@ -910,3 +910,31 @@ def parse_action_string(pkg_name, action_name, action_string):
 
     return ActionSpecification(
         pkg_name, action_name, goal_message, result_message, feedback_message)
+
+
+def tangle_markdown_to_rosidl(markdown_content, adapter_type):
+    if adapter_type == 'msg':
+        section_separator = None
+    elif adapter_type == 'srv':
+        section_separator = SERVICE_REQUEST_RESPONSE_SEPARATOR
+    elif adapter_type == 'action':
+        section_separator = ACTION_REQUEST_RESPONSE_SEPARATOR
+    tangle_yes_pattern = r'^```[^`]*tangle-yes'
+    output_lines = []
+    inside_codeblock = False
+    for line in [line.strip() for line in markdown_content.splitlines()]:
+        if inside_codeblock is True:
+            is_end_codefence = line == '```'
+            if is_end_codefence is True:
+                inside_codeblock = False
+            else:
+                output_lines.append(line)
+        else:
+            is_start_codefence = (line == '```' or re.search(tangle_yes_pattern, line))
+            if is_start_codefence is True:
+                inside_codeblock = True
+            else:
+                is_separator_line = (line == section_separator)
+                if is_separator_line is True:
+                    output_lines.append(section_separator)
+    return '\n'.join(output_lines)

--- a/rosidl_adapter/test/data/action/Test.action.md
+++ b/rosidl_adapter/test/data/action/Test.action.md
@@ -1,0 +1,38 @@
+# Foo
+## Goal
+```
+# goal definition
+# foo
+
+# bar
+bool bool_value
+# baz
+byte byte_value
+# asd
+char char_value  # bsd
+float32 float32_value
+float64 float64_value
+int8 int8_value
+uint8 uint8_value
+int16 int16_value
+uint16 uint16_value
+int32 int32_value
+uint32 uint32_value
+int64 int64_value
+uint64 uint64_value
+string string_value
+```
+---
+## Result and feedback
+```
+# result definition
+
+# ok docs
+bool ok
+---
+# feedback definition
+# more
+
+# sequence docs
+int32[] sequence
+```

--- a/rosidl_adapter/test/data/msg/Test.msg.md
+++ b/rosidl_adapter/test/data/msg/Test.msg.md
@@ -1,0 +1,42 @@
+# Test Msg
+
+Msg for testing parsing done by the `rosidl_adapter` package
+
+
+It is typical for a comment to describe the entire message as a whole and then to have a comment right above  single field to describe that field as follows:
+
+```
+# msg level doc
+
+# field level doc
+bool bool_value
+```
+
+The test message definition has multiple fields declared in varying types. The following field is commented on the same line as the field instead of the line right before the field.
+
+```
+byte byte_value  # field level doc, style 2
+```
+
+Some fields are commented with two different styles
+```
+# combined styles
+char char_value # combined styles, part 2
+```
+
+The remaining fields are not commented
+
+```
+float32 float32_value
+float64 float64_value
+int8 int8_value
+uint8 uint8_value
+int16 int16_value
+uint16 uint16_value
+int32 int32_value
+uint32 uint32_value
+int64 int64_value
+uint64 uint64_value
+```
+
+See the [test_tangle_markdown_to_rosidl](../../test_tangle_markdown_to_rosidl.py) test case.

--- a/rosidl_adapter/test/test_tangle_markdown_to_rosidl.py
+++ b/rosidl_adapter/test/test_tangle_markdown_to_rosidl.py
@@ -1,0 +1,44 @@
+# Copyright 2014 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib
+
+from rosidl_adapter.parser import tangle_markdown_to_rosidl
+
+
+DATA_PATH = pathlib.Path(__file__).parent / 'data'
+
+
+def test_tangle_msg_markdown_to_rosidl():
+    test_input_file_path = f'{DATA_PATH}/msg/Test.msg.md'
+    expected_output_file_path = f'{DATA_PATH}/msg/Test.msg'
+    with open(test_input_file_path, 'r', encoding='utf-8') as h:
+        test_input_content = h.read()
+    with open(expected_output_file_path, 'r', encoding='utf-8') as h:
+        expected_output_content = h.read().strip()
+    assert tangle_markdown_to_rosidl(
+        test_input_content, 'msg') == expected_output_content
+
+
+def test_tangle_action_markdown_to_rosidl():
+    test_input_file_path = f'{DATA_PATH}/action/Test.action.md'
+    expected_output_file_path = f'{DATA_PATH}/action/Test.action'
+    with open(test_input_file_path, 'r', encoding='utf-8') as h:
+        test_input_content = h.read()
+    with open(expected_output_file_path, 'r', encoding='utf-8') as h:
+        expected_output_content = h.read().strip()
+    print(tangle_markdown_to_rosidl(
+        test_input_content, 'action'))
+    assert tangle_markdown_to_rosidl(
+        test_input_content, 'action') == expected_output_content


### PR DESCRIPTION
Adds a parser function to be used as part of the process to convert Markdown to `msg`, `srv` or `action` content. The conversion allows Markdown files to be treated like source files in a literate programming approach to IDL processing.

Most message files have comments providing documentation (for example [common_interfaces/Plane.msg](https://github.com/ros2/common_interfaces/blob/rolling/shape_msgs/msg/Plane.msg) ) and using a literate programming approach would allow for nice looking documentation when browsing source on github and gitlab hosted files. This would help with SEO and could help improve the quality of documentation. The readme at [common_interfaces/README.md](https://github.com/ros2/common_interfaces/blob/rolling/shape_msgs/README.md) already links to `.msg` files and the experience would be better if those files could also be rendered in HTML by github instead of as a raw text document. Even when viewing the raw files in a text editor, it will be easier to read documentation when it is not commented out with `#` at the start of each line.

Literate programming is to be achieved by parsing Markdown files for code blocks and separators used by `srv` and `action` messages, then concatenating the code blocks and separators to convert the input to `msg`, `srv` or `action` content as applicable. The conversion process is known as tangling in literate programming terms (for another example of literate programming see the guide [How to Use Emacs Org-Babel Mode to Write Literate Programming Document in R Language](https://orgmode.org/worg/org-contrib/babel/how-to-use-Org-Babel-for-R.html)).

Here is an example Markdown file that could be saved with the name `my_message.msg.md`. The `.msg.md` extension indicates that the file contains Markdown content that needs to be converted to `msg` content:

````markdown
# My Message
## Fields
* The `data` member holds an integer.
  ```
  std_msgs/msg/Int32 data
  ```
* The `str` member holds an optional string.
  ```
  std_msgs/msg/String str
  ```
## See also
The `result_val` in `MyService` also has the same semantic meaning as the `data` field in `MyMessage`.
```srv
# ...
---
# ...
std_msgs/msg/Int32 result_val
```
````

When the above `my_message.msg.md` is processed it is converted to create the following content which is then further processed as any other `msg` file content for message codegen.
```
std_msgs/msg/Int32 data
std_msgs/msg/String str
```
Note that the `srv` code block is not part of the converted output. Other code blocks like python or c++ could also be included in the Markdown and will not be part of the converted output.
