### PR TITLE
Make `data_type` and `name` traits constexpr

### DIFF
--- a/rosidl_generator_cpp/resource/action__traits.hpp.em
+++ b/rosidl_generator_cpp/resource/action__traits.hpp.em
@@ -59,13 +59,13 @@ namespace rosidl_generator_traits
 {
 
 template<>
-inline const char * data_type<@(action_typename)>()
+constexpr const char * data_type<@(action_typename)>()
 {
   return "@(action_typename)";
 }
 
 template<>
-inline const char * name<@(action_typename)>()
+constexpr const char * name<@(action_typename)>()
 {
   return "@(action_fully_qualified_name)";
 }

--- a/rosidl_generator_cpp/resource/msg__traits.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__traits.hpp.em
@@ -223,13 +223,13 @@ namespace rosidl_generator_traits
 {
 
 template<>
-inline const char * data_type<@(message_typename)>()
+constexpr const char * data_type<@(message_typename)>()
 {
   return "@(message_typename)";
 }
 
 template<>
-inline const char * name<@(message_typename)>()
+constexpr const char * name<@(message_typename)>()
 {
   return "@(message_fully_qualified_name)";
 }

--- a/rosidl_generator_cpp/resource/srv__traits.hpp.em
+++ b/rosidl_generator_cpp/resource/srv__traits.hpp.em
@@ -29,13 +29,13 @@ namespace rosidl_generator_traits
 {
 
 template<>
-inline const char * data_type<@(service_typename)>()
+constexpr const char * data_type<@(service_typename)>()
 {
   return "@(service_typename)";
 }
 
 template<>
-inline const char * name<@(service_typename)>()
+constexpr const char * name<@(service_typename)>()
 {
   return "@(service_fully_qualified_name)";
 }

--- a/rosidl_generator_tests/test/rosidl_generator_cpp/test_traits.cpp
+++ b/rosidl_generator_tests/test/rosidl_generator_cpp/test_traits.cpp
@@ -434,13 +434,16 @@ TEST(Test_rosidl_generator_traits, is_service) {
   EXPECT_FALSE(is_service_response<ServiceEvent>());
 }
 
-constexpr bool streq(const char* a, const char* b) {
-    while (*a && (*a == *b)) {
-        ++a;
-        ++b;
-    }
-    return *a == *b;
+constexpr bool streq(const char * a, const char * b)
+{
+  while (*a && (*a == *b)) {
+    ++a;
+    ++b;
+  }
+  return *a == *b;
 }
 
-static_assert(streq(name<rosidl_generator_tests::srv::Empty>(), "rosidl_generator_tests/srv/Empty"));
-static_assert(streq(data_type<rosidl_generator_tests::srv::Empty>(), "rosidl_generator_tests::srv::Empty"));
+static_assert(streq(name<rosidl_generator_tests::srv::Empty>(),
+"rosidl_generator_tests/srv/Empty"));
+static_assert(streq(data_type<rosidl_generator_tests::srv::Empty>(),
+"rosidl_generator_tests::srv::Empty"));

--- a/rosidl_generator_tests/test/rosidl_generator_cpp/test_traits.cpp
+++ b/rosidl_generator_tests/test/rosidl_generator_cpp/test_traits.cpp
@@ -26,6 +26,8 @@
 #include "rosidl_generator_tests/msg/w_strings.hpp"
 #include "rosidl_generator_tests/srv/empty.hpp"
 
+using rosidl_generator_traits::name;
+using rosidl_generator_traits::data_type;
 using rosidl_generator_traits::is_message;
 using rosidl_generator_traits::is_service;
 using rosidl_generator_traits::is_service_request;
@@ -431,3 +433,14 @@ TEST(Test_rosidl_generator_traits, is_service) {
   EXPECT_FALSE(is_service_request<ServiceEvent>());
   EXPECT_FALSE(is_service_response<ServiceEvent>());
 }
+
+constexpr bool streq(const char* a, const char* b) {
+    while (*a && (*a == *b)) {
+        ++a;
+        ++b;
+    }
+    return *a == *b;
+}
+
+static_assert(streq(name<rosidl_generator_tests::srv::Empty>(), "rosidl_generator_tests/srv/Empty"));
+static_assert(streq(data_type<rosidl_generator_tests::srv::Empty>(), "rosidl_generator_tests::srv::Empty"));

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/traits.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/traits.hpp
@@ -151,10 +151,10 @@ inline void value_to_yaml(const std::u16string & value, std::ostream & out)
 }
 
 template<typename T>
-inline const char * data_type();
+constexpr const char * data_type();
 
 template<typename T>
-inline const char * name();
+constexpr const char * name();
 
 template<typename T>
 struct has_fixed_size : std::false_type {};


### PR DESCRIPTION
## Description

I was doing some meta programming that would need this to be fully resolved at compile time.

### Is this user-facing behavior change?

Should allow them to use constexpr downstream of these functions if they want.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
