### PR TITLE
Increased the cpplint timeout to 300 seconds

### DIFF
--- a/rosidl_generator_tests/CMakeLists.txt
+++ b/rosidl_generator_tests/CMakeLists.txt
@@ -136,3 +136,8 @@ if(BUILD_TESTING)
 endif()
 
 ament_package()
+
+if(TEST cpplint)
+  # must set the property after ament_package()
+  set_tests_properties(cpplint PROPERTIES TIMEOUT 300)
+endif()


### PR DESCRIPTION
In this [nightly job](https://ci.ros2.org/view/nightly/job/nightly_win_deb/3052/#showFailuresLink) I just see a cpplint timeout in `rosidl_generated_cpp` package

Increaing a little bit the timeout.

```bash
2: Done processing C:\ci\ws\build\rosidl_generator_tests\rosidl_generator_cpp\rosidl_generator_tests\msg\detail\strings__type_support.hpp
 2/44 Test  #2: cpplint_rosidl_generated_cpp ......................***Timeout 120.06 sec
```