### PR TITLE
Remove an unnecessary parentheses to raise.

### DIFF
--- a/rosidl_generator_type_description/rosidl_generator_type_description/__init__.py
+++ b/rosidl_generator_type_description/rosidl_generator_type_description/__init__.py
@@ -117,7 +117,7 @@ def generate_type_hash(generator_arguments_file: str) -> List[str]:
         except Exception as e:
             print('Error processing idl file: ' +
                   str(locator.get_absolute_path()), file=sys.stderr)
-            raise(e)
+            raise e
 
         idl_rel_path = Path(idl_parts[1])
         generate_to_dir = (output_dir / idl_rel_path).parent

--- a/rosidl_parser/test/test_parser.py
+++ b/rosidl_parser/test/test_parser.py
@@ -315,13 +315,13 @@ def test_service_parser(service_idl_file):
     assert srv.namespaced_type.name == 'MyService'
     assert len(srv.request_message.structure.members) == 2
     assert len(srv.response_message.structure.members) == 1
-    assert(srv.event_message.structure.namespaced_type.name ==
+    assert (srv.event_message.structure.namespaced_type.name ==
            'MyService' + SERVICE_EVENT_MESSAGE_SUFFIX)
 
     event_message_members = [i.name for i in srv.event_message.structure.members]
-    assert('request' in event_message_members)
-    assert('response' in event_message_members)
-    assert('info' in event_message_members)
+    assert 'request' in event_message_members
+    assert 'response' in event_message_members
+    assert 'info' in event_message_members
 
     constants = srv.request_message.constants
     assert len(constants) == 1

--- a/rosidl_pycommon/rosidl_pycommon/__init__.py
+++ b/rosidl_pycommon/rosidl_pycommon/__init__.py
@@ -116,7 +116,7 @@ def generate_files(
             print(
                 'Error processing idl file: ' +
                 str(locator.get_absolute_path()), file=sys.stderr)
-            raise(e)
+            raise e
 
     return generated_files
 


### PR DESCRIPTION
This will fix a warning when using newer versions of flake8.