### PR TITLE
Fix copy/paste errors in type support docs

### DIFF
--- a/rosidl_runtime_c/include/rosidl_runtime_c/message_type_support_struct.h
+++ b/rosidl_runtime_c/include/rosidl_runtime_c/message_type_support_struct.h
@@ -88,7 +88,7 @@ ROSIDL_GENERATOR_C_PUBLIC
 const rosidl_message_type_support_t * get_message_typesupport_handle_function(
   const rosidl_message_type_support_t * handle, const char * identifier);
 
-/// Get the message type support given a provided action and package.
+/// Get the message type support given a provided message and package.
 /**
  * \param PkgName Name of the package that contains the message
  * \param MsgSubfolder name of the subfolder (for example: msg)

--- a/rosidl_runtime_c/include/rosidl_runtime_c/sequence_bound.h
+++ b/rosidl_runtime_c/include/rosidl_runtime_c/sequence_bound.h
@@ -64,7 +64,7 @@ ROSIDL_GENERATOR_C_PUBLIC
 const rosidl_runtime_c__Sequence__bound * get_sequence_bound_handle_function(
   const rosidl_runtime_c__Sequence__bound * handle, const char * identifier);
 
-/// Get the sequence bounds given a provided action and package.
+/// Get the sequence bounds given a provided message and package.
 /**
  * \param PkgName Name of the package that contains the message
  * \param MsgSubfolder name of the subfolder (foe example: msg)

--- a/rosidl_runtime_c/include/rosidl_runtime_c/service_type_support_struct.h
+++ b/rosidl_runtime_c/include/rosidl_runtime_c/service_type_support_struct.h
@@ -136,7 +136,7 @@ ROSIDL_GENERATOR_C_PUBLIC
 const rosidl_service_type_support_t * get_service_typesupport_handle_function(
   const rosidl_service_type_support_t * handle, const char * identifier);
 
-/// Get the service type support given a provided action and package.
+/// Get the service type support given a provided service and package.
 /**
  * \param PkgName Name of the package that contains the service
  * \param SrvSubfolder name of the subfolder (for example: srv)


### PR DESCRIPTION
## Description

I believe this is a copy/paste mistake with this line: https://github.com/ros2/rosidl/blob/0a87c555518a67928890887a90fe3805c66f93a1/rosidl_runtime_c/include/rosidl_runtime_c/action_type_support_struct.h#L59

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
