### PR TITLE
Address #775: Really make `char` in python a `str`

### DIFF
--- a/rosidl_adapter/rosidl_adapter/msg/__init__.py
+++ b/rosidl_adapter/rosidl_adapter/msg/__init__.py
@@ -43,7 +43,7 @@ def convert_msg_to_idl(package_dir, package_name, input_file, output_dir):
 MSG_TYPE_TO_IDL = {
     'bool': 'boolean',
     'byte': 'octet',
-    'char': 'uint8',
+    'char': 'char',
     'int8': 'int8',
     'uint8': 'uint8',
     'int16': 'int16',

--- a/rosidl_adapter/test/data/action/Test.expected.idl
+++ b/rosidl_adapter/test/data/action/Test.expected.idl
@@ -20,7 +20,7 @@ module test_msgs {
       @verbatim (language="comment", text=
         "asd" "\n"
         "bsd")
-      uint8 char_value;
+      char char_value;
 
       float float32_value;
 

--- a/rosidl_adapter/test/data/msg/Test.expected.idl
+++ b/rosidl_adapter/test/data/msg/Test.expected.idl
@@ -19,7 +19,7 @@ module test_msgs {
       @verbatim (language="comment", text=
         "combined styles" "\n"
         "combined styles, part 2")
-      CHAR char_value;
+      char char_value;
 
       float float32_value;
 

--- a/rosidl_adapter/test/data/msg/Test.expected.idl
+++ b/rosidl_adapter/test/data/msg/Test.expected.idl
@@ -19,7 +19,7 @@ module test_msgs {
       @verbatim (language="comment", text=
         "combined styles" "\n"
         "combined styles, part 2")
-      uint8 char_value;
+      CHAR char_value;
 
       float float32_value;
 

--- a/rosidl_adapter/test/data/srv/Test.expected.idl
+++ b/rosidl_adapter/test/data/srv/Test.expected.idl
@@ -20,7 +20,7 @@ module test_msgs {
       @verbatim (language="comment", text=
         "5" "\n"
         "6")
-      uint8 char_value;
+      char char_value;
 
       float float32_value;
 

--- a/rosidl_generator_tests/test/rosidl_generator_c/test_interfaces.c
+++ b/rosidl_generator_tests/test/rosidl_generator_c/test_interfaces.c
@@ -236,7 +236,7 @@ static int test_bounded_sequences(void)
   }
 
   // char_values
-  res = rosidl_runtime_c__uint8__Sequence__init(&seq->char_values, ARR_SIZE);
+  res = rosidl_runtime_c__char__Sequence__init(&seq->char_values, ARR_SIZE);
   EXPECT_EQ(true, res);
   for (i = 0; i < ARR_SIZE; i++) {
     seq->char_values.data[i] = test_values_char[i];
@@ -466,7 +466,7 @@ int test_unbounded_sequences()
   }
 
   // char_values
-  res = rosidl_runtime_c__uint8__Sequence__init(&seq->char_values, ARR_SIZE);
+  res = rosidl_runtime_c__char__Sequence__init(&seq->char_values, ARR_SIZE);
   EXPECT_EQ(true, res);
   for (i = 0; i < ARR_SIZE; i++) {
     seq->char_values.data[i] = test_values_char[i];

--- a/rosidl_generator_tests/test/rosidl_generator_cpp/test_traits.cpp
+++ b/rosidl_generator_tests/test/rosidl_generator_cpp/test_traits.cpp
@@ -44,7 +44,7 @@ TEST(Test_rosidl_generator_traits, to_yaml_default_style) {
     EXPECT_STREQ(
       R"(bool_value: true
 byte_value: 0x32
-char_value: 100
+char_value: 0x64
 float32_value: 1.12500
 float64_value: 1.00000
 int8_value: -50

--- a/rosidl_generator_tests/test/rosidl_generator_cpp/test_traits.cpp
+++ b/rosidl_generator_tests/test/rosidl_generator_cpp/test_traits.cpp
@@ -183,7 +183,7 @@ defaults_values:
 -
   bool_value: true
   byte_value: 0x32
-  char_value: 100
+  char_value: 0x64
   float32_value: 1.12500
   float64_value: 1.12500
   int8_value: -50
@@ -349,7 +349,7 @@ w\xf6rld", wstring_value_default1: "Hello world!", )"
       R"(uint32_value: 60000, int64_value: -40000000, uint64_value: 50000000}],)"
       R"( bool_values_default: [false, true, false], )"
       R"(byte_values_default: [0x00, 0x01, 0xff], )"
-      R"(char_values_default: [0, 1, 127], float32_values_default: [1.12500, )"
+      R"(char_values_default: [0x00, 0x01, 0x7f], float32_values_default: [1.12500, )"
       R"(0.00000, -1.12500], float64_values_default: [3.14150, 0.00000, )"
       R"(-3.14150], int8_values_default: [0, 127, -128], )"
       R"(uint8_values_default: [0, 1, 255], int16_values_default: )"

--- a/rosidl_generator_tests/test/rosidl_generator_cpp/test_traits.cpp
+++ b/rosidl_generator_tests/test/rosidl_generator_cpp/test_traits.cpp
@@ -136,7 +136,7 @@ long_double_value: 1.12500
       R"(basic_types_value:
   bool_value: false
   byte_value: 0x00
-  char_value: 0
+  char_value: 0x00
   float32_value: 0.00000
   float64_value: 0.00000
   int8_value: 0
@@ -203,9 +203,9 @@ byte_values_default:
 - 0x01
 - 0xff
 char_values_default:
-- 0
-- 1
-- 127
+- 0x00
+- 0x01
+- 0x7f
 float32_values_default:
 - 1.12500
 - 0.00000
@@ -267,7 +267,7 @@ TEST(Test_rosidl_generator_traits, to_yaml_flow_style) {
     rosidl_generator_tests::msg::Defaults msg;
     msg.float64_value = 1.0;
     EXPECT_STREQ(
-      "{bool_value: true, byte_value: 0x32, char_value: 100, "
+      "{bool_value: true, byte_value: 0x32, char_value: 0x64, "
       "float32_value: 1.12500, float64_value: 1.00000, int8_value: -50, "
       "uint8_value: 200, int16_value: -1000, uint16_value: 2000, "
       "int32_value: -30000, uint32_value: 60000, int64_value: -40000000, "
@@ -319,7 +319,7 @@ w\xf6rld", wstring_value_default1: "Hello world!", )"
 #endif
     EXPECT_STREQ(
       R"({basic_types_value: {bool_value: false, byte_value: 0x00, )"
-      R"(char_value: 0, float32_value: 0.00000, float64_value: 0.00000, )"
+      R"(char_value: 0x00, float32_value: 0.00000, float64_value: 0.00000, )"
       R"(int8_value: 0, uint8_value: 0, int16_value: 0, uint16_value: 0, )"
       R"(int32_value: 0, uint32_value: 0, int64_value: 0, uint64_value: 0}})",
       yaml.c_str());
@@ -343,7 +343,7 @@ w\xf6rld", wstring_value_default1: "Hello world!", )"
       R"(int32_values: [], uint32_values: [], int64_values: [], )"
       R"(uint64_values: [], string_values: [], basic_types_values: [], )"
       R"(constants_values: [], defaults_values: [{bool_value: true, )"
-      R"(byte_value: 0x32, char_value: 100, float32_value: 1.12500, )"
+      R"(byte_value: 0x32, char_value: 0x64, float32_value: 1.12500, )"
       R"(float64_value: 1.12500, int8_value: -50, uint8_value: 200, )"
       R"(int16_value: -1000, uint16_value: 2000, int32_value: -30000, )"
       R"(uint32_value: 60000, int64_value: -40000000, uint64_value: 50000000}],)"

--- a/rosidl_typesupport_introspection_tests/test/introspection_libraries_under_test.hpp
+++ b/rosidl_typesupport_introspection_tests/test/introspection_libraries_under_test.hpp
@@ -354,7 +354,7 @@ struct Example<rosidl_typesupport_introspection_tests__msg__BoundedSequences>
       !rosidl_typesupport_introspection_tests__msg__BoundedSequences__init(message.get()) ||
       !rosidl_runtime_c__boolean__Sequence__init(&message->bool_values, 1u) ||
       !rosidl_runtime_c__byte__Sequence__init(&message->byte_values, 1u) ||
-      !rosidl_runtime_c__uint8__Sequence__init(&message->char_values, 1u) ||
+      !rosidl_runtime_c__char__Sequence__init(&message->char_values, 1u) ||
       !rosidl_runtime_c__float__Sequence__init(&message->float32_values, 1u) ||
       !rosidl_runtime_c__double__Sequence__init(&message->float64_values, 1u) ||
       !rosidl_runtime_c__int8__Sequence__init(&message->int8_values, 1u) ||
@@ -513,7 +513,7 @@ struct Example<rosidl_typesupport_introspection_tests__msg__UnboundedSequences>
       !rosidl_typesupport_introspection_tests__msg__UnboundedSequences__init(message.get()) ||
       !rosidl_runtime_c__boolean__Sequence__init(&message->bool_values, 1u) ||
       !rosidl_runtime_c__byte__Sequence__init(&message->byte_values, 1u) ||
-      !rosidl_runtime_c__uint8__Sequence__init(&message->char_values, 1u) ||
+      !rosidl_runtime_c__char__Sequence__init(&message->char_values, 1u) ||
       !rosidl_runtime_c__float__Sequence__init(&message->float32_values, 1u) ||
       !rosidl_runtime_c__double__Sequence__init(&message->float64_values, 1u) ||
       !rosidl_runtime_c__int8__Sequence__init(&message->int8_values, 1u) ||

--- a/rosidl_typesupport_introspection_tests/test/test_arrays_message_introspection.cpp
+++ b/rosidl_typesupport_introspection_tests/test/test_arrays_message_introspection.cpp
@@ -76,7 +76,7 @@ TYPED_TEST(ArraysMessageIntrospectionTest, MessageDescriptorIsCorrect)
     auto * member_descriptor = get_member_descriptor(message_descriptor, 2u);
     EXPECT_STREQ(get_member_name(member_descriptor), "char_values");
     // In ROS message definitions, char is an alias for uint8.
-    EXPECT_TRUE(is_base_type_member(member_descriptor, ROS_TYPE_UINT8));
+    EXPECT_TRUE(is_base_type_member(member_descriptor, ROS_TYPE_CHAR));
     EXPECT_TRUE(has_array_structure(member_descriptor, 3u));
   }
 
@@ -202,7 +202,7 @@ TYPED_TEST(ArraysMessageIntrospectionTest, MessageDescriptorIsCorrect)
     auto * member_descriptor = get_member_descriptor(message_descriptor, 19u);
     EXPECT_STREQ(get_member_name(member_descriptor), "char_values_default");
     // In ROS message definitions, char is an alias for uint8.
-    EXPECT_TRUE(is_base_type_member(member_descriptor, ROS_TYPE_UINT8));
+    EXPECT_TRUE(is_base_type_member(member_descriptor, ROS_TYPE_CHAR));
     EXPECT_TRUE(has_array_structure(member_descriptor, 3u));
   }
 

--- a/rosidl_typesupport_introspection_tests/test/test_arrays_service_introspection.cpp
+++ b/rosidl_typesupport_introspection_tests/test/test_arrays_service_introspection.cpp
@@ -87,7 +87,7 @@ TYPED_TEST(ArraysServiceIntrospectionTest, ServiceDescriptorIsCorrect)
     auto * member_descriptor = get_member_descriptor(request_message_descriptor, 2u);
     EXPECT_STREQ(get_member_name(member_descriptor), "char_values");
     // In ROS message definitions, char is an alias for uint8.
-    EXPECT_TRUE(is_base_type_member(member_descriptor, ROS_TYPE_UINT8));
+    EXPECT_TRUE(is_base_type_member(member_descriptor, ROS_TYPE_CHAR));
     EXPECT_TRUE(has_array_structure(member_descriptor, 3u));
   }
 
@@ -213,7 +213,7 @@ TYPED_TEST(ArraysServiceIntrospectionTest, ServiceDescriptorIsCorrect)
     auto * member_descriptor = get_member_descriptor(request_message_descriptor, 19u);
     EXPECT_STREQ(get_member_name(member_descriptor), "char_values_default");
     // In ROS message definitions, char is an alias for uint8.
-    EXPECT_TRUE(is_base_type_member(member_descriptor, ROS_TYPE_UINT8));
+    EXPECT_TRUE(is_base_type_member(member_descriptor, ROS_TYPE_CHAR));
     EXPECT_TRUE(has_array_structure(member_descriptor, 3u));
   }
 
@@ -320,7 +320,7 @@ TYPED_TEST(ArraysServiceIntrospectionTest, ServiceDescriptorIsCorrect)
     auto * member_descriptor = get_member_descriptor(response_message_descriptor, 2u);
     EXPECT_STREQ(get_member_name(member_descriptor), "char_values");
     // In ROS message definitions, char is an alias for uint8.
-    EXPECT_TRUE(is_base_type_member(member_descriptor, ROS_TYPE_UINT8));
+    EXPECT_TRUE(is_base_type_member(member_descriptor, ROS_TYPE_CHAR));
     EXPECT_TRUE(has_array_structure(member_descriptor, 3u));
   }
 
@@ -446,7 +446,7 @@ TYPED_TEST(ArraysServiceIntrospectionTest, ServiceDescriptorIsCorrect)
     auto * member_descriptor = get_member_descriptor(response_message_descriptor, 19u);
     EXPECT_STREQ(get_member_name(member_descriptor), "char_values_default");
     // In ROS message definitions, char is an alias for uint8.
-    EXPECT_TRUE(is_base_type_member(member_descriptor, ROS_TYPE_UINT8));
+    EXPECT_TRUE(is_base_type_member(member_descriptor, ROS_TYPE_CHAR));
     EXPECT_TRUE(has_array_structure(member_descriptor, 3u));
   }
 

--- a/rosidl_typesupport_introspection_tests/test/test_basic_types_message_introspection.cpp
+++ b/rosidl_typesupport_introspection_tests/test/test_basic_types_message_introspection.cpp
@@ -76,7 +76,7 @@ TYPED_TEST(BasicTypesMessageIntrospectionTest, MessageDescriptorIsCorrect)
     auto * member_descriptor = get_member_descriptor(message_descriptor, 2u);
     EXPECT_STREQ(get_member_name(member_descriptor), "char_value");
     // In ROS message definitions, char is an alias for uint8.
-    EXPECT_TRUE(is_base_type_member(member_descriptor, ROS_TYPE_UINT8));
+    EXPECT_TRUE(is_base_type_member(member_descriptor, ROS_TYPE_CHAR));
     EXPECT_TRUE(has_simple_structure(member_descriptor));
   }
 

--- a/rosidl_typesupport_introspection_tests/test/test_basic_types_service_introspection.cpp
+++ b/rosidl_typesupport_introspection_tests/test/test_basic_types_service_introspection.cpp
@@ -84,7 +84,7 @@ TYPED_TEST(BasicTypesServiceIntrospectionTest, ServiceDescriptorIsCorrect)
     auto * member_descriptor = get_member_descriptor(request_message_descriptor, 2u);
     EXPECT_STREQ(get_member_name(member_descriptor), "char_value");
     // In ROS message definitions, char is an alias for uint8.
-    EXPECT_TRUE(is_base_type_member(member_descriptor, ROS_TYPE_UINT8));
+    EXPECT_TRUE(is_base_type_member(member_descriptor, ROS_TYPE_CHAR));
     EXPECT_TRUE(has_simple_structure(member_descriptor));
   }
 
@@ -192,7 +192,7 @@ TYPED_TEST(BasicTypesServiceIntrospectionTest, ServiceDescriptorIsCorrect)
     auto * member_descriptor = get_member_descriptor(response_message_descriptor, 2u);
     EXPECT_STREQ(get_member_name(member_descriptor), "char_value");
     // In ROS message definitions, char is an alias for uint8.
-    EXPECT_TRUE(is_base_type_member(member_descriptor, ROS_TYPE_UINT8));
+    EXPECT_TRUE(is_base_type_member(member_descriptor, ROS_TYPE_CHAR));
     EXPECT_TRUE(has_simple_structure(member_descriptor));
   }
 

--- a/rosidl_typesupport_introspection_tests/test/test_bounded_sequences_message_introspection.cpp
+++ b/rosidl_typesupport_introspection_tests/test/test_bounded_sequences_message_introspection.cpp
@@ -76,7 +76,7 @@ TYPED_TEST(BoundedSequencesMessageIntrospectionTest, MessageDescriptorIsCorrect)
     auto * member_descriptor = get_member_descriptor(message_descriptor, 2u);
     EXPECT_STREQ(get_member_name(member_descriptor), "char_values");
     // In ROS message definitions, char is an alias for uint8.
-    EXPECT_TRUE(is_base_type_member(member_descriptor, ROS_TYPE_UINT8));
+    EXPECT_TRUE(is_base_type_member(member_descriptor, ROS_TYPE_CHAR));
     EXPECT_TRUE(has_bounded_sequence_structure(member_descriptor, 3u));
   }
 
@@ -202,7 +202,7 @@ TYPED_TEST(BoundedSequencesMessageIntrospectionTest, MessageDescriptorIsCorrect)
     auto * member_descriptor = get_member_descriptor(message_descriptor, 19u);
     EXPECT_STREQ(get_member_name(member_descriptor), "char_values_default");
     // In ROS message definitions, char is an alias for uint8.
-    EXPECT_TRUE(is_base_type_member(member_descriptor, ROS_TYPE_UINT8));
+    EXPECT_TRUE(is_base_type_member(member_descriptor, ROS_TYPE_CHAR));
     EXPECT_TRUE(has_bounded_sequence_structure(member_descriptor, 3u));
   }
 

--- a/rosidl_typesupport_introspection_tests/test/test_defaults_message_introspection.cpp
+++ b/rosidl_typesupport_introspection_tests/test/test_defaults_message_introspection.cpp
@@ -76,7 +76,7 @@ TYPED_TEST(DefaultsMessageIntrospectionTest, MessageDescriptorIsCorrect)
     auto * member_descriptor = get_member_descriptor(message_descriptor, 2u);
     EXPECT_STREQ(get_member_name(member_descriptor), "char_value");
     // In ROS message definitions, char is an alias for uint8.
-    EXPECT_TRUE(is_base_type_member(member_descriptor, ROS_TYPE_UINT8));
+    EXPECT_TRUE(is_base_type_member(member_descriptor, ROS_TYPE_CHAR));
     EXPECT_TRUE(has_simple_structure(member_descriptor));
   }
 

--- a/rosidl_typesupport_introspection_tests/test/test_unbounded_sequences_message_introspection.cpp
+++ b/rosidl_typesupport_introspection_tests/test/test_unbounded_sequences_message_introspection.cpp
@@ -78,7 +78,7 @@ TYPED_TEST(UnboundedSequencesMessageIntrospectionTest, MessageDescriptorIsCorrec
     auto * member_descriptor = get_member_descriptor(message_descriptor, 2u);
     EXPECT_STREQ(get_member_name(member_descriptor), "char_values");
     // In ROS message definitions, char is an alias for uint8.
-    EXPECT_TRUE(is_base_type_member(member_descriptor, ROS_TYPE_UINT8));
+    EXPECT_TRUE(is_base_type_member(member_descriptor, ROS_TYPE_CHAR));
     EXPECT_TRUE(has_sequence_structure(member_descriptor));
   }
 
@@ -204,7 +204,7 @@ TYPED_TEST(UnboundedSequencesMessageIntrospectionTest, MessageDescriptorIsCorrec
     auto * member_descriptor = get_member_descriptor(message_descriptor, 19u);
     EXPECT_STREQ(get_member_name(member_descriptor), "char_values_default");
     // In ROS message definitions, char is an alias for uint8.
-    EXPECT_TRUE(is_base_type_member(member_descriptor, ROS_TYPE_UINT8));
+    EXPECT_TRUE(is_base_type_member(member_descriptor, ROS_TYPE_CHAR));
     EXPECT_TRUE(has_sequence_structure(member_descriptor));
   }
 


### PR DESCRIPTION
This commit addresses #775 for rolling going forward.

Note: This commit breaks a lot of down stream tests. I will be pushing fixes one by one as I discover errors.