### PR TITLE
Add `rosidl_auto_generate_inetrfaces` function

### DIFF
--- a/rosidl_cmake/cmake/rosidl_auto_generate_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_auto_generate_interfaces.cmake
@@ -84,8 +84,8 @@ macro(rosidl_auto_generate_interfaces)
     ${PROJECT_NAME}
     ${${PROJECT_NAME}_interface_files}
   )
-  if(${PROJECT_NAME}_FOUND_BUILD_DEPENDS)
-    list(APPEND _rosidl_args DEPENDENCIES ${${PROJECT_NAME}_FOUND_BUILD_DEPENDS})
+  if(${PROJECT_NAME}_BUILD_DEPENDS)
+    list(APPEND _rosidl_args DEPENDENCIES ${${PROJECT_NAME}_BUILD_DEPENDS})
   endif()
   rosidl_generate_interfaces(${_rosidl_args})
   ament_export_dependencies(rosidl_default_runtime)

--- a/rosidl_cmake/cmake/rosidl_auto_generate_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_auto_generate_interfaces.cmake
@@ -29,6 +29,9 @@
 # :param TARGETS: list of targets in same package that should be linked against
 #   same package's interface typesupport library so they can use the generated code of interfaces.
 # :type TARGETS: list of strings
+# :param TYPESUPPORT: the typesupport package to use for linking TARGETS.
+#   Defaults to "rosidl_typesupport_cpp". Use "rosidl_typesupport_c" for C projects.
+# :type TYPESUPPORT: string
 # :param LIBRARY_NAME: the base name of the library, specific generators might
 #   append their own suffix (passed to rosidl_generate_interfaces)
 # :type LIBRARY_NAME: string
@@ -42,9 +45,14 @@
 # @public
 #
 macro(rosidl_auto_generate_interfaces)
-  cmake_parse_arguments(_ARG "ADD_LINTER_TESTS;SKIP_INSTALL" "LIBRARY_NAME" "TARGETS" ${ARGN})
+  cmake_parse_arguments(_ARG "ADD_LINTER_TESTS;SKIP_INSTALL" "TYPESUPPORT;LIBRARY_NAME" "TARGETS" ${ARGN})
   if(_ARG_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "rosidl_auto_generate_interfaces called with unused arguments: ${_ARG_UNPARSED_ARGUMENTS}")
+  endif()
+
+  # Set default typesupport if not specified
+  if(NOT _ARG_TYPESUPPORT)
+    set(_ARG_TYPESUPPORT "rosidl_typesupport_cpp")
   endif()
 
   # Ensure package.xml is parsed so *_DEPENDS variables are available

--- a/rosidl_cmake/cmake/rosidl_auto_generate_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_auto_generate_interfaces.cmake
@@ -1,0 +1,102 @@
+# Copyright 2014 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Generate code from msg/srv/action interface files.
+#
+# Requires that the package declares all of the following in `package.xml`:
+# - runtime dependency on `rosidl_default_runtime`
+# - buildtool dependency on `rosidl_default_generators`
+# - membership in group `rosidl_interface_packages`
+# If any is missing, the macro fails with a hint message.
+#
+# :param TARGETS: list of targets in same package that should be linked against
+#   same package's interface typesupport library so they can use the generated code of interfaces.
+# :type TARGETS: list of strings
+#
+# @public
+#
+macro(rosidl_auto_generate_interfaces)
+  cmake_parse_arguments(_ARG "" "" "TARGETS" ${ARGN})
+  if(_ARG_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "rosidl_auto_generate_interfaces called with unused arguments: ${_ARG_UNPARSED_ARGUMENTS}")
+  endif()
+
+  # Ensure package.xml is parsed so *_DEPENDS variables are available
+  if(NOT _AMENT_PACKAGE_NAME)
+    ament_package_xml()
+  endif()
+
+  # Validate required <exec_depend> tags
+  if(NOT rosidl_default_runtime IN_LIST ${PROJECT_NAME}_EXEC_DEPENDS)
+    message(FATAL_ERROR
+      "rosidl_auto_generate_interfaces: '${PROJECT_NAME}' must declare an exec_depend on 'rosidl_default_runtime' to use generated interfaces at runtime.\n"
+      "Hint:\n"
+      "  - package.xml: add <exec_depend>rosidl_default_runtime</exec_depend>\n")
+  endif()
+
+  # Validate required <buildtool_depend> tags
+  if(NOT rosidl_default_generators IN_LIST ${PROJECT_NAME}_BUILDTOOL_DEPENDS)
+    message(FATAL_ERROR
+      "rosidl_auto_generate_interfaces: '${PROJECT_NAME}' must declare a buildtool dependency on 'rosidl_default_generators' to generate interfaces.\n"
+      "Hint:\n"
+      "  - package.xml: add <buildtool_depend>rosidl_default_generators</buildtool_depend>\n")
+  endif()
+
+  # Validate required <member_of_group> tags
+  if(NOT rosidl_interface_packages IN_LIST ${PROJECT_NAME}_MEMBER_OF_GROUPS)
+    message(FATAL_ERROR
+      "rosidl_auto_generate_interfaces: '${PROJECT_NAME}' should join a `rosidl_interface_packages` group so tools can discover interface packages.\n"
+      "Hint:\n"
+      "  - package.xml: add <member_of_group>rosidl_interface_packages</member_of_group>\n")
+  endif()
+
+  set(${PROJECT_NAME}_interface_files "")
+  file(
+    GLOB
+    ${PROJECT_NAME}_interface_files
+    RELATIVE
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+    CONFIGURE_DEPENDS
+    "msg/*.msg"
+    "srv/*.srv"
+    "action/*.action"
+  )
+
+  if(NOT ${PROJECT_NAME}_interface_files)
+    message(WARNING "rosidl_auto_generate_interfaces: no message, service, or action files found")
+    return()
+  endif()
+
+  # Only forward DEPENDENCIES if present to avoid passing empty args
+  set(_rosidl_args
+    ${PROJECT_NAME}
+    ${${PROJECT_NAME}_interface_files}
+  )
+  if(${PROJECT_NAME}_FOUND_BUILD_DEPENDS)
+    list(APPEND _rosidl_args DEPENDENCIES ${${PROJECT_NAME}_FOUND_BUILD_DEPENDS})
+  endif()
+  rosidl_generate_interfaces(${_rosidl_args})
+  ament_export_dependencies(rosidl_default_runtime)
+
+  # Optionally wire interfaces into same-package targets
+  if(_ARG_TARGETS)
+    rosidl_get_typesupport_target(${PROJECT_NAME}_auto_typesupport_target ${PROJECT_NAME} rosidl_typesupport_cpp)
+    foreach(target IN LISTS _ARG_TARGETS)
+      target_link_libraries(${target} ${${PROJECT_NAME}_auto_typesupport_target})
+    endforeach()
+  endif()
+
+  ament_execute_extensions(rosidl_auto_generate_interfaces)
+endmacro()

--- a/rosidl_cmake/cmake/rosidl_auto_generate_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_auto_generate_interfaces.cmake
@@ -13,13 +13,18 @@
 # limitations under the License.
 
 #
-# Generate code from msg/srv/action interface files.
+# Automatically generate code from msg/srv/action interface files.
+#
+# This macro provides a simplified interface to rosidl_generate_interfaces()
+# by automatically:
+# - Discovering interface files in msg/, srv/, and action/ directories
+# - Using ${PROJECT_NAME}_BUILD_DEPENDS from package.xml as dependencies
+# - Exporting rosidl_default_runtime as a dependency
 #
 # Requires that the package declares all of the following in `package.xml`:
-# - runtime dependency on `rosidl_default_runtime`
-# - buildtool dependency on `rosidl_default_generators`
-# - membership in group `rosidl_interface_packages`
-# If any is missing, the macro fails with a hint message.
+# - exec_depend on `rosidl_default_runtime`
+# - buildtool_depend on `rosidl_default_generators`
+# - member_of_group `rosidl_interface_packages`
 #
 # :param TARGETS: list of targets in same package that should be linked against
 #   same package's interface typesupport library so they can use the generated code of interfaces.

--- a/rosidl_cmake/cmake/rosidl_auto_generate_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_auto_generate_interfaces.cmake
@@ -17,7 +17,7 @@
 #
 # This macro provides a simplified interface to rosidl_generate_interfaces()
 # by automatically:
-# - Discovering interface files in msg/, srv/, and action/ directories
+# - Discovering interface files (.msg, .srv, .action, .idl) in msg/, srv/, and action/ directories
 # - Using ${PROJECT_NAME}_BUILD_DEPENDS from package.xml as dependencies
 # - Exporting rosidl_default_runtime as a dependency
 #
@@ -84,8 +84,11 @@ macro(rosidl_auto_generate_interfaces)
     "${CMAKE_CURRENT_SOURCE_DIR}"
     CONFIGURE_DEPENDS
     "msg/*.msg"
+    "msg/*.idl"
     "srv/*.srv"
+    "srv/*.idl"
     "action/*.action"
+    "action/*.idl"
   )
 
   if(NOT ${PROJECT_NAME}_interface_files)

--- a/rosidl_cmake/cmake/rosidl_auto_generate_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_auto_generate_interfaces.cmake
@@ -24,11 +24,20 @@
 # :param TARGETS: list of targets in same package that should be linked against
 #   same package's interface typesupport library so they can use the generated code of interfaces.
 # :type TARGETS: list of strings
+# :param LIBRARY_NAME: the base name of the library, specific generators might
+#   append their own suffix (passed to rosidl_generate_interfaces)
+# :type LIBRARY_NAME: string
+# :param ADD_LINTER_TESTS: if set lint the interface files using
+#   the ``ament_lint`` package (passed to rosidl_generate_interfaces)
+# :type ADD_LINTER_TESTS: option
+# :param SKIP_INSTALL: if set skip installing the interface files
+#   (passed to rosidl_generate_interfaces)
+# :type SKIP_INSTALL: option
 #
 # @public
 #
 macro(rosidl_auto_generate_interfaces)
-  cmake_parse_arguments(_ARG "" "" "TARGETS" ${ARGN})
+  cmake_parse_arguments(_ARG "ADD_LINTER_TESTS;SKIP_INSTALL" "LIBRARY_NAME" "TARGETS" ${ARGN})
   if(_ARG_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "rosidl_auto_generate_interfaces called with unused arguments: ${_ARG_UNPARSED_ARGUMENTS}")
   endif()
@@ -79,13 +88,22 @@ macro(rosidl_auto_generate_interfaces)
     return()
   endif()
 
-  # Only forward DEPENDENCIES if present to avoid passing empty args
+  # Build arguments for rosidl_generate_interfaces
   set(_rosidl_args
     ${PROJECT_NAME}
     ${${PROJECT_NAME}_interface_files}
   )
   if(${PROJECT_NAME}_BUILD_DEPENDS)
     list(APPEND _rosidl_args DEPENDENCIES ${${PROJECT_NAME}_BUILD_DEPENDS})
+  endif()
+  if(_ARG_LIBRARY_NAME)
+    list(APPEND _rosidl_args LIBRARY_NAME ${_ARG_LIBRARY_NAME})
+  endif()
+  if(_ARG_ADD_LINTER_TESTS)
+    list(APPEND _rosidl_args ADD_LINTER_TESTS)
+  endif()
+  if(_ARG_SKIP_INSTALL)
+    list(APPEND _rosidl_args SKIP_INSTALL)
   endif()
   rosidl_generate_interfaces(${_rosidl_args})
   ament_export_dependencies(rosidl_default_runtime)

--- a/rosidl_cmake/cmake/rosidl_auto_generate_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_auto_generate_interfaces.cmake
@@ -41,25 +41,25 @@ macro(rosidl_auto_generate_interfaces)
   # Validate required <exec_depend> tags
   if(NOT rosidl_default_runtime IN_LIST ${PROJECT_NAME}_EXEC_DEPENDS)
     message(FATAL_ERROR
-      "rosidl_auto_generate_interfaces: '${PROJECT_NAME}' must declare an exec_depend on 'rosidl_default_runtime' to use generated interfaces at runtime.\n"
-      "Hint:\n"
-      "  - package.xml: add <exec_depend>rosidl_default_runtime</exec_depend>\n")
+      "Packages installing interfaces must include "
+      "'<exec_depend>rosidl_default_runtime</exec_depend>' "
+      "in their package.xml")
   endif()
 
   # Validate required <buildtool_depend> tags
   if(NOT rosidl_default_generators IN_LIST ${PROJECT_NAME}_BUILDTOOL_DEPENDS)
     message(FATAL_ERROR
-      "rosidl_auto_generate_interfaces: '${PROJECT_NAME}' must declare a buildtool dependency on 'rosidl_default_generators' to generate interfaces.\n"
-      "Hint:\n"
-      "  - package.xml: add <buildtool_depend>rosidl_default_generators</buildtool_depend>\n")
+      "Packages installing interfaces must include "
+      "'<buildtool_depend>rosidl_default_generators</buildtool_depend>' "
+      "in their package.xml")
   endif()
 
   # Validate required <member_of_group> tags
   if(NOT rosidl_interface_packages IN_LIST ${PROJECT_NAME}_MEMBER_OF_GROUPS)
     message(FATAL_ERROR
-      "rosidl_auto_generate_interfaces: '${PROJECT_NAME}' should join a `rosidl_interface_packages` group so tools can discover interface packages.\n"
-      "Hint:\n"
-      "  - package.xml: add <member_of_group>rosidl_interface_packages</member_of_group>\n")
+      "Packages installing interfaces must include "
+      "'<member_of_group>rosidl_interface_packages</member_of_group>' "
+      "in their package.xml")
   endif()
 
   set(${PROJECT_NAME}_interface_files "")

--- a/rosidl_cmake/cmake/rosidl_auto_generate_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_auto_generate_interfaces.cmake
@@ -1,4 +1,4 @@
-# Copyright 2014 Open Source Robotics Foundation, Inc.
+# Copyright 2025 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rosidl_cmake/rosidl_cmake-extras.cmake
+++ b/rosidl_cmake/rosidl_cmake-extras.cmake
@@ -30,6 +30,7 @@ endmacro()
 find_package(rosidl_adapter)  # not required, being used when available
 
 include("${rosidl_cmake_DIR}/rosidl_generate_interfaces.cmake")
+include("${rosidl_cmake_DIR}/rosidl_auto_generate_interfaces.cmake")
 include("${rosidl_cmake_DIR}/rosidl_get_typesupport_target.cmake")
 include("${rosidl_cmake_DIR}/rosidl_write_generator_arguments.cmake")
 include("${rosidl_cmake_DIR}/string_camel_case_to_lower_case_underscore.cmake")


### PR DESCRIPTION
## Description

This pull-request adds `rosidl_auto_generate_inetrfaces` function to simplify boilerplate CMake in interface packages.

`rosidl_auto_generate_inetrfaces` function was originally planned as the `ament_auto_generate_code` function. However, when I implemented it in https://github.com/ament/ament_cmake/pull/600, I was advised to move it to `rosidl_cmake` because `ament_cmake`'s dependency on `rosidl_cmake` would create a circular dependency.

Using `rosidl_auto_generate_inetrfaces` simplifies CMake for interface packages as follows:

before
```cmake
cmake_minimum_required(VERSION 3.12)
project(my_interfaces)

find_package(ament_cmake REQUIRED)
find_package(rosidl_default_generators REQUIRED)
find_package(std_msgs REQUIRED)

rosidl_generate_interfaces(${PROJECT_NAME}
  "msg/Test.msg"
  "msg/TestA.msg"
  "msg/TestB.msg"
  DEPENDENCIES std_msgs
  ADD_LINTER_TESTS
)

ament_export_dependencies(rosidl_default_runtime)

ament_package()
```

after
```cmake
cmake_minimum_required(VERSION 3.12)
project(my_interfaces)

find_package(ament_cmake REQUIRED)
find_package(rosidl_default_generators REQUIRED)
find_package(std_msgs REQUIRED)

rosidl_auto_generate_interfaces(ADD_LINTER_TESTS)

ament_package()
```

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

I used Gemini 3.0 to review my code.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
