### PR TITLE
Fixes for modern uncrustify.

### DIFF
--- a/rosidl_generator_tests/test/rosidl_generator_c/test_interfaces.c
+++ b/rosidl_generator_tests/test/rosidl_generator_c/test_interfaces.c
@@ -45,21 +45,16 @@
   u"Deep into that darkness peering, long I stood there wondering, fearing \u2122"
 #define ARR_SIZE 3
 
-#define STRINGIFY(x) _STRINGIFY(x)
 #define _STRINGIFY(x) #x
+#define STRINGIFY(x) _STRINGIFY(x)
 
-#define EXPECT_FALSE(arg) if (arg) { \
-    fputs(STRINGIFY(arg) " is not false\n", stderr); \
-    return 1; \
-}
-#define EXPECT_TRUE(arg) if (!(arg)) { \
-    fputs(STRINGIFY(arg) " is not true\n", stderr); \
-    return 1; \
-}
-#define EXPECT_EQ(arg1, arg2) if ((arg1) != (arg2)) { \
-    fputs(STRINGIFY(arg1) " != " STRINGIFY(arg2) "\n", stderr); \
-    return 1; \
-}
+#define PUTS(arg, extra) fprintf(stderr, "%s%s\n", STRINGIFY(arg), extra)
+
+#define EXPECT_FALSE(arg) if (arg) {PUTS(arg, " is not false"); return 1;}
+#define EXPECT_TRUE(arg) if (!(arg)) {PUTS(arg, " is not true"); return 1;}
+
+#define PUTS_NE(arg1, arg2) fprintf(stderr, "%s != %s\n", STRINGIFY(arg1), STRINGIFY(arg2))
+#define EXPECT_EQ(arg1, arg2) if ((arg1) != (arg2)) {PUTS_NE(arg1, arg2); return 1;}
 #define EXPECT_NE(arg1, arg2) if ((arg1) == (arg2)) return 1
 
 static const uint8_t test_values_byte[ARR_SIZE] = {0, 57, 110};


### PR DESCRIPTION
Mostly just redoing macros to make them fit on one line so we can avoid problems between old and new uncrustify.