### PR TITLE
Patch warnings (#810) (#814)

### DIFF
--- a/rosidl_generator_tests/test/rosidl_generator_cpp/test_interfaces.cpp
+++ b/rosidl_generator_tests/test/rosidl_generator_cpp/test_interfaces.cpp
@@ -12,7 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
 #include <gtest/gtest.h>
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 #include <algorithm>
 #include <array>
@@ -478,15 +486,7 @@ TEST(Test_messages, constants_assign) {
 // Defaults
 TEST(Test_messages, defaults) {
   rosidl_generator_tests::msg::Defaults message;
-// workaround for https://github.com/google/googletest/issues/322
-#ifdef __linux__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wconversion-null"
-#endif
   TEST_BASIC_TYPE_FIELD_ASSIGNMENT(message, bool_value, true, false);
-#ifdef __linux__
-#pragma GCC diagnostic pop
-#endif
   TEST_BASIC_TYPE_FIELD_ASSIGNMENT(message, byte_value, 50, 255);
   TEST_BASIC_TYPE_FIELD_ASSIGNMENT(message, char_value, 100, UINT8_MAX);
   TEST_BASIC_TYPE_FIELD_ASSIGNMENT(message, float32_value, 1.125f, FLT_MAX);
@@ -510,7 +510,6 @@ TEST(Test_messages, string_arrays_default) {
   ASSERT_EQ(3ul, message.string_values_default.size());
 }
 
-// TODO(mikaelarguedas) reenable this test when bounded strings enforce length
 TEST(Test_messages, DISABLED_Test_bounded_strings) {
   rosidl_generator_tests::msg::Strings message;
   TEST_STRING_FIELD_ASSIGNMENT(message, bounded_string_value, "", "Deep into")

--- a/rosidl_runtime_cpp/test/benchmark/benchmark_bounded_vector.cpp
+++ b/rosidl_runtime_cpp/test/benchmark/benchmark_bounded_vector.cpp
@@ -67,7 +67,18 @@ BENCHMARK_F(PerformanceTest, bounded_vector_insert)(benchmark::State & st)
   for (auto _ : st) {
     (void)_;
     v.insert(v.begin(), v2.begin(), v2.end());
+// GCC 13 has false positive warnings around stringop-overflow and array-bounds.
+// Suppress them until this is fixed in upstream gcc.  See
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114758 for more details.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
     v.erase(v.begin());
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
   }
 }
 


### PR DESCRIPTION
gcc 13 has false positives around array-bounds and stringop-overflow, so suppress them here while generating test cases. (#810)

This will fix at least one of the warnings as seen in https://ci.ros2.org/view/nightly/job/nightly_linux_release/3103/gcc/new/ (#814)

Warnings still happening on Jazzy ([reference build](https://build.ros2.org/view/Jci/job/Jci__nightly-release_ubuntu_noble_amd64/27/gcc/))