### PR TITLE
Add Optional Parsing

### DIFF
--- a/rosidl_adapter/rosidl_adapter/parser.py
+++ b/rosidl_adapter/rosidl_adapter/parser.py
@@ -534,8 +534,8 @@ def parse_message_string(pkg_name: str, msg_name: str,
         annotation_index = line.rfind(OPTIONAL_ANNOTATION)
         if annotation_index >= 0:
             if is_optional:
-                raise MultipleOptionalAnnotations('Already declared @optional.'
-                                                  f' Error detected with {line}.')
+                raise MultipleOptionalAnnotations(
+                    f'Already declared @optional. Error detected with {line}.')
 
             line = line[len(OPTIONAL_ANNOTATION):].lstrip()
             is_optional = True

--- a/rosidl_adapter/rosidl_adapter/parser.py
+++ b/rosidl_adapter/rosidl_adapter/parser.py
@@ -530,7 +530,6 @@ def parse_message_string(pkg_name: str, msg_name: str,
             if not line:
                 continue
 
-        # TODO multiline optionals
         annotation_index = line.rfind(OPTIONAL_ANNOTATION)
         if annotation_index >= 0:
             if is_optional:

--- a/rosidl_adapter/rosidl_adapter/parser.py
+++ b/rosidl_adapter/rosidl_adapter/parser.py
@@ -19,6 +19,8 @@ import textwrap
 from typing import Final, Iterable, List, Optional, Tuple, TYPE_CHECKING, TypedDict, Union
 
 PACKAGE_NAME_MESSAGE_TYPE_SEPARATOR: Final = '/'
+ANNOTATION_DELIMITER: Final = '@'
+OPTIONAL_ANNOTATION: Final = ANNOTATION_DELIMITER + 'optional'
 COMMENT_DELIMITER: Final = '#'
 CONSTANT_SEPARATOR: Final = '='
 ARRAY_UPPER_BOUND_TOKEN: Final = '<='
@@ -83,6 +85,7 @@ if TYPE_CHECKING:
     class Annotations(TypedDict, total=False):
         comment: List[str]
         unit: str
+        optional: bool
 
 
 class InvalidSpecification(Exception):
@@ -106,6 +109,10 @@ class InvalidFieldDefinition(InvalidSpecification):
 
 
 class UnknownMessageType(InvalidSpecification):
+    pass
+
+
+class MultipleOptionalAnnotations(InvalidSpecification):
     pass
 
 
@@ -408,7 +415,7 @@ class MessageSpecification:
         self.msg_name = msg_name
         self.annotations: 'Annotations' = {}
 
-        self.fields = []
+        self.fields: list[Field] = []
         for index, field in enumerate(fields):
             if not isinstance(field, Field):
                 raise TypeError("field %u must be a 'Field' instance" % index)
@@ -422,7 +429,7 @@ class MessageSpecification:
                 'the fields iterable contains duplicate names: %s' %
                 ', '.join(sorted(duplicate_field_names)))
 
-        self.constants = []
+        self.constants: list[Constant] = []
         for index, constant in enumerate(constants):
             if not isinstance(constant, Constant):
                 raise TypeError("constant %u must be a 'Constant' instance" %
@@ -485,10 +492,11 @@ def parse_message_string(pkg_name: str, msg_name: str,
     fields: List[Field] = []
     constants: List[Constant] = []
     last_element: Union[Field, Constant, None] = None  # either a field or a constant
+    is_optional = False
     # replace tabs with spaces
     message_string = message_string.replace('\t', ' ')
 
-    current_comments = []
+    current_comments: list[str] = []
     message_comments, lines = extract_file_level_comments(message_string)
     for line in lines:
         line = line.rstrip()
@@ -519,6 +527,19 @@ def parse_message_string(pkg_name: str, msg_name: str,
             current_comments.append(comment)
 
             line = line.rstrip()
+            if not line:
+                continue
+
+        # TODO multiline optionals
+        annotation_index = line.rfind(OPTIONAL_ANNOTATION)
+        if annotation_index >= 0:
+            if is_optional:
+                raise MultipleOptionalAnnotations('Already declared @optional.'
+                                                  f' Error detected with {line}.')
+
+            line = line[len(OPTIONAL_ANNOTATION):].lstrip()
+            is_optional = True
+
             if not line:
                 continue
 
@@ -555,6 +576,9 @@ def parse_message_string(pkg_name: str, msg_name: str,
             last_element = constants[-1]
 
         # add "unused" comments to the field / constant
+        if is_optional:
+            last_element.annotations['optional'] = is_optional
+        is_optional = False
         comment_lines = last_element.annotations.setdefault(
             'comment', [])
         comment_lines += current_comments

--- a/rosidl_adapter/rosidl_adapter/resource/struct.idl.em
+++ b/rosidl_adapter/rosidl_adapter/resource/struct.idl.em
@@ -50,6 +50,9 @@ else:
 @[      end for]@
 )
 @[    end if]@
+@[    if 'optional' in constant.annotations]@
+      @@optional
+@[    end if]@
       const @(get_idl_type(constant.type)) @(constant.name) = @(to_idl_literal(get_idl_type(constant.type), constant.value));
 @[  end for]@
     };
@@ -80,6 +83,9 @@ else:
 @[        end if]@
 @[      end for]@
 )
+@[    end if]@
+@[    if 'optional' in field.annotations]@
+      @@optional
 @[    end if]@
 @[    if field.default_value is not None]@
       @@default (value=@(to_idl_literal(get_idl_type(field.type), field.default_value)))

--- a/rosidl_adapter/test/data/action/Test.action
+++ b/rosidl_adapter/test/data/action/Test.action
@@ -23,6 +23,9 @@ string string_value
 
 # ok docs
 bool ok
+
+@optional
+bool optional_bool
 ---
 # feedback definition
 # more

--- a/rosidl_adapter/test/data/action/Test.expected.idl
+++ b/rosidl_adapter/test/data/action/Test.expected.idl
@@ -50,6 +50,9 @@ module test_msgs {
       @verbatim (language="comment", text=
         "ok docs")
       boolean ok;
+
+      @optional
+      boolean optional_bool;
     };
     @verbatim (language="comment", text=
       "feedback definition" "\n"

--- a/rosidl_adapter/test/data/msg/Test.expected.idl
+++ b/rosidl_adapter/test/data/msg/Test.expected.idl
@@ -5,6 +5,10 @@
 
 module test_msgs {
   module msg {
+    module Test_Constants {
+      @optional
+      const float INLINE_CONSTANT = 32.0;
+    };
     @verbatim (language="comment", text=
       "msg level doc")
     struct Test {
@@ -40,6 +44,16 @@ module test_msgs {
       int64 int64_value;
 
       uint64 uint64_value;
+
+      @optional
+      float multiline_optional;
+
+      @optional
+      float inline_optional;
+
+      @optional
+      @default (value=32.0)
+      float inline_default_optional;
     };
   };
 };

--- a/rosidl_adapter/test/data/msg/Test.msg
+++ b/rosidl_adapter/test/data/msg/Test.msg
@@ -15,3 +15,10 @@ int32 int32_value
 uint32 uint32_value
 int64 int64_value
 uint64 uint64_value
+
+@optional
+float32 multiline_optional
+
+@optional float32 inline_optional
+@optional float32 inline_default_optional 32.0
+@optional float32 INLINE_CONSTANT=32.0

--- a/rosidl_adapter/test/data/srv/Test.expected.idl
+++ b/rosidl_adapter/test/data/srv/Test.expected.idl
@@ -50,6 +50,9 @@ module test_msgs {
       @verbatim (language="comment", text=
         "8")
       boolean ok;
+
+      @optional
+      boolean optional_bool;
     };
   };
 };

--- a/rosidl_adapter/test/data/srv/Test.srv
+++ b/rosidl_adapter/test/data/srv/Test.srv
@@ -23,3 +23,4 @@ string string_value
 # 8
 
 bool ok
+@optional bool optional_bool

--- a/rosidl_parser/test/msg/MyMessage.idl
+++ b/rosidl_parser/test/msg/MyMessage.idl
@@ -81,6 +81,10 @@ module rosidl_parser {
       float fixed_frac_only;
       @default ( value=7d )
       float fixed_int_only;
+
+      // Optional test
+      @optional
+      int32 optional_int;
     };
   };
 };

--- a/rosidl_parser/test/test_parser.py
+++ b/rosidl_parser/test/test_parser.py
@@ -134,7 +134,7 @@ def test_message_parser_structure(message_idl_file: IdlFile) -> None:
     structure = messages[0].structure
     assert structure.namespaced_type.namespaces == ['rosidl_parser', 'msg']
     assert structure.namespaced_type.name == 'MyMessage'
-    assert len(structure.members) == 45
+    assert len(structure.members) == 46
 
     assert isinstance(structure.members[0].type, BasicType)
     assert structure.members[0].type.typename == 'int16'
@@ -303,6 +303,12 @@ def test_message_parser_annotations(message_idl_file: IdlFile) -> None:
     assert structure.members[44].name == 'fixed_int_only'
     assert len(structure.members[44].annotations) == 1
     assert structure.members[44].annotations[0].name == 'default'
+
+    assert isinstance(structure.members[45].type, BasicType)
+    assert structure.members[45].type.typename == 'int32'
+    assert structure.members[45].name == 'optional_int'
+    assert len(structure.members[45].annotations) == 1
+    assert structure.members[45].annotations[0].name == 'optional'
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
## Description

As a first part of fixing #850 adds support for parsing `@optional` annotations to ros files.

### Is this user-facing behavior change?

Will allow downstream users to start including these annotations even if they do not affect message generation yet.

### Did you use Generative AI?

no
### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
