### PR TITLE
Add an ament_cmake_gtest dependency to rosidl_runtime_c.

### DIFF
--- a/rosidl_runtime_c/package.xml
+++ b/rosidl_runtime_c/package.xml
@@ -28,6 +28,7 @@
 
   <depend>rcutils</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>performance_test_fixture</test_depend>


### PR DESCRIPTION
This was found while testing out a fix to colcon-core which will reduce the scope of test_depend.  Regardless, this package actually does depend on ament_cmake_gtest so the dependency should be there.

This is related to https://github.com/colcon/colcon-core/pull/693 .  Once approved, this should likely be backported to at least Kilted, and probably also Jazzy and Humble.  @cottsay FYI