### PR TITLE
Add name and data_type traits for actions

### DIFF
--- a/rosidl_generator_cpp/resource/action__traits.hpp.em
+++ b/rosidl_generator_cpp/resource/action__traits.hpp.em
@@ -52,10 +52,23 @@ TEMPLATE(
 
 @{
 action_typename = '::'.join(action.namespaced_type.namespaced_name())
+action_fully_qualified_name = '/'.join(action.namespaced_type.namespaced_name())
 }@
 @
 namespace rosidl_generator_traits
 {
+
+template<>
+inline const char * data_type<@(action_typename)>()
+{
+  return "@(action_typename)";
+}
+
+template<>
+inline const char * name<@(action_typename)>()
+{
+  return "@(action_fully_qualified_name)";
+}
 
 template<>
 struct is_action<@(action_typename)>

--- a/rosidl_generator_tests/test/rosidl_generator_cpp/test_name.cpp
+++ b/rosidl_generator_tests/test/rosidl_generator_cpp/test_name.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
+#include "rosidl_generator_tests/action/fibonacci.hpp"
 #include "rosidl_generator_tests/msg/empty.hpp"
 #include "rosidl_generator_tests/msg/strings.hpp"
 #include "rosidl_generator_tests/srv/basic_types.hpp"
@@ -27,6 +28,15 @@ TEST(Test_rosidl_generator_traits, check_msg_name) {
     rosidl_generator_traits::name<rosidl_generator_tests::msg::Empty>());
 }
 
+TEST(Test_rosidl_generator_traits, check_msg_data_type) {
+  ASSERT_STREQ(
+    "rosidl_generator_tests::msg::Strings",
+    rosidl_generator_traits::data_type<rosidl_generator_tests::msg::Strings>());
+  ASSERT_STREQ(
+    "rosidl_generator_tests::msg::Empty",
+    rosidl_generator_traits::data_type<rosidl_generator_tests::msg::Empty>());
+}
+
 TEST(Test_rosidl_generator_traits, check_srv_name) {
   ASSERT_STREQ(
     "rosidl_generator_tests/srv/BasicTypes",
@@ -34,4 +44,25 @@ TEST(Test_rosidl_generator_traits, check_srv_name) {
   ASSERT_STREQ(
     "rosidl_generator_tests/srv/Empty",
     rosidl_generator_traits::name<rosidl_generator_tests::srv::Empty>());
+}
+
+TEST(Test_rosidl_generator_traits, check_srv_data_type) {
+  ASSERT_STREQ(
+    "rosidl_generator_tests::srv::BasicTypes",
+    rosidl_generator_traits::data_type<rosidl_generator_tests::srv::BasicTypes>());
+  ASSERT_STREQ(
+    "rosidl_generator_tests::srv::Empty",
+    rosidl_generator_traits::data_type<rosidl_generator_tests::srv::Empty>());
+}
+
+TEST(Test_rosidl_generator_traits, check_action_name) {
+  ASSERT_STREQ(
+    "rosidl_generator_tests/action/Fibonacci",
+    rosidl_generator_traits::name<rosidl_generator_tests::action::Fibonacci>());
+}
+
+TEST(Test_rosidl_generator_traits, check_action_data_type) {
+  ASSERT_STREQ(
+    "rosidl_generator_tests::action::Fibonacci",
+    rosidl_generator_traits::data_type<rosidl_generator_tests::action::Fibonacci>());
 }


### PR DESCRIPTION
This implements the `rosidl_generator_traits::name<>()` and `rosidl_generator_traits::data_type<>()` trait functions for generated actions, similarly to how it's done for messages and services.

Unit tests are added to verify this behaviour, and the prior tests are extended to cover the `data_type` trait for all interface types.