### PR TITLE
Suppress warnings in the benchmarks for upstream GCC false positives.

### DIFF
--- a/rosidl_runtime_cpp/test/benchmark/benchmark_bounded_vector.cpp
+++ b/rosidl_runtime_cpp/test/benchmark/benchmark_bounded_vector.cpp
@@ -67,7 +67,18 @@ BENCHMARK_F(PerformanceTest, bounded_vector_insert)(benchmark::State & st)
   for (auto _ : st) {
     (void)_;
     v.insert(v.begin(), v2.begin(), v2.end());
+// GCC 13 has false positive warnings around stringop-overflow and array-bounds.
+// Suppress them until this is fixed in upstream gcc.  See
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114758 for more details.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
     v.erase(v.begin());
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
   }
 }
 


### PR DESCRIPTION
This will fix at least one of the warnings as seen in https://ci.ros2.org/view/nightly/job/nightly_linux_release/3103/gcc/new/

@Crola1702 FYI