### PR TITLE
rosidl_generator_cpp: constexpr message traits and to_tuple_ref for generated structs

### DIFF
--- a/rosidl_generator_cpp/resource/idl__traits.hpp.em
+++ b/rosidl_generator_cpp/resource/idl__traits.hpp.em
@@ -29,9 +29,14 @@ include_directives = set()
 
 #include <stdint.h>
 
+#include <array>
+#include <cstddef>
 #include <sstream>
 #include <string>
+#include <string_view>
+#include <tuple>
 #include <type_traits>
+#include <utility>
 
 #include "@(include_base)__struct.hpp"
 #include "rosidl_runtime_cpp/traits.hpp"

--- a/rosidl_generator_cpp/resource/msg__traits.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__traits.hpp.em
@@ -214,6 +214,19 @@ inline std::string to_yaml(const @(message.structure.namespaced_type.name) & msg
   }
   return out.str();
 }
+
+template<typename T, std::enable_if_t<std::is_same_v<std::decay_t<T>, @(message_typename)>, int> = 0>
+constexpr auto as_tuple_ref(T&& msg) {
+@[if len(message.structure.members) == 0]@
+  return std::forward_as_tuple();
+@[elif len(message.structure.members) == 1]@
+  return std::forward_as_tuple(std::forward<T>(msg).@(message.structure.members[0].name));
+@[else]@
+  return std::forward_as_tuple(
+@{forward_args = [f'    std::forward<T>(msg).{member.name}' for member in message.structure.members]}@
+@(',\n'.join(forward_args)));
+@[end if]@
+}
 @[for ns in reversed(message.structure.namespaced_type.namespaces)]@
 
 }  // namespace @(ns)
@@ -285,5 +298,15 @@ struct has_bounded_size<@(message_typename)>
 template<>
 struct is_message<@(message_typename)>
   : std::true_type {};
+
+template<>
+struct MessageTraits<@(message_typename)> {
+  static constexpr std::size_t member_count = @(len(message.structure.members));
+  static constexpr std::array<std::string_view, member_count> member_names = {
+@[for member in message.structure.members]@
+    "@(member.name)",
+@[end for]@
+  };
+};
 
 }  // namespace rosidl_generator_traits

--- a/rosidl_generator_cpp/resource/msg__traits.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__traits.hpp.em
@@ -216,7 +216,8 @@ inline std::string to_yaml(const @(message.structure.namespaced_type.name) & msg
 }
 
 template<typename T, std::enable_if_t<std::is_same_v<std::decay_t<T>, @(message_typename)>, int> = 0>
-constexpr auto as_tuple_ref(T&& msg) {
+constexpr auto as_tuple_ref(T && msg)
+{
 @[if len(message.structure.members) == 0]@
   return std::forward_as_tuple();
 @[elif len(message.structure.members) == 1]@
@@ -300,7 +301,8 @@ struct is_message<@(message_typename)>
   : std::true_type {};
 
 template<>
-struct MessageTraits<@(message_typename)> {
+struct MessageTraits<@(message_typename)>
+{
   static constexpr std::size_t member_count = @(len(message.structure.members));
   static constexpr std::array<std::string_view, member_count> member_names = {
 @[for member in message.structure.members]@

--- a/rosidl_generator_tests/test/rosidl_generator_cpp/test_traits.cpp
+++ b/rosidl_generator_tests/test/rosidl_generator_cpp/test_traits.cpp
@@ -15,6 +15,7 @@
 
 #include <gtest/gtest.h>
 #include <string>
+#include <tuple>
 
 // the idl file is commented out in the test_interface_files package
 // #include "rosidl_generator_tests/idl/idl_only_types.hpp"
@@ -32,6 +33,7 @@ using rosidl_generator_traits::is_message;
 using rosidl_generator_traits::is_service;
 using rosidl_generator_traits::is_service_request;
 using rosidl_generator_traits::is_service_response;
+using rosidl_generator_traits::MessageTraits;
 using rosidl_generator_tests::msg::to_yaml;
 
 TEST(Test_rosidl_generator_traits, to_yaml_default_style) {
@@ -447,3 +449,83 @@ static_assert(streq(name<rosidl_generator_tests::srv::Empty>(),
 "rosidl_generator_tests/srv/Empty"));
 static_assert(streq(data_type<rosidl_generator_tests::srv::Empty>(),
 "rosidl_generator_tests::srv::Empty"));
+
+// Compile-time tests for member count and member names in MessageTraits
+using MessageTraitsDefaults = MessageTraits<rosidl_generator_tests::msg::Defaults>;
+static_assert(MessageTraitsDefaults::member_count == 13,
+              "Unexpected number of members for Defaults message");
+static_assert(MessageTraitsDefaults::member_names[0] == "bool_value",
+              "Unexpected member name for Defaults::bool_value");
+static_assert(MessageTraitsDefaults::member_names[1] == "byte_value",
+              "Unexpected member name for Defaults::byte_value");
+static_assert(MessageTraitsDefaults::member_names[2] == "char_value",
+              "Unexpected member name for Defaults::char_value");
+static_assert(MessageTraitsDefaults::member_names[3] == "float32_value",
+              "Unexpected member name for Defaults::float32_value");
+static_assert(MessageTraitsDefaults::member_names[4] == "float64_value",
+              "Unexpected member name for Defaults::float64_value");
+static_assert(MessageTraitsDefaults::member_names[5] == "int8_value",
+              "Unexpected member name for Defaults::int8_value");
+static_assert(MessageTraitsDefaults::member_names[6] == "uint8_value",
+              "Unexpected member name for Defaults::uint8_value");
+static_assert(MessageTraitsDefaults::member_names[7] == "int16_value",
+              "Unexpected member name for Defaults::int16_value");
+static_assert(MessageTraitsDefaults::member_names[8] == "uint16_value",
+              "Unexpected member name for Defaults::uint16_value");
+static_assert(MessageTraitsDefaults::member_names[9] == "int32_value",
+              "Unexpected member name for Defaults::int32_value");
+static_assert(MessageTraitsDefaults::member_names[10] == "uint32_value",
+              "Unexpected member name for Defaults::uint32_value");
+static_assert(MessageTraitsDefaults::member_names[11] == "int64_value",
+              "Unexpected member name for Defaults::int64_value");
+static_assert(MessageTraitsDefaults::member_names[12] == "uint64_value",
+              "Unexpected member name for Defaults::uint64_value");
+
+TEST(Test_rosidl_generator_traits, structured_binding_support)
+{
+  rosidl_generator_tests::msg::Defaults msg;
+  auto [bool_value, byte_value, char_value, float32_value, float64_value, int8_value, uint8_value,
+    int16_value, uint16_value, int32_value, uint32_value, int64_value, uint64_value] = msg;
+
+  ASSERT_TRUE(bool_value);
+  ASSERT_EQ(50, byte_value);
+  ASSERT_EQ(100, char_value);
+  ASSERT_EQ(1.125f, float32_value);
+  ASSERT_EQ(1.125, float64_value);
+  ASSERT_EQ(-50, int8_value);
+  ASSERT_EQ(200, uint8_value);
+  ASSERT_EQ(-1000, int16_value);
+  ASSERT_EQ(2000, uint16_value);
+  ASSERT_EQ(-30000L, int32_value);
+  ASSERT_EQ(60000UL, uint32_value);
+  ASSERT_EQ(-40000000LL, int64_value);
+  ASSERT_EQ(50000000ULL, uint64_value);
+
+  // Structured binding without & are copies and should not be modifiable
+  bool_value = false;
+  ASSERT_TRUE(msg.bool_value);
+
+  // Test with references
+  auto & [bool_ref, byte_ref, char_ref, float32_ref, float64_ref, int8_ref, uint8_ref, int16_ref,
+    uint16_ref, int32_ref, uint32_ref, int64_ref, uint64_ref] = msg;
+
+  // Now the structural binding returns modifiable references
+  bool_ref = false;
+  ASSERT_FALSE(msg.bool_value);
+}
+
+TEST(Test_rosidl_generator_traits, as_tuple_ref)
+{
+  rosidl_generator_tests::msg::Defaults msg;
+
+  // Check initial value
+  ASSERT_EQ(-1000, msg.int16_value);
+
+  // Default-initialize all fields via tuple reference
+  std::apply([&msg](auto & ... field) {
+      ((field = {}), ...);
+    }, as_tuple_ref(msg));
+
+  // Check that field has been modified
+  ASSERT_EQ(0, msg.int16_value);
+}

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/traits.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/traits.hpp
@@ -186,6 +186,9 @@ struct is_action_result : std::false_type {};
 template<typename T>
 struct is_action_feedback : std::false_type {};
 
+template<typename T>
+struct MessageTraits {};
+
 }  // namespace rosidl_generator_traits
 
 #endif  // ROSIDL_RUNTIME_CPP__TRAITS_HPP_


### PR DESCRIPTION
## Description

This PR adds a constexpr-capable MemberTraits structure such that the number of members and member names can be used in a compile-time context.  The PR also adds a function that forwards the members of the struct as a tuple of references. This makes it very simple to treat the members generically, using for example std::apply.

Implements #923 

### Is this user-facing behavior change?
It should not, as the new struct / function is contained within the appropriate namespaces.

### Did you use Generative AI?
No
