### PR TITLE
Use IWYU pragma export to avoid clangd warnings for generated headers

### DIFF
--- a/rosidl_generator_cpp/resource/idl.hpp.em
+++ b/rosidl_generator_cpp/resource/idl.hpp.em
@@ -22,9 +22,9 @@ include_base = '/'.join(include_parts_detail)
 #ifndef @(header_guard_variable)
 #define @(header_guard_variable)
 
-#include "@(include_base)__struct.hpp"
-#include "@(include_base)__builder.hpp"
-#include "@(include_base)__traits.hpp"
-#include "@(include_base)__type_support.hpp"
+#include "@(include_base)__struct.hpp"  // IWYU pragma: export
+#include "@(include_base)__builder.hpp"    // IWYU pragma: export
+#include "@(include_base)__traits.hpp"    // IWYU pragma: export
+#include "@(include_base)__type_support.hpp"    // IWYU pragma: export
 
 #endif  // @(header_guard_variable)


### PR DESCRIPTION
## Description

Please tell me if the base branch is wrong.

This adds `// IWYU pragma: export ` to the lines in `idl.hpp.em` that include the generated implementation files.
 
### Is this user-facing behavior change?

It does not affect user-facing behavior for code compilation or runtime.

It improves user-facing behavior for tools like clangd and [IWYU](https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/IWYUPragmas.md#iwyu-pragma-export):
 * Without these lines, clangd in editors like VSCode/Cursor will complain (see image) that any generated headers you include are not used directly, and tools like IWYU try to remove the main include and instead directly include one of the implementation headers.

<img width="1334" height="398" alt="image" src="https://github.com/user-attachments/assets/f5fac34f-7c38-4d8a-b973-c5fb0c7ad0a8" />


### Did you use Generative AI?

No.