### PR TITLE
Fix default wstring length

### DIFF
--- a/rosidl_generator_c/resource/full__description.c.em
+++ b/rosidl_generator_c/resource/full__description.c.em
@@ -2,6 +2,7 @@
 @{
 from collections import OrderedDict
 from rosidl_generator_c import escape_string
+from rosidl_generator_c import escape_utf8
 from rosidl_generator_c import idl_structure_type_to_c_include_prefix
 from rosidl_generator_c import type_hash_to_c_definition
 from rosidl_parser.definition import NamespacedType
@@ -23,13 +24,12 @@ def static_seq_n(varname, n):
 def static_seq(varname, values):
   """Statically define a runtime Sequence or String type."""
   if values:
-    return f'{{{varname}, {len(values)}, {len(values)}}}'
+    if isinstance(values, str):
+      utf8_values = values.encode('utf-8')
+      return f'{{{varname}, {len(utf8_values)}, {len(utf8_values)}}}'
+    else:
+      return f'{{{varname}, {len(values)}, {len(values)}}}'
   return '{NULL, 0, 0}'
-
-def utf8_encode(value_string):
-  from rosidl_generator_c import escape_string
-  # Slice removes the b'' from the representation.
-  return escape_string(repr(value_string.encode('utf-8'))[2:-1])
 
 implicit_type_names = set(td['type_description']['type_name'] for td, _ in implicit_type_descriptions)
 includes = OrderedDict()
@@ -98,7 +98,7 @@ ref_tds = msg['referenced_type_descriptions']
 @[  for field in itype_description['fields']]@
 static char @(td_c_typename)__FIELD_NAME__@(field['name'])[] = "@(field['name'])";
 @[    if field['default_value']]@
-static char @(td_c_typename)__DEFAULT_VALUE__@(field['name'])[] = "@(utf8_encode(field['default_value']))";
+static char @(td_c_typename)__DEFAULT_VALUE__@(field['name'])[] = "@(escape_utf8(escape_string(field['default_value'])))";
 @[    end if]@
 @[  end for]@
 
@@ -167,9 +167,9 @@ c_typename = typename_to_c(ref_td['type_name'])
 @[if raw_source_content]@
 static char toplevel_type_raw_source[] =@
 @[  for line in raw_source_content.splitlines()[:-1]]
-  "@(utf8_encode(line))\n"@
+  "@(escape_utf8(escape_string(line)))\n"@
 @[  end for]
-  "@(utf8_encode(raw_source_content.splitlines()[-1]))";
+  "@(escape_utf8(escape_string(raw_source_content.splitlines()[-1])))";
 @[end if]@
 
 static char @(toplevel_encoding)_encoding[] = "@(toplevel_encoding)";

--- a/rosidl_generator_c/rosidl_generator_c/__init__.py
+++ b/rosidl_generator_c/rosidl_generator_c/__init__.py
@@ -229,6 +229,18 @@ def escape_wstring(s):
     return escape_string(s)
 
 
+def escape_utf8(s):
+    result = ''
+    for c in s.encode('utf-8'):
+        if c < 0x80:
+            # ASCII characters are encoded as-is
+            result += chr(c)
+        else:
+            # Non-ASCII characters are encoded as UTF-8
+            result += '\\x%02x' % c
+    return result
+
+
 def type_hash_to_c_definition(hash_string, *, indent=2):
     """Generate empy for rosidl_type_hash_t instance with 8 bytes per line for readability."""
     bytes_per_row = 8


### PR DESCRIPTION
This PR fixes strings containing unicode characters not being escaped properly and their size being inaccurate. For instance on [WString](https://github.com/ros2/test_interface_files/blob/rolling/msg/WStrings.msg) it results in the following change

```diff
38c38
< static char test_msgs__msg__WStrings__DEFAULT_VALUE__wstring_value_default2[] = "Hell\\xc3\\xb6 w\\xc3\\xb6rld!";
---
> static char test_msgs__msg__WStrings__DEFAULT_VALUE__wstring_value_default2[] = "Hell\xc3\xb6 w\xc3\xb6rld!";
40c40
< static char test_msgs__msg__WStrings__DEFAULT_VALUE__wstring_value_default3[] = "\\xe3\\x83\\x8f\\xe3\\x83\\xad\\xe3\\x83\\xbc\\xe3\\x83\\xaf\\xe3\\x83\\xbc\\xe3\\x83\\xab\\xe3\\x83\\x89";
---
> static char test_msgs__msg__WStrings__DEFAULT_VALUE__wstring_value_default3[] = "\xe3\x83\x8f\xe3\x83\xad\xe3\x83\xbc\xe3\x83\xaf\xe3\x83\xbc\xe3\x83\xab\xe3\x83\x89";
74c74
<     {test_msgs__msg__WStrings__DEFAULT_VALUE__wstring_value_default2, 12, 12},
---
>     {test_msgs__msg__WStrings__DEFAULT_VALUE__wstring_value_default2, 14, 14},
84c84
<     {test_msgs__msg__WStrings__DEFAULT_VALUE__wstring_value_default3, 7, 7},
---
>     {test_msgs__msg__WStrings__DEFAULT_VALUE__wstring_value_default3, 21, 21},
140,141c140,141
<   "wstring wstring_value_default2 \"Hell\\xc3\\xb6 w\\xc3\\xb6rld!\"\n"
<   "wstring wstring_value_default3 \"\\xe3\\x83\\x8f\\xe3\\x83\\xad\\xe3\\x83\\xbc\\xe3\\x83\\xaf\\xe3\\x83\\xbc\\xe3\\x83\\xab\\xe3\\x83\\x89\"\n"
---
>   "wstring wstring_value_default2 \"Hell\xc3\xb6 w\xc3\xb6rld!\"\n"
>   "wstring wstring_value_default3 \"\xe3\x83\x8f\xe3\x83\xad\xe3\x83\xbc\xe3\x83\xaf\xe3\x83\xbc\xe3\x83\xab\xe3\x83\x89\"\n"
161c161
<     {toplevel_type_raw_source, 399, 399},
---
>     {toplevel_type_raw_source, 415, 415},
```

It also fixes `"` and `'` being over escaped (and some other escaped characters). For instance on https://github.com/Tonywelte/test_interface_files/blob/rolling/msg/Strings.msg (see https://github.com/ros2/test_interface_files/pull/25)

```diff
46c46
< static char test_msgs__msg__Strings__DEFAULT_VALUE__string_value_default6[] = "Hello\\\\world!";
---
> static char test_msgs__msg__Strings__DEFAULT_VALUE__string_value_default6[] = "Hello\\world!";
48c48
< static char test_msgs__msg__Strings__DEFAULT_VALUE__string_value_default7[] = "Hello\\tworld!";
---
> static char test_msgs__msg__Strings__DEFAULT_VALUE__string_value_default7[] = "Hello  world!";
61c61
< static char test_msgs__msg__Strings__DEFAULT_VALUE__bounded_string_value_default6[] = "Hello\\\\world!";
---
> static char test_msgs__msg__Strings__DEFAULT_VALUE__bounded_string_value_default6[] = "Hello\\world!";
63c63
< static char test_msgs__msg__Strings__DEFAULT_VALUE__bounded_string_value_default7[] = "Hello\\tworld!";
---
> static char test_msgs__msg__Strings__DEFAULT_VALUE__bounded_string_value_default7[] = "Hello  world!";
250,255c250,255
<   "string string_value_default2 \"Hello\\'world!\"\n"
<   "string string_value_default3 \\'Hello\"world!\\'\n"
<   "string string_value_default4 'Hello\\\\'world!'\n"
<   "string string_value_default5 \"Hello\\\\\"world!\"\n"
<   "string string_value_default6 \"Hello\\\\\\\\world!\"\n"
<   "string string_value_default7 \"Hello\\\\tworld!\"\n"
---
>   "string string_value_default2 \"Hello'world!\"\n"
>   "string string_value_default3 'Hello\"world!'\n"
>   "string string_value_default4 'Hello\\'world!'\n"
>   "string string_value_default5 \"Hello\\\"world!\"\n"
>   "string string_value_default6 \"Hello\\\\world!\"\n"
>   "string string_value_default7 \"Hello\\tworld!\"\n"
260,265c260,265
<   "string<=22 bounded_string_value_default2 \"Hello\\'world!\"\n"
<   "string<=22 bounded_string_value_default3 \\'Hello\"world!\\'\n"
<   "string<=22 bounded_string_value_default4 'Hello\\\\'world!'\n"
<   "string<=22 bounded_string_value_default5 \"Hello\\\\\"world!\"\n"
<   "string<=22 bounded_string_value_default6 \"Hello\\\\\\\\world!\"\n"
<   "string<=22 bounded_string_value_default7 \"Hello\\\\tworld!\"\n"
---
>   "string<=22 bounded_string_value_default2 \"Hello'world!\"\n"
>   "string<=22 bounded_string_value_default3 'Hello\"world!'\n"
>   "string<=22 bounded_string_value_default4 'Hello\\'world!'\n"
>   "string<=22 bounded_string_value_default5 \"Hello\\\"world!\"\n"
>   "string<=22 bounded_string_value_default6 \"Hello\\\\world!\"\n"
>   "string<=22 bounded_string_value_default7 \"Hello\\tworld!\"\n"
```

## Additional notes

- While working on this fix I noticed that [rosidl_runtime_c__String](https://github.com/ros2/rosidl/blob/rolling/rosidl_runtime_c/include/rosidl_runtime_c/string.h) states that the capacity should include the null byte but the size shouldn't. None of the string defined by rosidl generator do this. I haven't fixed it in this PR since I'm not sure what needs to be changed. It should be as simple as adding  `+1` in `static_seq` but for `toplevel_type_raw_source` it should be `-1`. I'm not sure what's the difference.
- A think it should be clarified what escaped characters are supported in default strings. `\'` and `\"` are mentioned in https://design.ros2.org/articles/legacy_interface_definition.html but other (`\\` and `\t`) worked in rosidl_generator_cpp but rosidl_generator_c didn't escape them properly. `\n` doesn't work at all.

Fixes #855 