### PR TITLE
Switch to target_link_libraries.

### DIFF
--- a/rosidl_runtime_c/CMakeLists.txt
+++ b/rosidl_runtime_c/CMakeLists.txt
@@ -37,9 +37,10 @@ add_library(${PROJECT_NAME}
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
-ament_target_dependencies(${PROJECT_NAME}
-  "rcutils"
-  "rosidl_typesupport_interface")
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  rcutils::rcutils
+  rosidl_typesupport_interface::rosidl_typesupport_interface
+)
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
   set_target_properties(${PROJECT_NAME} PROPERTIES
     COMPILE_OPTIONS -Wall -Wextra -Wpedantic)
@@ -116,8 +117,6 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_sequence_bound test/test_sequence_bound.cpp)
   if(TARGET test_sequence_bound)
-    ament_target_dependencies(test_sequence_bound
-      "rosidl_typesupport_interface")
     target_link_libraries(test_sequence_bound ${PROJECT_NAME})
   endif()
 

--- a/rosidl_typesupport_introspection_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_introspection_cpp/CMakeLists.txt
@@ -16,11 +16,7 @@ find_package(ament_cmake_ros REQUIRED)
 find_package(rosidl_runtime_cpp REQUIRED)
 find_package(rosidl_typesupport_introspection_c REQUIRED)
 
-ament_export_dependencies(rosidl_runtime_c)
-ament_export_dependencies(rosidl_runtime_cpp)
-ament_export_dependencies(rosidl_typesupport_interface)
-ament_export_dependencies(rosidl_typesupport_introspection_c)
-
+ament_export_dependencies(rosidl_runtime_cpp rosidl_typesupport_introspection_c)
 
 ament_python_install_package(${PROJECT_NAME})
 
@@ -32,9 +28,10 @@ endif()
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
-ament_target_dependencies(${PROJECT_NAME}
-  rosidl_runtime_cpp
-  rosidl_typesupport_introspection_c)
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  rosidl_runtime_cpp::rosidl_runtime_cpp
+  rosidl_typesupport_introspection_c::rosidl_typesupport_introspection_c
+)
 
 # Export old-style CMake variables
 ament_export_include_directories("include/${PROJECT_NAME}")


### PR DESCRIPTION
There really isn't any need to use ament_target_dependencies.