### PR TITLE
Improve deprecation notice of rosidl_target_interface to give a hint on how to update the code

### DIFF
--- a/rosidl_cmake/cmake/rosidl_target_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_target_interfaces.cmake
@@ -29,7 +29,10 @@
 # @public
 #
 function(rosidl_target_interfaces target interface_target typesupport_name)
-  message(DEPRECATION "Use rosidl_get_typesupport_target() and target_link_libraries() instead of rosidl_target_interfaces()")
+  message(DEPRECATION "Use rosidl_get_typesupport_target() and target_link_libraries() instead of rosidl_target_interfaces(). i.e:
+  rosidl_get_typesupport_target(cpp_typesupport_target \"\${PROJECT_NAME}\" \"rosidl_typesupport_cpp\")
+  target_link_libraries(\${PROJECT_NAME}_node \"\${cpp_typesupport_target}\")
+")
   if(ARGN)
     message(FATAL_ERROR
       "rosidl_target_interfaces() called with unused arguments: ${ARGN}")


### PR DESCRIPTION
This adds a code example on how to fix the deprecation notice of rosidl_target_interface

The new message looks like:
![image](https://github.com/ros2/rosidl/assets/6976744/95cd3c96-d594-4e9d-b0f9-6a66d0a1b1fb)
