### PR TITLE
Fix `@optional` for string literals

### DIFF
--- a/rosidl_adapter/rosidl_adapter/parser.py
+++ b/rosidl_adapter/rosidl_adapter/parser.py
@@ -530,8 +530,7 @@ def parse_message_string(pkg_name: str, msg_name: str,
             if not line:
                 continue
 
-        annotation_index = line.rfind(OPTIONAL_ANNOTATION)
-        if annotation_index >= 0:
+        if line.startswith(OPTIONAL_ANNOTATION):
             if is_optional:
                 raise MultipleOptionalAnnotations(
                     f'Already declared @optional. Error detected with {line}.')

--- a/rosidl_adapter/test/data/msg/Test.expected.idl
+++ b/rosidl_adapter/test/data/msg/Test.expected.idl
@@ -8,6 +8,8 @@ module test_msgs {
     module Test_Constants {
       @optional
       const float INLINE_CONSTANT = 32.0;
+      @optional
+      const string OPTIONAL_STRING_CONST = "@optional";
     };
     @verbatim (language="comment", text=
       "msg level doc")
@@ -54,6 +56,10 @@ module test_msgs {
       @optional
       @default (value=32.0)
       float inline_default_optional;
+
+      @optional
+      @default (value="@optional")
+      string optional_default_string;
     };
   };
 };

--- a/rosidl_adapter/test/data/msg/Test.msg
+++ b/rosidl_adapter/test/data/msg/Test.msg
@@ -22,3 +22,6 @@ float32 multiline_optional
 @optional float32 inline_optional
 @optional float32 inline_default_optional 32.0
 @optional float32 INLINE_CONSTANT=32.0
+
+@optional string optional_default_string @optional
+@optional string OPTIONAL_STRING_CONST=@optional


### PR DESCRIPTION
## Description

Changes a flaw implementation to allow `@optional` in defaults and constants.

Fixes #904

### Is this user-facing behavior change?

Should unbreak backwards compatibility.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
