### PR TITLE
Build time generation of fixed-size strings

### DIFF
--- a/rosidl_adapter/rosidl_adapter/parser.py
+++ b/rosidl_adapter/rosidl_adapter/parser.py
@@ -560,7 +560,7 @@ def parse_message_string(pkg_name, msg_name, message_string):
         current_comments = []
 
         # Add fixed_size annotations if configured in file
-        for based_type in ['string', 'wstring']:
+        for based_type in ['string']:
             __add_fixed_size_annotations(
                 pkg_name=pkg_name,
                 msg_name=msg_name,
@@ -617,7 +617,7 @@ def __add_fixed_size_annotations(pkg_name, msg_name, last_element, field_base_ty
             fixed_size = fixed_size_config[field_base_type][pkg_name][msg_name][str(last_element.name)]
 
         # Load default fixed_size if present
-        elif 'default_fixed_size' in fixed_size_config[field_base_type]:
+        if fixed_size is None and 'default_fixed_size' in fixed_size_config[field_base_type]:
             fixed_size = fixed_size_config[field_base_type]['default_fixed_size']
 
     if fixed_size is not None:

--- a/rosidl_adapter/rosidl_adapter/parser.py
+++ b/rosidl_adapter/rosidl_adapter/parser.py
@@ -621,6 +621,12 @@ def __add_fixed_size_annotations(pkg_name, msg_name, last_element, field_base_ty
             fixed_size = fixed_size_config[field_base_type]['default_fixed_size']
 
     if fixed_size is not None:
+        if fixed_size % 4 != 0:
+            print(
+                f'ERROR: Configured fixed size for {field_full_name} is {fixed_size}: ' +
+                'NOT a multiple of 4.'
+            )
+            sys.exit(1)
         last_element.annotations.setdefault(
             'cdr_plain',
             f'@cdr_plain(fixed_size={fixed_size})'

--- a/rosidl_adapter/rosidl_adapter/parser.py
+++ b/rosidl_adapter/rosidl_adapter/parser.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import fnmatch
 import os
 import re
 import sys
 import textwrap
+import yaml
 
 PACKAGE_NAME_MESSAGE_TYPE_SEPARATOR = '/'
 COMMENT_DELIMITER = '#'
@@ -470,6 +472,16 @@ def parse_message_string(pkg_name, msg_name, message_string):
     # replace tabs with spaces
     message_string = message_string.replace('\t', ' ')
 
+    # Try to load type bounds config file from the environment
+    type_bounds_file = os.environ['ROS2_TYPE_BOUNDS_FILE']
+    bounds_config = None
+    if type_bounds_file:
+        try:
+            with open(type_bounds_file, 'r', encoding='utf-8') as config_file:
+                bounds_config = yaml.safe_load(config_file)
+        except IOError as exc:
+            print(f'Cannot open {type_bounds_file}. {exc}')
+
     current_comments = []
     message_comments, lines = extract_file_level_comments(message_string)
     for line in lines:
@@ -542,6 +554,16 @@ def parse_message_string(pkg_name, msg_name, message_string):
         comment_lines += current_comments
         current_comments = []
 
+        # Add bound annotations if configured in file
+        for based_type in ['string', 'wstring']:
+            __add_bound_annotations(
+                pkg_name=pkg_name,
+                msg_name=msg_name,
+                last_element=last_element,
+                field_base_type=based_type,
+                bounds_config=bounds_config)
+            print('')
+
     msg = MessageSpecification(pkg_name, msg_name, fields, constants)
     msg.annotations['comment'] = message_comments
 
@@ -553,6 +575,52 @@ def parse_message_string(pkg_name, msg_name, message_string):
         process_comments(constant)
 
     return msg
+
+
+def __add_bound_annotations(pkg_name, msg_name, last_element, field_base_type, bounds_config):
+    elem_based_type = str(last_element.type).split('[')[0]
+    if bounds_config is None or field_base_type != elem_based_type:
+        return
+
+    bound = None
+    skip_field = False
+    field_full_name = f'{pkg_name}/{msg_name}/{last_element.name}'
+
+    # Check if config for strings
+    if field_base_type not in bounds_config:
+        skip_field = True
+
+    # Check if field is blocklisted
+    elif 'skip' in bounds_config[field_base_type]:
+        for elem in bounds_config[field_base_type]['skip']:
+            if fnmatch.fnmatch(field_full_name, elem):
+                skip_field = True
+                break
+
+    # Check for specific config for field
+    if not skip_field:
+
+        # Check if config for package
+        if pkg_name not in bounds_config[field_base_type]:
+            pass
+
+        # Check if config for type
+        elif msg_name not in bounds_config[field_base_type][pkg_name]:
+            pass
+
+        # Check if config for field
+        elif str(last_element.name) in bounds_config[field_base_type][pkg_name][msg_name]:
+            bound = bounds_config[field_base_type][pkg_name][msg_name][str(last_element.name)]
+
+        # Load default bound if present
+        elif 'default_bound' in bounds_config[field_base_type]:
+            bound = bounds_config[field_base_type]['default_bound']
+
+    if bound is not None:
+        last_element.annotations.setdefault(
+            'bound',
+            f'@bound(size={bound})'
+        )
 
 
 def process_comments(instance):

--- a/rosidl_adapter/rosidl_adapter/resource/struct.idl.em
+++ b/rosidl_adapter/rosidl_adapter/resource/struct.idl.em
@@ -81,8 +81,8 @@ else:
 @[      end for]@
 )
 @[    end if]@
-@[    if field.annotations.get('bound')]@
-      @(field.annotations['bound'])@
+@[    if field.annotations.get('cdr_plain')]@
+      @(field.annotations['cdr_plain'])@
 
 @[    end if]@
 @[    if field.default_value is not None]@

--- a/rosidl_adapter/rosidl_adapter/resource/struct.idl.em
+++ b/rosidl_adapter/rosidl_adapter/resource/struct.idl.em
@@ -81,6 +81,10 @@ else:
 @[      end for]@
 )
 @[    end if]@
+@[    if field.annotations.get('bound')]@
+      @(field.annotations['bound'])@
+
+@[    end if]@
 @[    if field.default_value is not None]@
       @@default (value=@(to_idl_literal(get_idl_type(field.type), field.default_value)))
 @[    end if]@

--- a/rosidl_generator_cpp/resource/idl__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/idl__struct.hpp.em
@@ -33,6 +33,7 @@ include_directives = set()
 #include <vector>
 
 #include "rosidl_runtime_cpp/bounded_vector.hpp"
+#include "rosidl_runtime_cpp/cdr_compatible_fixed_capacity_string.hpp"
 #include "rosidl_runtime_cpp/message_initialization.hpp"
 
 @#######################################################################

--- a/rosidl_generator_cpp/resource/msg__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.em
@@ -123,7 +123,7 @@ def generate_default_string(membset):
                     # For more info, see https://github.com/ros2/rosidl/issues/309
                     # TODO(jacobperron): Investigate reason for build warnings on Windows
                     # TODO(jacobperron): Write test case for this path of execution
-                    strlist.append('std::fill<typename %s::iterator, %s>(this->%s.begin(), this->%s.end(), %s);' % (msg_type_to_cpp(member.type), msg_type_only_to_cpp(member.type), member.name, member.name, member.default_value[0]))
+                    strlist.append('std::fill<typename %s::iterator, %s>(this->%s.begin(), this->%s.end(), %s);' % (msg_type_to_cpp(member), msg_type_only_to_cpp(member), member.name, member.name, member.default_value[0]))
                 else:
                     for index, val in enumerate(member.default_value):
                         strlist.append('this->%s[%d] = %s;' % (member.name, index, val))
@@ -141,12 +141,12 @@ def generate_zero_string(membset, fill_args):
             if member.num_prealloc > 0:
                 strlist.append('this->%s.resize(%d);' % (member.name, member.num_prealloc))
             if member.zero_need_array_override:
-                strlist.append('this->%s.fill(%s{%s});' % (member.name, msg_type_only_to_cpp(member.type), fill_args))
+                strlist.append('this->%s.fill(%s{%s});' % (member.name, msg_type_only_to_cpp(member.real_member), fill_args))
             else:
                 # Specifying type for std::fill because of MSVC 14.12 warning about casting 'const int' to smaller types (C4244)
                 # For more info, see https://github.com/ros2/rosidl/issues/309
                 # TODO(jacobperron): Investigate reason for build warnings on Windows
-                strlist.append('std::fill<typename %s::iterator, %s>(this->%s.begin(), this->%s.end(), %s);' % (msg_type_to_cpp(member.type), msg_type_only_to_cpp(member.type), member.name, member.name, member.zero_value[0]))
+                strlist.append('std::fill<typename %s::iterator, %s>(this->%s.begin(), this->%s.end(), %s);' % (msg_type_to_cpp(member.real_member), msg_type_only_to_cpp(member.real_member), member.name, member.name, member.zero_value[0]))
         else:
             strlist.append('this->%s = %s;' % (member.name, member.zero_value))
     return strlist
@@ -247,7 +247,7 @@ non_defaulted_zero_initialized_members = [
   // field types and members
 @[for member in message.structure.members]@
   using _@(member.name)_type =
-    @(msg_type_to_cpp(member.type));
+    @(msg_type_to_cpp(member));
   _@(member.name)_type @(member.name);
 @[end for]@
 
@@ -255,7 +255,7 @@ non_defaulted_zero_initialized_members = [
   // setters for named parameter idiom
 @[  for member in message.structure.members]@
   Type & set__@(member.name)(
-    const @(msg_type_to_cpp(member.type)) & _arg)
+    const @(msg_type_to_cpp(member)) & _arg)
   {
     this->@(member.name) = _arg;
     return *this;

--- a/rosidl_parser/test/msg/MyMessage.idl
+++ b/rosidl_parser/test/msg/MyMessage.idl
@@ -41,7 +41,7 @@ module rosidl_parser {
       uint32 uint32_value;
       int64 int64_value;
       uint64 uint64_value;
-      @cdr_plain( capacity=64 )
+      @cdr_plain(fixed_size=64)
       string string_value;
       string<5> bounded_string_value;
       wstring wstring_value;

--- a/rosidl_parser/test/msg/MyMessage.idl
+++ b/rosidl_parser/test/msg/MyMessage.idl
@@ -41,6 +41,7 @@ module rosidl_parser {
       uint32 uint32_value;
       int64 int64_value;
       uint64 uint64_value;
+      @cdr_plain( capacity=64 )
       string string_value;
       string<5> bounded_string_value;
       wstring wstring_value;

--- a/rosidl_parser/test/test_parser.py
+++ b/rosidl_parser/test/test_parser.py
@@ -225,8 +225,8 @@ def test_message_parser_annotations(message_idl_file):
 
     assert structure.members[22].annotations[0].name == 'cdr_plain'
     assert len(structure.members[22].annotations[0].value) == 1
-    assert 'capacity' in structure.members[22].annotations[0].value
-    assert structure.members[22].annotations[0].value['capacity'] == 64
+    assert 'fixed_size' in structure.members[22].annotations[0].value
+    assert structure.members[22].annotations[0].value['fixed_size'] == 64
 
     assert isinstance(structure.members[32].type, BasicType)
     assert structure.members[32].type.typename == 'float'

--- a/rosidl_parser/test/test_parser.py
+++ b/rosidl_parser/test/test_parser.py
@@ -221,6 +221,13 @@ def test_message_parser_annotations(message_idl_file):
     assert 'max' in structure.members[3].annotations[1].value
     assert structure.members[3].annotations[1].value['max'] == 10
 
+    assert len(structure.members[22].annotations) == 1
+
+    assert structure.members[22].annotations[0].name == 'cdr_plain'
+    assert len(structure.members[22].annotations[0].value) == 1
+    assert 'capacity' in structure.members[22].annotations[0].value
+    assert structure.members[22].annotations[0].value['capacity'] == 64
+
     assert isinstance(structure.members[32].type, BasicType)
     assert structure.members[32].type.typename == 'float'
     assert structure.members[32].name == 'int_and_frac_with_positive_scientific'

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/cdr_compatible_fixed_capacity_string.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/cdr_compatible_fixed_capacity_string.hpp
@@ -164,6 +164,19 @@ public:
     return !operator==(rhs);
   }
 
+  CDRCompatibleFixedCapacityString<Capacity>& operator+=(const char* const rhs)
+  {
+    this->append_value(rhs);
+    return *this;
+  }
+
+  template<typename Stringable>
+  CDRCompatibleFixedCapacityString<Capacity>& operator+=(const Stringable& rhs)
+  {
+    this->append_value(rhs.c_str());
+    return *this;
+  }
+
  private:
 
   void append_value(const char* const str) { append_value(str, ::strlen(str)); }
@@ -210,6 +223,20 @@ inline bool operator!=(const T& lhs,
     const CDRCompatibleFixedCapacityString<Capacity>& rhs)
 {
   return 0 != rhs.compare(lhs.c_str());
+}
+
+template <size_t N, uint32_t Capacity>
+inline std::string operator+(
+    const char (&lhs)[N], const CDRCompatibleFixedCapacityString<Capacity>& rhs)
+{
+  return std::string(lhs) + rhs.c_str();
+}
+
+template <uint32_t Capacity>
+inline std::string operator+(
+    const std::string& lhs, const CDRCompatibleFixedCapacityString<Capacity>& rhs)
+{
+  return lhs + rhs.c_str();
 }
 
 }  // namespace rosidl_runtime_cpp

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/cdr_compatible_fixed_capacity_string.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/cdr_compatible_fixed_capacity_string.hpp
@@ -103,6 +103,67 @@ public:
 
   void clear() noexcept { ::memset(m_string, 0, m_capacity); }
 
+  int32_t compare(
+      const size_t my_pos,
+      const size_t my_count,
+      const char* const other,
+      const size_t other_count = std::string::npos) const
+  {
+    if (nullptr == other) {
+      throw std::invalid_argument("other is nullptr");
+    }
+
+    const size_t my_len = length();
+    if (my_pos > my_len) {
+      throw std::out_of_range("my_pos > my_len");
+    }
+
+    const size_t my_used_count =
+        (std::string::npos == my_count) ? my_len : my_count;
+    size_t other_len = other_count;
+    if (std::string::npos == other_count) {
+      other_len = ::strlen(other);
+    }
+
+    const size_t my_remaining_len = std::min(my_used_count, my_len - my_pos);
+    int32_t retval = ::strncmp(data() + my_pos, other, std::min(my_remaining_len, other_len));
+
+    if (retval == 0) {
+      if (my_remaining_len < other_len) {
+        retval = -1;
+      }
+      if (my_remaining_len > other_len) {
+        retval = 1;
+      }
+    }
+    return retval;
+  }
+
+  inline int32_t compare(const char* const s) const
+  {
+    return this->compare(0U, std::string::npos, s);
+  }
+
+  bool operator==(const std::string& rhs) const
+  {
+    return this->compare(rhs.c_str()) == 0;
+  }
+
+  bool operator!=(const std::string& rhs) const
+  {
+    return !operator==(rhs);
+  }
+
+  bool operator==(const char* const rhs) const
+  {
+    return this->compare(rhs) == 0;
+  }
+
+  bool operator!=(const char* const rhs) const
+  {
+    return !operator==(rhs);
+  }
+
  private:
 
   void append_value(const char* const str) { append_value(str, ::strlen(str)); }
@@ -135,6 +196,20 @@ typename ::std::basic_ostream<char>& operator<<(
 {
   return out_stream.write(str.c_str(),
                           static_cast<std::streamsize>(str.size()));
+}
+
+template <typename Stringable, uint32_t Capacity>
+inline bool operator==(const Stringable& lhs,
+    const CDRCompatibleFixedCapacityString<Capacity>& rhs)
+{
+  return 0 == rhs.compare(lhs.c_str());
+}
+
+template <typename T, uint32_t Capacity>
+inline bool operator!=(const T& lhs,
+    const CDRCompatibleFixedCapacityString<Capacity>& rhs)
+{
+  return 0 != rhs.compare(lhs.c_str());
 }
 
 }  // namespace rosidl_runtime_cpp

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/cdr_compatible_fixed_capacity_string.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/cdr_compatible_fixed_capacity_string.hpp
@@ -1,0 +1,93 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_RUNTIME_CPP__CDR_COMPATIBLE_FIXED_CAPACITY_STRING_HPP_
+#define ROSIDL_RUNTIME_CPP__CDR_COMPATIBLE_FIXED_CAPACITY_STRING_HPP_
+
+#include <cstring>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+namespace rosidl_runtime_cpp
+{
+
+/// A fixed-size, POD type, CDR binary compatible string.
+/**
+ * Meets the same requirements as std::string.
+ *
+ * \param Capacity Maximum number of characters including the NUL terminator
+ */
+template<uint32_t Capacity>
+class CDRCompatibleFixedCapacityString
+{
+public:
+
+  static_assert(Capacity > 0,
+    "CDRCompatibleFixedCapacityString requires space for at least the NUL terminator");
+
+  CDRCompatibleFixedCapacityString()
+  {
+    clear();
+  }
+
+  inline constexpr bool empty() const noexcept { return '\0' == m_string[0u]; }
+
+  char* data() noexcept { return m_string; }
+
+  const char* data() const noexcept { return m_string; }
+
+  const char* c_str() const noexcept { return m_string; }
+
+  inline constexpr size_t capacity() const { return m_capacity - 1u; }
+
+  inline constexpr size_t max_size() const { return m_capacity - 1u; }
+
+  size_t size() const noexcept { return length(); }
+
+  size_t length() const noexcept
+  {
+    return ::strnlen(m_string, this->capacity());
+  }
+
+  char& operator[](size_t idx)
+  {
+    if (idx >= m_capacity) {
+      throw std::out_of_range("idx >= m_capacity");
+    }
+    return m_string[idx];
+  }
+
+  char operator[](size_t idx) const
+  {
+    if (idx >= m_capacity) {
+      throw std::out_of_range("idx >= m_capacity");
+    }
+    return m_string[idx];
+  }
+
+  void clear() noexcept { ::memset(m_string, 0, m_capacity); }
+
+ private:
+
+  // NOTE: In order for this to be binary compatible with its CDR representation, the following
+  // two fields shall be the only attributes in this class.
+
+  uint32_t m_capacity = Capacity;
+  char m_string[Capacity];
+};
+
+}  // namespace rosidl_runtime_cpp
+
+#endif  // ROSIDL_RUNTIME_CPP__CDR_COMPATIBLE_FIXED_CAPACITY_STRING_HPP_

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/cdr_compatible_fixed_capacity_string.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/cdr_compatible_fixed_capacity_string.hpp
@@ -17,6 +17,7 @@
 
 #include <cstring>
 #include <memory>
+#include <ostream>
 #include <stdexcept>
 #include <string>
 
@@ -126,6 +127,15 @@ public:
   uint32_t m_capacity = Capacity;
   char m_string[Capacity];
 };
+
+template <uint32_t Capacity>
+typename ::std::basic_ostream<char>& operator<<(
+    std::basic_ostream<char>& out_stream,
+    const CDRCompatibleFixedCapacityString<Capacity>& str)
+{
+  return out_stream.write(str.c_str(),
+                          static_cast<std::streamsize>(str.size()));
+}
 
 }  // namespace rosidl_runtime_cpp
 

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/cdr_compatible_fixed_capacity_string.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/cdr_compatible_fixed_capacity_string.hpp
@@ -42,6 +42,28 @@ public:
     clear();
   }
 
+  // Implicit conversion from C string
+  CDRCompatibleFixedCapacityString(const char * const str)
+      : CDRCompatibleFixedCapacityString()
+  {
+    if (nullptr == str) {
+      throw std::invalid_argument(
+          "Constructing CDRCompatibleFixedCapacityString with null pointer");
+    }
+
+    append_value(str);
+  }
+
+  // Implicit conversion from C++ string
+  CDRCompatibleFixedCapacityString(const std::string& str)
+      : CDRCompatibleFixedCapacityString()
+  {
+    append_value(str.c_str(), str.length());
+  }
+
+  // Implicit conversion to C++ string
+  operator std::string() const { return std::string(m_string); }
+
   inline constexpr bool empty() const noexcept { return '\0' == m_string[0u]; }
 
   char* data() noexcept { return m_string; }
@@ -80,6 +102,22 @@ public:
   void clear() noexcept { ::memset(m_string, 0, m_capacity); }
 
  private:
+
+  void append_value(const char* const str) { append_value(str, ::strlen(str)); }
+
+  void append_value(const char * const str, size_t len)
+  {
+    size_t my_len = this->length();
+    size_t new_len = my_len + len;
+
+    if (new_len > capacity()) {
+      // TODO(MiguelCompany): Make this configurable
+      throw std::overflow_error("Appending string will overflow capacity");
+    }
+
+    ::memmove(&m_string[my_len], str, len);
+    m_string[new_len] = '\0';
+  }
 
   // NOTE: In order for this to be binary compatible with its CDR representation, the following
   // two fields shall be the only attributes in this class.

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/cdr_compatible_fixed_capacity_string.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/cdr_compatible_fixed_capacity_string.hpp
@@ -34,9 +34,10 @@ class CDRCompatibleFixedCapacityString
 {
 public:
 
-  static_assert(Capacity > 0,
-    "CDRCompatibleFixedCapacityString requires space for at least the NUL terminator");
+  static_assert(Capacity > 0, "Should have space for at least the NUL terminator");
+  static_assert(0 == (Capacity % sizeof(uint32_t)), "Needs alignment as uint32_t");
 
+  // Default constructor
   CDRCompatibleFixedCapacityString()
   {
     clear();
@@ -66,11 +67,11 @@ public:
 
   inline constexpr bool empty() const noexcept { return '\0' == m_string[0u]; }
 
-  char* data() noexcept { return m_string; }
+  constexpr char* data() noexcept { return m_string; }
 
-  const char* data() const noexcept { return m_string; }
+  constexpr const char* data() const noexcept { return m_string; }
 
-  const char* c_str() const noexcept { return m_string; }
+  constexpr const char* c_str() const noexcept { return m_string; }
 
   inline constexpr size_t capacity() const { return m_capacity - 1u; }
 


### PR DESCRIPTION
This is part of a PoC towards achieving the goals of ros2/rclcpp#2201

* On rosidl_runtime_cpp, a new class has been added that behaves as a bounded string but can be considered POD by the underlying middleware.
* On rosidl_generator_cpp, processing of a new `cdr_plain` annotation has been introduced, so string members with that annotation will be generated using the new class.
* On rosidl_adapter, strings can be annotated with this new annotation depending on the contents of a YAML file specified in the environment variable `ROS2_TYPE_FIXED_SIZE_FILE`.