### PR TITLE
Global use of nodiscard

### DIFF
--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/action_type_support_decl.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/action_type_support_decl.hpp
@@ -27,6 +27,7 @@ namespace rosidl_runtime_cpp
  * \return Function handler for the action's typesupport.
  */
 template<typename T>
+[[nodiscard]]
 const rosidl_action_type_support_t * get_action_type_support_handle();
 
 }  // namespace rosidl_runtime_cpp

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/bounded_vector.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/bounded_vector.hpp
@@ -714,6 +714,7 @@ private:
    * \param y A %BoundedVector of the same type as @a x
    * \return True if the size and elements of the vectors are equal
   */
+  [[nodiscard]]
   friend bool
   operator==(
     const BoundedVector & x,
@@ -734,6 +735,7 @@ private:
    * \param y A %BoundedVector of the same type as @a x
    * @return True if @a x is lexicographically less than @a y
   */
+  [[nodiscard]]
   friend bool
   operator<(
     const BoundedVector & x,
@@ -743,6 +745,7 @@ private:
   }
 
   /// Based on operator==
+  [[nodiscard]]
   friend bool
   operator!=(
     const BoundedVector & x,
@@ -752,6 +755,7 @@ private:
   }
 
   /// Based on operator<
+  [[nodiscard]]
   friend bool
   operator>(
     const BoundedVector & x,
@@ -761,6 +765,7 @@ private:
   }
 
   /// Based on operator<
+  [[nodiscard]]
   friend bool
   operator<=(
     const BoundedVector & x,
@@ -770,6 +775,7 @@ private:
   }
 
   /// Based on operator<
+  [[nodiscard]]
   friend bool
   operator>=(
     const BoundedVector & x,

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/message_type_support_decl.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/message_type_support_decl.hpp
@@ -27,6 +27,7 @@ namespace rosidl_runtime_cpp
  * \return Function handler for the message's typesupport.
  */
 template<typename T>
+[[nodiscard]]
 const rosidl_message_type_support_t * get_message_type_support_handle();
 
 }  // namespace rosidl_runtime_cpp

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/service_type_support_decl.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/service_type_support_decl.hpp
@@ -27,6 +27,7 @@ namespace rosidl_runtime_cpp
  * \return Function handler for the service's typesupport.
  */
 template<typename T>
+[[nodiscard]]
 const rosidl_service_type_support_t * get_service_type_support_handle();
 
 }  // namespace rosidl_runtime_cpp

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/type_description/field__struct.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/type_description/field__struct.hpp
@@ -133,6 +133,7 @@ struct Field_
     ConstPtr;
 
   // comparison operators
+  [[nodiscard]]
   bool operator==(const Field_ & other) const
   {
     if (this->name != other.name) {
@@ -146,6 +147,7 @@ struct Field_
     }
     return true;
   }
+  [[nodiscard]]
   bool operator!=(const Field_ & other) const
   {
     return !this->operator==(other);

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/type_description/field_type__struct.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/type_description/field_type__struct.hpp
@@ -335,6 +335,7 @@ struct FieldType_
     ConstPtr;
 
   // comparison operators
+  [[nodiscard]]
   bool operator==(const FieldType_ & other) const
   {
     if (this->type_id != other.type_id) {
@@ -351,6 +352,7 @@ struct FieldType_
     }
     return true;
   }
+  [[nodiscard]]
   bool operator!=(const FieldType_ & other) const
   {
     return !this->operator==(other);

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/type_description/individual_type_description__struct.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/type_description/individual_type_description__struct.hpp
@@ -119,6 +119,7 @@ struct IndividualTypeDescription_
     ConstPtr;
 
   // comparison operators
+  [[nodiscard]]
   bool operator==(const IndividualTypeDescription_ & other) const
   {
     if (this->type_name != other.type_name) {
@@ -129,6 +130,7 @@ struct IndividualTypeDescription_
     }
     return true;
   }
+  [[nodiscard]]
   bool operator!=(const IndividualTypeDescription_ & other) const
   {
     return !this->operator==(other);

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/type_description/key_value__struct.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/type_description/key_value__struct.hpp
@@ -118,6 +118,7 @@ struct KeyValue_
     ConstPtr;
 
   // comparison operators
+  [[nodiscard]]
   bool operator==(const KeyValue_ & other) const
   {
     if (this->key != other.key) {
@@ -128,6 +129,7 @@ struct KeyValue_
     }
     return true;
   }
+  [[nodiscard]]
   bool operator!=(const KeyValue_ & other) const
   {
     return !this->operator==(other);

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/type_description/type_description__struct.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/type_description/type_description__struct.hpp
@@ -113,6 +113,7 @@ struct TypeDescription_
     ConstPtr;
 
   // comparison operators
+  [[nodiscard]]
   bool operator==(const TypeDescription_ & other) const
   {
     if (this->type_description != other.type_description) {
@@ -123,6 +124,7 @@ struct TypeDescription_
     }
     return true;
   }
+  [[nodiscard]]
   bool operator!=(const TypeDescription_ & other) const
   {
     return !this->operator==(other);

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/type_description/type_source__struct.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/type_description/type_source__struct.hpp
@@ -130,6 +130,7 @@ struct TypeSource_
     ConstPtr;
 
   // comparison operators
+  [[nodiscard]]
   bool operator==(const TypeSource_ & other) const
   {
     if (this->type_name != other.type_name) {
@@ -143,6 +144,7 @@ struct TypeSource_
     }
     return true;
   }
+  [[nodiscard]]
   bool operator!=(const TypeSource_ & other) const
   {
     return !this->operator==(other);

--- a/rosidl_runtime_cpp/include/rosidl_typesupport_cpp/action_type_support.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_typesupport_cpp/action_type_support.hpp
@@ -22,6 +22,7 @@ namespace rosidl_typesupport_cpp
 {
 
 template<typename T>
+[[nodiscard]]
 const rosidl_action_type_support_t * get_action_type_support_handle();
 
 }  // namespace rosidl_typesupport_cpp

--- a/rosidl_runtime_cpp/include/rosidl_typesupport_cpp/message_type_support.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_typesupport_cpp/message_type_support.hpp
@@ -22,6 +22,7 @@ namespace rosidl_typesupport_cpp
 {
 
 template<typename T>
+[[nodiscard]]
 const rosidl_message_type_support_t * get_message_type_support_handle();
 
 }  // namespace rosidl_typesupport_cpp

--- a/rosidl_runtime_cpp/include/rosidl_typesupport_cpp/service_type_support.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_typesupport_cpp/service_type_support.hpp
@@ -25,6 +25,7 @@ namespace rosidl_typesupport_cpp
 {
 
 template<typename T>
+[[nodiscard]]
 const rosidl_service_type_support_t * get_service_type_support_handle();
 
 template<typename T>

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/message_type_support_decl.hpp
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/message_type_support_decl.hpp
@@ -28,6 +28,7 @@ namespace rosidl_typesupport_introspection_cpp
 /// the rosidl_generate_interfaces() macro.
 /// This is implemented in the shared library provided by this package.
 template<typename T>
+[[nodiscard]]
 ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC
 const rosidl_message_type_support_t * get_message_type_support_handle();
 

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/service_type_support_decl.hpp
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/service_type_support_decl.hpp
@@ -27,6 +27,7 @@ namespace rosidl_typesupport_introspection_cpp
 /// services.
 /// This is implemented in the shared library provided by this package.
 template<typename T>
+[[nodiscard]]
 ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC
 const rosidl_service_type_support_t * get_service_type_support_handle();
 


### PR DESCRIPTION
This PR is meant to address #786 in the `rosidl` repo, so using [`nodiscard`](https://en.cppreference.com/w/cpp/language/attributes/nodiscard) on any getter functions and operators if possible. Adding `nodiscard` should prevent a lot of unnecessary bugs ahead of time. Though, I do have a couple things that we may need to address

1. Is this something that we want to do in any repository with C++, since it would reduce bugs projectwide? If that's the case, this issue should be expanded to [the ros2 repo](https://github.com/ros2/ros2), even if Jazzy is enduring a feature freeze.
2. To what extent should we be using `nodiscard`? At the original release of this PR I just went for getters and operators because of the implementation details:
> Getters and operators could have the [[nodiscard]] attribute to prevent bugs.

Though realistically many functions could utilize `nodiscard` to prevent weird issues.

3. Any operator that returns`*this` cannot use `nodiscard` because you must always assign that `this` value but each operator overload has `nodiscard`, so we would have to make extra functions which don't use `nodiscard`, getting rid of the purpose.
