### PR TITLE
Fix same named types overriding typesources

### DIFF
--- a/rosidl_generator_tests/CMakeLists.txt
+++ b/rosidl_generator_tests/CMakeLists.txt
@@ -34,6 +34,7 @@ if(BUILD_TESTING)
     ${test_interface_files_ACTION_FILES}
     ${test_interface_files_MSG_FILES}
     ${test_interface_files_SRV_FILES}
+    msg/BasicIdl.idl
     ADD_LINTER_TESTS
     SKIP_INSTALL
   )

--- a/rosidl_generator_tests/msg/BasicIdl.idl
+++ b/rosidl_generator_tests/msg/BasicIdl.idl
@@ -1,0 +1,7 @@
+module rosidl_generator_tests {
+  module msg {
+    struct BasicIdl {
+        float x;
+    };
+  };
+};

--- a/rosidl_generator_tests/test/rosidl_generator_c/test_descriptions.c
+++ b/rosidl_generator_tests/test/rosidl_generator_c/test_descriptions.c
@@ -29,7 +29,9 @@
 #include "rosidl_runtime_c/type_description/type_source__struct.h"
 
 #include "rosidl_generator_tests/action/fibonacci.h"
+#include "rosidl_generator_tests/msg/basic_idl.h"
 #include "rosidl_generator_tests/msg/defaults.h"
+#include "rosidl_generator_tests/msg/empty.h"
 #include "rosidl_generator_tests/srv/empty.h"
 
 #include "type_description_interfaces/msg/field.h"
@@ -67,6 +69,7 @@ bool string_char_equal(const rosidl_runtime_c__String * lhs, const char * rhs)
 int test_description_linkage();
 int test_copied_type_description_struct_hashes();
 int test_source_defined();
+int test_same_name_types();
 
 int main(void)
 {
@@ -84,6 +87,11 @@ int main(void)
   printf("Testing rosidl_generator_tests embedded raw sources...\n");
   if (test_source_defined()) {
     fprintf(stderr, "test_source_defined() FAILED\n");
+    rc++;
+  }
+  printf("Testing same named types...\n");
+  if (test_same_name_types()) {
+    fprintf(stderr, "test_same_name_types() FAILED\n");
     rc++;
   }
 
@@ -254,6 +262,18 @@ int test_source_defined()
   {
     return 1;
   }
+
+  // IDL
+  check_src = rosidl_generator_tests__msg__BasicIdl__get_individual_type_description_source(NULL);
+  if (!check_src) {
+    fprintf(stderr, "BasicIdl.idl sources not available.\n");
+    return 1;
+  }
+  if (!string_char_equal(&check_src->encoding, "idl")) {
+    fprintf(stderr, "BasicIdl.idl source encoding '%s' is not 'idl'\n", check_src->encoding.data);
+    return 1;
+  }
+
   return 0;
 }
 
@@ -291,4 +311,32 @@ int test_copied_type_description_struct_hashes()
   #undef msghash
   #undef runtimehash
   return rc;
+}
+
+int test_same_name_types()
+{
+  // Msg and srv with same name in this package
+  // Regression check case, this was receiving "srv" encoding with Empty.srv sources
+  const rosidl_runtime_c__type_description__TypeSource * empty_msg_src =
+    rosidl_generator_tests__msg__Empty__get_individual_type_description_source(NULL);
+  if (!string_char_equal(&empty_msg_src->type_name, "rosidl_generator_tests/msg/Empty")) {
+    fprintf(stderr, "Empty.msg source name not as expected\n");
+    return 1;
+  }
+  if (!string_char_equal(&empty_msg_src->encoding, "msg")) {
+    fprintf(stderr, "Empty.msg source not encoded as msg\n");
+    return 1;
+  }
+
+  const rosidl_runtime_c__type_description__TypeSource * empty_srv_src =
+    rosidl_generator_tests__srv__Empty__get_individual_type_description_source(NULL);
+  if (!string_char_equal(&empty_srv_src->type_name, "rosidl_generator_tests/srv/Empty")) {
+    fprintf(stderr, "Empty.srv source name not as expected\n");
+    return 1;
+  }
+  if (!string_char_equal(&empty_srv_src->encoding, "srv")) {
+    fprintf(stderr, "Empty.srv source not encoded as srv\n");
+    return 1;
+  }
+  return 0;
 }

--- a/rosidl_pycommon/rosidl_pycommon/__init__.py
+++ b/rosidl_pycommon/rosidl_pycommon/__init__.py
@@ -70,7 +70,9 @@ def generate_files(
     ros_interface_files = {}
     for ros_interface_file in args.get('ros_interface_files',  []):
         p = pathlib.Path(ros_interface_file)
-        ros_interface_files[p.stem] = p
+        # e.g. ('Empty', 'msg')
+        key = (p.stem, p.suffix[1:])
+        ros_interface_files[key] = p
 
     for idl_tuple in args.get('idl_tuples', []):
         idl_parts = idl_tuple.rsplit(':', 1)
@@ -85,7 +87,8 @@ def generate_files(
                 type_description_info = json.load(f)
 
         idl_stem = idl_rel_path.stem
-        type_source_file = ros_interface_files.get(idl_stem, locator.get_absolute_path())
+        type_source_key = (idl_stem, idl_rel_path.parts[-2])
+        type_source_file = ros_interface_files.get(type_source_key, locator.get_absolute_path())
         if not keep_case:
             idl_stem = convert_camel_case_to_lower_case_underscore(idl_stem)
         try:

--- a/rosidl_pycommon/rosidl_pycommon/__init__.py
+++ b/rosidl_pycommon/rosidl_pycommon/__init__.py
@@ -70,8 +70,8 @@ def generate_files(
     ros_interface_files = {}
     for ros_interface_file in args.get('ros_interface_files',  []):
         p = pathlib.Path(ros_interface_file)
-        # e.g. ('Empty', 'msg')
-        key = (p.stem, p.suffix[1:])
+        # e.g. ('msg', 'Empty')
+        key = (p.suffix[1:], p.stem)
         ros_interface_files[key] = p
 
     for idl_tuple in args.get('idl_tuples', []):
@@ -87,7 +87,7 @@ def generate_files(
                 type_description_info = json.load(f)
 
         idl_stem = idl_rel_path.stem
-        type_source_key = (idl_stem, idl_rel_path.parts[-2])
+        type_source_key = (idl_rel_path.parts[-2], idl_stem)
         type_source_file = ros_interface_files.get(type_source_key, locator.get_absolute_path())
         if not keep_case:
             idl_stem = convert_camel_case_to_lower_case_underscore(idl_stem)


### PR DESCRIPTION
When two interface types in the same package had the same name stem (e.g. `msg/Empty.msg` and `srv/Empty.srv`), both types would receive the same `TypeSource`s in their generated description. Can be considered undefined behavior, but it's processed alphabetically so the `msg` consistently received the `srv` sources.

This fixes it, adds a regression test, and adds a new basic test for `.idl` files just to make sure that continues to work OK.
Bug exists in Iron, this would need to be backported.