### PR TITLE
Allow legacy field names in rosidl_generate_interfaces [rolling]

### DIFF
--- a/rosidl_adapter/cmake/rosidl_adapt_interfaces.cmake
+++ b/rosidl_adapter/cmake/rosidl_adapt_interfaces.cmake
@@ -30,11 +30,13 @@
 # @public
 #
 function(rosidl_adapt_interfaces idl_var arguments_file)
-  cmake_parse_arguments(ARG "" "TARGET" ""
-    ${ARGN})
+  set(options ALLOW_LEGACY_FIELD_NAMES)
+  set(oneValueArgs TARGET)
+  set(multiValueArgs "")
+  cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
   if(ARG_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "rosidl_adapt_interfaces() called with unused "
-      "arguments: ${ARG_UNPARSED_ARGUMENTS}")
+      "arguments: ${ARG_UNPARSED_ARGUMENTS}. ALLOW_LEGACY? '${ARG_ALLOW_LEGACY_FIELD_NAMES}'")
   endif()
 
   find_package(Python3 REQUIRED COMPONENTS Interpreter)
@@ -46,6 +48,11 @@ function(rosidl_adapt_interfaces idl_var arguments_file)
     --arguments-file "${arguments_file}"
     --output-dir "${CMAKE_CURRENT_BINARY_DIR}/rosidl_adapter/${PROJECT_NAME}"
     --output-file "${idl_output}")
+  if(ARG_ALLOW_LEGACY_FIELD_NAMES)
+    list(APPEND cmd --allow-legacy-field-naming)
+    MESSAGE(WARNING Allowing legacy arguments.)
+  endif()
+
   execute_process(
     COMMAND ${cmd}
     OUTPUT_QUIET

--- a/rosidl_adapter/rosidl_adapter/__init__.py
+++ b/rosidl_adapter/rosidl_adapter/__init__.py
@@ -13,14 +13,15 @@
 # limitations under the License.
 
 from pathlib import Path
-
+from rosidl_adapter.parser import DEFAULT_ALLOW_LEGACY_FIELD_NAMES
 
 def convert_to_idl(package_dir: Path, package_name: str, interface_file: Path,
-                   output_dir: Path) -> Path:
+                   output_dir: Path, *, allow_legacy_field_naming: bool=DEFAULT_ALLOW_LEGACY_FIELD_NAMES) -> Path:
     if interface_file.suffix == '.msg':
         from rosidl_adapter.msg import convert_msg_to_idl
+
         return convert_msg_to_idl(
-            package_dir, package_name, interface_file, output_dir / 'msg')
+            package_dir, package_name, interface_file, output_dir / 'msg', allow_legacy_field_naming=allow_legacy_field_naming)
 
     if interface_file.suffix == '.srv':
         from rosidl_adapter.srv import convert_srv_to_idl

--- a/rosidl_adapter/rosidl_adapter/main.py
+++ b/rosidl_adapter/rosidl_adapter/main.py
@@ -21,6 +21,7 @@ from typing import List
 
 
 from rosidl_adapter import convert_to_idl
+from rosidl_adapter.parser import DEFAULT_ALLOW_LEGACY_FIELD_NAMES
 
 
 def main(argv: List[str] = sys.argv[1:]) -> None:
@@ -39,6 +40,10 @@ def main(argv: List[str] = sys.argv[1:]) -> None:
         '--output-file', required=True,
         help='The output file containing the tuples for the generated .idl '
              'files')
+    legacy_field_name_action = "store_true" if not DEFAULT_ALLOW_LEGACY_FIELD_NAMES else "store_false"
+    parser.add_argument(
+        '--allow-legacy-field-naming', required=False, action=legacy_field_name_action,
+        help='Allow legacy ROS1 style field names that use PascalCase, camelCase, and Pascal_With_Underscores')
     args = parser.parse_args(argv)
     output_dir = pathlib.Path(args.output_dir)
     output_file = pathlib.Path(args.output_file)
@@ -53,7 +58,8 @@ def main(argv: List[str] = sys.argv[1:]) -> None:
         basepath, relative_path = non_idl_tuple.rsplit(':', 1)
         abs_idl_file = convert_to_idl(
             pathlib.Path(basepath), args.package_name,
-            pathlib.Path(relative_path), output_dir)
+            pathlib.Path(relative_path), output_dir,
+            allow_legacy_field_naming=args.allow_legacy_field_naming)
         idl_tuples.append((output_dir, abs_idl_file.relative_to(output_dir)))
 
     output_file.parent.mkdir(exist_ok=True)

--- a/rosidl_adapter/rosidl_adapter/msg/__init__.py
+++ b/rosidl_adapter/rosidl_adapter/msg/__init__.py
@@ -15,12 +15,12 @@
 from pathlib import Path
 from typing import Final, Optional, Union
 
-from rosidl_adapter.parser import BaseType, parse_message_string, Type
+from rosidl_adapter.parser import BaseType, parse_message_string, Type, DEFAULT_ALLOW_LEGACY_FIELD_NAMES
 from rosidl_adapter.resource import expand_template, MsgData
 
 
 def convert_msg_to_idl(package_dir: Path, package_name: str, input_file: Path,
-                       output_dir: Path) -> Path:
+                       output_dir: Path, *, allow_legacy_field_naming: bool=DEFAULT_ALLOW_LEGACY_FIELD_NAMES) -> Path:
     assert package_dir.is_absolute()
     assert not input_file.is_absolute()
     assert input_file.suffix == '.msg'
@@ -29,7 +29,7 @@ def convert_msg_to_idl(package_dir: Path, package_name: str, input_file: Path,
     print(f'Reading input file: {abs_input_file}')
     abs_input_file = package_dir / input_file
     content = abs_input_file.read_text(encoding='utf-8')
-    msg = parse_message_string(package_name, input_file.stem, content)
+    msg = parse_message_string(package_name, input_file.stem, content, allow_legacy_field_naming=allow_legacy_field_naming)
 
     output_file = output_dir / input_file.with_suffix('.idl').name
     abs_output_file = output_file.absolute()

--- a/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
@@ -52,7 +52,7 @@
 #
 macro(rosidl_generate_interfaces target)
   cmake_parse_arguments(_ARG
-    "ADD_LINTER_TESTS;SKIP_INSTALL;SKIP_GROUP_MEMBERSHIP_CHECK"
+    "ADD_LINTER_TESTS;SKIP_INSTALL;SKIP_GROUP_MEMBERSHIP_CHECK;ALLOW_LEGACY_FIELD_NAMES"
     "LIBRARY_NAME" "DEPENDENCIES"
     ${ARGN})
   if(NOT _ARG_UNPARSED_ARGUMENTS)
@@ -129,9 +129,18 @@ macro(rosidl_generate_interfaces target)
         PACKAGE_NAME "${PROJECT_NAME}"
         NON_IDL_TUPLES "${_non_idl_tuples}"
       )
+      set(_rosidl_apt_interfaces_opts)
+      if(_ARG_ALLOW_LEGACY_FIELD_NAMES)
+        set(_rosidl_apt_interfaces_opts ALLOW_LEGACY_FIELD_NAMES)
+        message(WARNING "Allowing legacy field names")
+      endif()
+
+      #${_rosidl_apt_interfaces_opts}
+
       rosidl_adapt_interfaces(
         _idl_adapter_tuples
         "${_adapter_arguments_file}"
+        ${_rosidl_apt_interfaces_opts}
         TARGET ${target}
       )
     endif()


### PR DESCRIPTION
# Purpose

Allow camelCase in message fields.

Continuing discussion from https://github.com/ros2/rosidl/pull/834, with the PR now targetting rolling.
As I have time, I'll satisfy the remaining actions.

# Actions Remaining

* [ ] Add more descriptive author warnings
* [ ] Handle services and actions
* [ ] Test the effect of camelCase on tool X and Y 
* [ ] Satisfy linters
* [ ] Add tests