### PR TITLE
Add missing cstdint include

### DIFF
--- a/rosidl_generator_cpp/resource/idl__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/idl__struct.hpp.em
@@ -28,6 +28,7 @@ include_directives = set()
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/traits.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/traits.hpp
@@ -16,6 +16,7 @@
 #define ROSIDL_RUNTIME_CPP__TRAITS_HPP_
 
 #include <codecvt>
+#include <cstdint>
 #include <iomanip>
 #include <iosfwd>
 #include <string>


### PR DESCRIPTION
Add missing cstdint includes which cause build failures with GCC 15.1.1.