### PR TITLE
Switch to using fastjsonschema for schema validation.

### DIFF
--- a/rosidl_generator_tests/package.xml
+++ b/rosidl_generator_tests/package.xml
@@ -24,7 +24,7 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_index_python</test_depend>
-  <test_depend>python3-jsonschema</test_depend>
+  <test_depend>python3-fastjsonschema</test_depend>
   <test_depend>rosidl_cmake</test_depend>
   <test_depend>rosidl_generator_c</test_depend>
   <test_depend>rosidl_generator_cpp</test_depend>

--- a/rosidl_generator_tests/test/rosidl_generator_type_description/test_type_hash.py
+++ b/rosidl_generator_tests/test/rosidl_generator_type_description/test_type_hash.py
@@ -17,7 +17,7 @@ import os
 from pathlib import Path
 
 from ament_index_python import get_package_share_directory
-import jsonschema
+import fastjsonschema
 
 
 def test_type_hash():
@@ -25,8 +25,10 @@ def test_type_hash():
     schema_path = (
         Path(get_package_share_directory('rosidl_generator_type_description')) / 'resource' /
         'HashedTypeDescription.schema.json')
+
     with schema_path.open('r') as schema_file:
         schema = json.load(schema_file)
+        validator = fastjsonschema.compile(schema)
 
     generated_files_dir = Path(os.environ['GENERATED_TEST_FILE_DIR'])
     validated_files = 0
@@ -36,6 +38,6 @@ def test_type_hash():
             assert p.suffix == '.json'
             with p.open('r') as f:
                 instance = json.load(f)
-            jsonschema.validate(instance=instance, schema=schema)
+            validator(instance)
             validated_files += 1
     assert validated_files, 'Needed to validate at least one JSON output.'


### PR DESCRIPTION
The main reason to do this is because jsonschema (what we currently use) depends on referencing, which depends on rpds-py, which has C libraries.  That means that when using the python debug interpreter on Windows, we would have to build a custom pip package for it to work.

In contrast, fastjsonschema is pure python and has no dependencies.  It is also available on all of our default platforms.  So switch to using it here so things work on Windows debug.

Note that this depends on both https://github.com/ros2/ci/pull/782 and https://github.com/ros/rosdistro/pull/41538 to go in first.