### PR TITLE
Add missing dependency on ament_cmake_pytest

### DIFF
--- a/rosidl_generator_type_description/package.xml
+++ b/rosidl_generator_type_description/package.xml
@@ -21,6 +21,7 @@
   <exec_depend>rosidl_cli</exec_depend>
   <exec_depend>rosidl_parser</exec_depend>
 
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 


### PR DESCRIPTION
## Description

This package is needed for testing here: https://github.com/ros2/rosidl/blob/106220c8d6257ccdd33a62a8ebed31d0c9411aac/rosidl_generator_type_description/CMakeLists.txt#L13

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information

This missing dependency is surfaced when building with `COLCON_FEATURE_FLAGS="restore_build_isolation"`.