### PR TITLE
Small fix for newer flake8 compatibility.

### DIFF
--- a/rosidl_parser/rosidl_parser/definition.py
+++ b/rosidl_parser/rosidl_parser/definition.py
@@ -108,7 +108,7 @@ class AbstractType:
     __slots__ = ()
 
     def __eq__(self, other):
-        return type(self) == type(other)
+        return type(self) is type(other)
 
 
 class AbstractNestableType(AbstractType):


### PR DESCRIPTION
Don't directly compare types, but instead use "is" instead.