### PR TITLE
fix setuptools deprecations

### DIFF
--- a/rosidl_cli/setup.py
+++ b/rosidl_cli/setup.py
@@ -7,6 +7,9 @@ setup(
     packages=find_packages(exclude=['test']),
     extras_require={
         'completion': ['argcomplete'],
+        'test': [
+            'pytest',
+        ],
     },
     data_files=[
         ('share/ament_index/resource_index/packages', [
@@ -32,14 +35,12 @@ setup(
     classifiers=[
         'Environment :: Console',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
     ],
     description='Command line tools for ROS interface generation.',
     long_description="""\
 The tooling provides a single command line script for ROS interface source code generation.""",
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
     entry_points={
         'console_scripts': [
             'rosidl = rosidl_cli.cli:main',


### PR DESCRIPTION

## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

FIX:

#UserWarning: Unknown distribution option: 'tests_require'

and

#SetuptoolsDeprecationWarning: License classifiers are deprecated. !!


### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
