### PR TITLE
Allow legacy field names in rosidl_generate_interfaces [humble]

### DIFF
--- a/rosidl_adapter/cmake/rosidl_adapt_interfaces.cmake
+++ b/rosidl_adapter/cmake/rosidl_adapt_interfaces.cmake
@@ -30,11 +30,13 @@
 # @public
 #
 function(rosidl_adapt_interfaces idl_var arguments_file)
-  cmake_parse_arguments(ARG "" "TARGET" ""
-    ${ARGN})
+  set(options ALLOW_LEGACY_FIELD_NAMES)
+  set(oneValueArgs TARGET)
+  set(multiValueArgs "")
+  cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
   if(ARG_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "rosidl_adapt_interfaces() called with unused "
-      "arguments: ${ARG_UNPARSED_ARGUMENTS}")
+      "arguments: ${ARG_UNPARSED_ARGUMENTS}. ALLOW_LEGACY? '${ARG_ALLOW_LEGACY_FIELD_NAMES}'")
   endif()
 
   find_package(ament_cmake_core REQUIRED)  # for get_executable_path
@@ -48,6 +50,11 @@ function(rosidl_adapt_interfaces idl_var arguments_file)
     --arguments-file "${arguments_file}"
     --output-dir "${CMAKE_CURRENT_BINARY_DIR}/rosidl_adapter/${PROJECT_NAME}"
     --output-file "${idl_output}")
+  if(ARG_ALLOW_LEGACY_FIELD_NAMES)
+    list(APPEND cmd --allow-legacy-field-naming)
+    MESSAGE(WARNING Allowing legacy arguments.)
+  endif()
+
   execute_process(
     COMMAND ${cmd}
     OUTPUT_QUIET

--- a/rosidl_adapter/rosidl_adapter/__init__.py
+++ b/rosidl_adapter/rosidl_adapter/__init__.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from rosidl_adapter.parser import DEFAULT_ALLOW_LEGACY_FIELD_NAMES
 
-def convert_to_idl(package_dir, package_name, interface_file, output_dir):
+def convert_to_idl(package_dir, package_name, interface_file, output_dir, *, allow_legacy_field_naming=DEFAULT_ALLOW_LEGACY_FIELD_NAMES):
     if interface_file.suffix == '.msg':
         from rosidl_adapter.msg import convert_msg_to_idl
+
         return convert_msg_to_idl(
-            package_dir, package_name, interface_file, output_dir / 'msg')
+            package_dir, package_name, interface_file, output_dir / 'msg', allow_legacy_field_naming=allow_legacy_field_naming)
 
     if interface_file.suffix == '.srv':
         from rosidl_adapter.srv import convert_srv_to_idl

--- a/rosidl_adapter/rosidl_adapter/main.py
+++ b/rosidl_adapter/rosidl_adapter/main.py
@@ -20,6 +20,7 @@ import sys
 
 
 from rosidl_adapter import convert_to_idl
+from rosidl_adapter.parser import DEFAULT_ALLOW_LEGACY_FIELD_NAMES
 
 
 def main(argv=sys.argv[1:]):
@@ -38,6 +39,10 @@ def main(argv=sys.argv[1:]):
         '--output-file', required=True,
         help='The output file containing the tuples for the generated .idl '
              'files')
+    legacy_field_name_action = "store_true" if DEFAULT_ALLOW_LEGACY_FIELD_NAMES else "store_false"
+    parser.add_argument(
+        '--allow-legacy-field-naming', required=False, action=legacy_field_name_action,
+        help='Allow legacy ROS1 style field names that use PascalCase, camelCase, and Pascal_With_Underscores')
     args = parser.parse_args(argv)
     output_dir = pathlib.Path(args.output_dir)
     output_file = pathlib.Path(args.output_file)
@@ -52,7 +57,8 @@ def main(argv=sys.argv[1:]):
         basepath, relative_path = non_idl_tuple.rsplit(':', 1)
         abs_idl_file = convert_to_idl(
             pathlib.Path(basepath), args.package_name,
-            pathlib.Path(relative_path), output_dir)
+            pathlib.Path(relative_path), output_dir,
+            allow_legacy_field_naming=args.allow_legacy_field_naming)
         idl_tuples.append((output_dir, abs_idl_file.relative_to(output_dir)))
 
     output_file.parent.mkdir(exist_ok=True)

--- a/rosidl_adapter/rosidl_adapter/main.py
+++ b/rosidl_adapter/rosidl_adapter/main.py
@@ -39,7 +39,7 @@ def main(argv=sys.argv[1:]):
         '--output-file', required=True,
         help='The output file containing the tuples for the generated .idl '
              'files')
-    legacy_field_name_action = "store_true" if DEFAULT_ALLOW_LEGACY_FIELD_NAMES else "store_false"
+    legacy_field_name_action = "store_true" if not DEFAULT_ALLOW_LEGACY_FIELD_NAMES else "store_false"
     parser.add_argument(
         '--allow-legacy-field-naming', required=False, action=legacy_field_name_action,
         help='Allow legacy ROS1 style field names that use PascalCase, camelCase, and Pascal_With_Underscores')

--- a/rosidl_adapter/rosidl_adapter/msg/__init__.py
+++ b/rosidl_adapter/rosidl_adapter/msg/__init__.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from rosidl_adapter.parser import parse_message_string
+from rosidl_adapter.parser import parse_message_string, DEFAULT_ALLOW_LEGACY_FIELD_NAMES
 from rosidl_adapter.resource import expand_template
 
 
-def convert_msg_to_idl(package_dir, package_name, input_file, output_dir):
+def convert_msg_to_idl(package_dir, package_name, input_file, output_dir, *, allow_legacy_field_naming=DEFAULT_ALLOW_LEGACY_FIELD_NAMES):
+
     assert package_dir.is_absolute()
     assert not input_file.is_absolute()
     assert input_file.suffix == '.msg'
@@ -25,7 +26,7 @@ def convert_msg_to_idl(package_dir, package_name, input_file, output_dir):
     print(f'Reading input file: {abs_input_file}')
     abs_input_file = package_dir / input_file
     content = abs_input_file.read_text(encoding='utf-8')
-    msg = parse_message_string(package_name, input_file.stem, content)
+    msg = parse_message_string(package_name, input_file.stem, content, allow_legacy_field_naming=allow_legacy_field_naming)
 
     output_file = output_dir / input_file.with_suffix('.idl').name
     abs_output_file = output_file.absolute()

--- a/rosidl_adapter/rosidl_adapter/parser.py
+++ b/rosidl_adapter/rosidl_adapter/parser.py
@@ -125,8 +125,8 @@ def is_valid_legacy_field_name(name):
         raise InvalidResourceName(name)
     return m is not None and m.group(0) == name
 
-def is_valid_field_name(name, allow_legacy_field_names=DEFAULT_ALLOW_LEGACY_FIELD_NAMES):
-    if allow_legacy_field_names:
+def is_valid_field_name(name, allow_legacy_field_naming=DEFAULT_ALLOW_LEGACY_FIELD_NAMES):
+    if allow_legacy_field_naming:
         return is_valid_legacy_field_name(name)
     try:
         m = VALID_FIELD_NAME_PATTERN.match(name)
@@ -361,11 +361,10 @@ class Field:
             raise TypeError(
                 "the field type '%s' must be a 'Type' instance" % type_)
         self.type = type_
-        if not allow_legacy_field_naming:
-            if not is_valid_field_name(name, allow_legacy_field_name=allow_legacy_field_naming):
-                raise NameError(
-                    "'{}' is an invalid field name. It should have the pattern '{}'".format(
-                        name, VALID_FIELD_NAME_PATTERN.pattern))
+        if not is_valid_field_name(name, allow_legacy_field_naming=allow_legacy_field_naming):
+            raise NameError(
+                "'{}' is an invalid field name. It should have the pattern '{}'".format(
+                    name, VALID_FIELD_NAME_PATTERN.pattern))
         self.name = name
         if default_value_string is None:
             self.default_value = None

--- a/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
@@ -52,7 +52,7 @@
 #
 macro(rosidl_generate_interfaces target)
   cmake_parse_arguments(_ARG
-    "ADD_LINTER_TESTS;SKIP_INSTALL;SKIP_GROUP_MEMBERSHIP_CHECK"
+    "ADD_LINTER_TESTS;SKIP_INSTALL;SKIP_GROUP_MEMBERSHIP_CHECK;ALLOW_LEGACY_FIELD_NAMES"
     "LIBRARY_NAME" "DEPENDENCIES"
     ${ARGN})
   if(NOT _ARG_UNPARSED_ARGUMENTS)
@@ -127,9 +127,21 @@ macro(rosidl_generate_interfaces target)
         PACKAGE_NAME "${PROJECT_NAME}"
         NON_IDL_TUPLES "${_non_idl_tuples}"
       )
+      set(_rosidl_apt_interfaces_opts)
+      if(_ARG_ALLOW_LEGACY_FIELD_NAMES)
+        set(_rosidl_apt_interfaces_opts ALLOW_LEGACY_FIELD_NAMES)
+        #list(APPEND _arg ALLOW_LEGACY_FIELD_NAMES)
+        message(WARNING "Allowing legacy field names")
+      else()
+        message(FATAL_ERROR NO Legacy field names)
+      endif()
+
+      #${_rosidl_apt_interfaces_opts}
+
       rosidl_adapt_interfaces(
         _idl_adapter_tuples
         "${_adapter_arguments_file}"
+        ${_rosidl_apt_interfaces_opts}
         TARGET ${target}
       )
     endif()


### PR DESCRIPTION
# Purpose

Propose an implementation of relaxing ROSIDL constraints on field names per this ROS Discourse proposal from a while back.

https://discourse.ros.org/t/relaxing-ros2-topic-service-field-name-restrictions/6371/8

# Use Case 

Happy Halloween! Do you deal with scary :ghost:  large ROS1 code bases that use cameCase for message field names? I do!

 I have a rather large codebase that I need to migrate from ROS 1 to ROS 2. It is very much "legacy" code, so it's largely untested and unmaintained. All of the message fields names use camelCase, and `sed` operations don't work because variables names are reused to non-ROS messages. I don't want to cause regressions porting to ROS 2, so minimizing the code change is crucial.  I am very risk averse and also in a resource bind because ROS 1 is EOL soon. Having to deal with variable naming changes is the last thing I want to bother with when porting to ROS 2. It's at least 2000 LOC of potential copy-paste typos, with many similarly named fields, such as `lat` and `alt` that are easily mixed up.
 
I am proposing this on `humble` because that's what I tested this on. If the maintainers like the implementation, I can forward port to `rolling` (clean up the code, finish the implementation, get CI happy, etc). 

I think yellow CMake warnings about legacy field names at compile time are a good thing - open to removing those.


 
 # Demo
 
 Follow this guide, with some changes: https://docs.ros.org/en/humble/Tutorials/Beginner-Client-Libraries/Single-Package-Define-And-Use-Interface.html#create-a-package
 
 # CMakeLists
 change to this, noticing the new `ALLOW_LEGACY_FIELD_NAMES` option.
 ```cmake
 rosidl_generate_interfaces(${PROJECT_NAME} ALLOW_LEGACY_FIELD_NAMES 
  ${msg_files}
)
```

Add these so we can test the new versions
**package.xml**
```xml

  <depend>rosidl_cmake</depend>
  <depend>rosidl_adapter</depend>

```

**AddressBook.msg**

Change `phone_type` to `phoneType`
```idl
uint8 phoneType
```

If needed, set up a rolling environment:
```bash
docker run --net host -v $(pwd):/ws -w /ws -it ros:rolling bash
apt-get update
rosdep install --from-paths . --ignore-src -ry
colcon build --packages-up-to more_interfaces --event-handlers=console_cohesion+
```

Finally, build and test:
```
# ROS 2 Rolling only
colcon build --packages-up-to more_interfaces --event-handlers=console_cohesion+

# ROS 2 humble ONLY
colcon build --packages-up-to more_interfaces --allow-overriding rosidl_adapter rosidl_cmake --event-handlers=console_cohesion+
```


