### PR TITLE
Add cache mechanism for rosidl code generation

### DIFF
--- a/rosidl_parser/rosidl_parser/cache.py
+++ b/rosidl_parser/rosidl_parser/cache.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import hashlib
+import json
+import os
+import pathlib
+import pickle
+import shutil
+import tempfile
+from typing import Any, List, Optional, TypedDict
+
+
+class CacheConfig(TypedDict):
+    cache_dir: Optional[str]
+    cache_debug: bool
+    cache_max_size: int
+
+
+class _CacheEntry(TypedDict):
+    path: pathlib.Path
+    size: int
+    mtime: float
+
+
+_cache_config = None
+
+
+def get_cache_config() -> CacheConfig:
+    global _cache_config
+    if _cache_config is not None:
+        return _cache_config
+
+    config: CacheConfig = {
+        'cache_dir': None,
+        'cache_debug': False,
+        'cache_max_size': 1073741824
+    }
+
+    config_file = os.environ.get('ROSIDL_CACHE_CONFIG')
+    if config_file and os.path.exists(config_file):
+        with open(config_file, 'r') as f:
+            file_config = json.load(f)
+            if 'cache_dir' in file_config:
+                config['cache_dir'] = file_config['cache_dir']
+            if 'cache_debug' in file_config:
+                config['cache_debug'] = file_config['cache_debug']
+            if 'cache_max_size' in file_config:
+                config['cache_max_size'] = file_config['cache_max_size']
+
+    # Override with environment variables
+    env_cache_dir = os.environ.get('ROSIDL_CACHE_DIR')
+    if env_cache_dir is not None:
+        config['cache_dir'] = env_cache_dir
+    env_cache_debug = os.environ.get('ROSIDL_CACHE_DEBUG')
+    if env_cache_debug is not None:
+        config['cache_debug'] = env_cache_debug.lower() in ('1', 'true', 'yes')
+    env_cache_max_size = os.environ.get('ROSIDL_CACHE_MAX_SIZE')
+    if env_cache_max_size is not None:
+        config['cache_max_size'] = int(env_cache_max_size)
+
+    _cache_config = config
+    return config
+
+
+def debug_print(msg: str) -> None:
+    if get_cache_config()['cache_debug']:
+        print(msg)
+
+
+def get_cache_dir(subdirectory: str) -> Optional[pathlib.Path]:
+    cache_dir_str = get_cache_config()['cache_dir']
+    if not cache_dir_str:
+        return None
+
+    cache_dir = pathlib.Path(cache_dir_str) / subdirectory
+    return cache_dir
+
+
+def cleanup_cache_if_needed(subdirectory: str):
+    config = get_cache_config()
+    cache_dir = get_cache_dir(subdirectory)
+    max_size = config['cache_max_size']
+
+    if not cache_dir or not cache_dir.exists():
+        return
+
+    # Collect cache entry directories with sizes and modification times
+    entries: List[_CacheEntry] = []
+    total_size = 0
+
+    for entry_dir in cache_dir.iterdir():
+        if not entry_dir.is_dir():
+            continue
+
+        try:
+            dir_size = sum(
+                f.stat().st_size for f in entry_dir.rglob('*') if f.is_file()
+            )
+            mtime = max(
+                (f.stat().st_mtime for f in entry_dir.rglob('*') if f.is_file()),
+                default=0.0
+            )
+            entries.append({
+                'path': entry_dir,
+                'size': dir_size,
+                'mtime': mtime
+            })
+            total_size += dir_size
+        except (OSError, PermissionError):
+            continue
+
+    if total_size <= max_size:
+        return
+
+    # Sort by modification time (oldest first)
+    entries.sort(key=lambda e: e['mtime'])
+
+    # Delete oldest entries until we're below 80% of max_size
+    target_size = int(max_size * 0.8)
+    current_size = total_size
+
+    for entry in entries:
+        if current_size <= target_size:
+            break
+
+        try:
+            shutil.rmtree(entry['path'])
+            current_size -= entry['size']
+            debug_print(f'[rosidl cache] Removed old cache entry: {entry["path"].name}')
+        except (OSError, PermissionError) as e:
+            debug_print(f'[rosidl cache] Failed to remove cache entry: {e}')
+
+
+def compute_cache_key(*args) -> Optional[str]:
+    if not get_cache_config()['cache_dir']:
+        return None
+
+    hasher = hashlib.sha256()
+
+    for arg in args:
+        if isinstance(arg, pathlib.Path):
+            with open(arg, 'rb') as f:
+                hasher.update(f.read())
+        elif isinstance(arg, dict):
+            hasher.update(json.dumps(arg, sort_keys=True).encode('utf-8'))
+        else:
+            hasher.update(pickle.dumps(arg, protocol=pickle.HIGHEST_PROTOCOL))
+
+    return hasher.hexdigest()
+
+
+def save_object_to_cache(cache_key: str, cache_subdir: str, obj: Any) -> None:
+    cache_dir = get_cache_dir(cache_subdir)
+    if not cache_dir:
+        return
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cache_entry_dir = cache_dir / cache_key
+    tmp_dir = None
+    try:
+        tmp_dir = pathlib.Path(tempfile.mkdtemp(dir=cache_dir))
+        cache_file = tmp_dir / 'object.pkl'
+        with open(cache_file, 'wb') as f:
+            pickle.dump(obj, f, protocol=pickle.HIGHEST_PROTOCOL)
+        if cache_entry_dir.exists():
+            shutil.rmtree(cache_entry_dir)
+        tmp_dir.rename(cache_entry_dir)
+    except Exception as e:
+        debug_print(f'[rosidl cache] Failed to save to cache: {e}')
+        if tmp_dir and tmp_dir.exists():
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+        return
+    cleanup_cache_if_needed(cache_subdir)
+
+
+def restore_object_from_cache(cache_key: str, cache_subdir: str) -> Optional[Any]:
+    cache_dir = get_cache_dir(cache_subdir)
+    if not cache_dir:
+        return None
+    cache_entry_dir = cache_dir / cache_key
+    cache_file = cache_entry_dir / 'object.pkl'
+    if not cache_file.exists():
+        return None
+    try:
+        with open(cache_file, 'rb') as f:
+            return pickle.load(f)
+    except Exception as e:
+        debug_print(f'[rosidl cache] Failed to load from cache: {e}')
+        return None
+
+
+def save_files_to_cache(
+    cache_key: str,
+    cache_subdir: str,
+    files: list,
+    base_dir: str
+) -> None:
+    cache_dir = get_cache_dir(cache_subdir)
+    if not cache_dir:
+        return
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cache_entry_dir = cache_dir / cache_key
+    tmp_dir = None
+    try:
+        tmp_dir = pathlib.Path(tempfile.mkdtemp(dir=cache_dir))
+        base_path = pathlib.Path(base_dir)
+        for rel_path in files:
+            src = base_path / rel_path
+            dest = tmp_dir / rel_path
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dest)
+        if cache_entry_dir.exists():
+            shutil.rmtree(cache_entry_dir)
+        tmp_dir.rename(cache_entry_dir)
+    except Exception as e:
+        debug_print(f'[rosidl cache] Failed to save files to cache: {e}')
+        if tmp_dir and tmp_dir.exists():
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+        return
+
+    cleanup_cache_if_needed(cache_subdir)
+
+
+def restore_files_from_cache(
+    cache_key: str,
+    cache_subdir: str,
+    output_dir: str
+) -> Optional[list]:
+    cache_dir = get_cache_dir(cache_subdir)
+    if not cache_dir:
+        return None
+
+    cache_entry_dir = cache_dir / cache_key
+    if not cache_entry_dir.exists():
+        return None
+
+    output_path = pathlib.Path(output_dir)
+    restored_files = []
+
+    for src in cache_entry_dir.rglob('*'):
+        if not src.is_file():
+            continue
+        rel_path = src.relative_to(cache_entry_dir)
+        dest = output_path / rel_path
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            shutil.copy2(src, dest)
+            restored_files.append(str(dest))
+        except Exception as e:
+            debug_print(f'[rosidl cache] Failed to restore file {rel_path}: {e}')
+            return None
+
+    return restored_files

--- a/rosidl_parser/rosidl_parser/cache.py
+++ b/rosidl_parser/rosidl_parser/cache.py
@@ -17,10 +17,74 @@ import hashlib
 import json
 import os
 import pathlib
-import pickle
 import shutil
 import tempfile
 from typing import Any, List, Optional, TypedDict
+
+import rosidl_parser.definition as _def
+
+# Build class registry and precomputed slots for safe deserialization
+_CLASSES = {}
+_SLOTS = {}
+
+for _name in dir(_def):
+    _obj = getattr(_def, _name)
+    if isinstance(_obj, type):
+        _CLASSES[_name] = _obj
+        # Precompute all slot names across MRO
+        _slots = []
+        for _klass in _obj.__mro__:
+            _klass_slots = getattr(_klass, '__slots__', ())
+            if isinstance(_klass_slots, str):
+                _slots.append(_klass_slots)
+            else:
+                _slots.extend(_klass_slots)
+        _SLOTS[_obj] = tuple(_slots)
+
+
+def _encode(obj):
+    if obj is None or isinstance(obj, (bool, int, float, str)):
+        return obj
+    if isinstance(obj, pathlib.Path):
+        return {'__path__': str(obj)}
+    if isinstance(obj, list):
+        return [_encode(item) for item in obj]
+    if isinstance(obj, tuple):
+        return {'__tuple__': [_encode(item) for item in obj]}
+    if isinstance(obj, dict):
+        return {k: _encode(v) for k, v in obj.items()}
+    slots = _SLOTS.get(type(obj))
+    if slots is None:
+        raise TypeError(f'Cannot JSON-encode object of type {type(obj).__name__}')
+    data = {'__class__': type(obj).__name__}
+    for slot in slots:
+        if hasattr(obj, slot):
+            data[slot] = _encode(getattr(obj, slot))
+    return data
+
+
+def _decode(data):
+    if data is None or isinstance(data, (bool, int, float, str)):
+        return data
+    if isinstance(data, list):
+        return [_decode(item) for item in data]
+    if isinstance(data, dict):
+        if '__path__' in data:
+            return pathlib.Path(data['__path__'])
+        if '__tuple__' in data:
+            return tuple(_decode(item) for item in data['__tuple__'])
+        cls_name = data.get('__class__')
+        if cls_name:
+            if cls_name not in _CLASSES:
+                raise ValueError(f'Unknown class: {cls_name}')
+            cls = _CLASSES[cls_name]
+            obj = cls.__new__(cls)
+            for slot in _SLOTS[cls]:
+                if slot in data:
+                    object.__setattr__(obj, slot, _decode(data[slot]))
+            return obj
+        return {k: _decode(v) for k, v in data.items()}
+    return data
 
 
 class CacheConfig(TypedDict):
@@ -157,7 +221,7 @@ def compute_cache_key(*args) -> Optional[str]:
         elif isinstance(arg, dict):
             hasher.update(json.dumps(arg, sort_keys=True).encode('utf-8'))
         else:
-            hasher.update(pickle.dumps(arg, protocol=pickle.HIGHEST_PROTOCOL))
+            hasher.update(json.dumps(arg, sort_keys=True, default=str).encode('utf-8'))
 
     return hasher.hexdigest()
 
@@ -171,9 +235,9 @@ def save_object_to_cache(cache_key: str, cache_subdir: str, obj: Any) -> None:
     tmp_dir = None
     try:
         tmp_dir = pathlib.Path(tempfile.mkdtemp(dir=cache_dir))
-        cache_file = tmp_dir / 'object.pkl'
-        with open(cache_file, 'wb') as f:
-            pickle.dump(obj, f, protocol=pickle.HIGHEST_PROTOCOL)
+        cache_file = tmp_dir / 'object.json'
+        with open(cache_file, 'w', encoding='utf-8') as f:
+            json.dump(_encode(obj), f)
         if cache_entry_dir.exists():
             shutil.rmtree(cache_entry_dir)
         tmp_dir.rename(cache_entry_dir)
@@ -190,12 +254,12 @@ def restore_object_from_cache(cache_key: str, cache_subdir: str) -> Optional[Any
     if not cache_dir:
         return None
     cache_entry_dir = cache_dir / cache_key
-    cache_file = cache_entry_dir / 'object.pkl'
+    cache_file = cache_entry_dir / 'object.json'
     if not cache_file.exists():
         return None
     try:
-        with open(cache_file, 'rb') as f:
-            return pickle.load(f)
+        with open(cache_file, 'r', encoding='utf-8') as f:
+            return _decode(json.load(f))
     except Exception as e:
         debug_print(f'[rosidl cache] Failed to load from cache: {e}')
         return None

--- a/rosidl_parser/rosidl_parser/cache.py
+++ b/rosidl_parser/rosidl_parser/cache.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import hashlib
+import importlib.metadata
 import json
 import os
 import pathlib
@@ -206,6 +207,13 @@ def cleanup_cache_if_needed(subdirectory: str):
             debug_print(f'[rosidl cache] Removed old cache entry: {entry["path"].name}')
         except (OSError, PermissionError) as e:
             debug_print(f'[rosidl cache] Failed to remove cache entry: {e}')
+
+
+def get_package_version(package_name: str) -> str:
+    try:
+        return importlib.metadata.version(package_name)
+    except importlib.metadata.PackageNotFoundError:
+        return 'unknown'
 
 
 def compute_cache_key(*args) -> Optional[str]:

--- a/rosidl_parser/rosidl_parser/parser.py
+++ b/rosidl_parser/rosidl_parser/parser.py
@@ -32,6 +32,9 @@ from lark.lexer import Token
 from lark.tree import pydot__tree_to_png
 from lark.tree import Tree
 
+from rosidl_parser.cache import compute_cache_key
+from rosidl_parser.cache import restore_object_from_cache
+from rosidl_parser.cache import save_object_to_cache
 from rosidl_parser.definition import AbstractNestableType
 from rosidl_parser.definition import AbstractNestedType
 from rosidl_parser.definition import AbstractType
@@ -87,12 +90,20 @@ _parser: Optional[Lark] = None
 
 def parse_idl_file(locator: IdlLocator, png_file: Optional[str] = None) -> IdlFile:
     string = locator.get_absolute_path().read_text(encoding='utf-8')
+    cache_key = None if png_file is not None else compute_cache_key(string)
+    if cache_key:
+        cached_result = restore_object_from_cache(cache_key, 'idl_parse')
+        if cached_result is not None:
+            return cached_result
     try:
         content = parse_idl_string(string, png_file=png_file)
     except Exception as e:
         print(str(e), str(locator.get_absolute_path()), file=sys.stderr)
         raise
-    return IdlFile(locator, content)
+    result = IdlFile(locator, content)
+    if cache_key:
+        save_object_to_cache(cache_key, 'idl_parse', result)
+    return result
 
 
 def parse_idl_string(idl_string: str, png_file: Optional[str] = None) -> IdlContent:

--- a/rosidl_parser/rosidl_parser/parser.py
+++ b/rosidl_parser/rosidl_parser/parser.py
@@ -33,6 +33,7 @@ from lark.tree import pydot__tree_to_png
 from lark.tree import Tree
 
 from rosidl_parser.cache import compute_cache_key
+from rosidl_parser.cache import get_package_version
 from rosidl_parser.cache import restore_object_from_cache
 from rosidl_parser.cache import save_object_to_cache
 from rosidl_parser.definition import AbstractNestableType
@@ -90,7 +91,8 @@ _parser: Optional[Lark] = None
 
 def parse_idl_file(locator: IdlLocator, png_file: Optional[str] = None) -> IdlFile:
     string = locator.get_absolute_path().read_text(encoding='utf-8')
-    cache_key = None if png_file is not None else compute_cache_key(string)
+    cache_key = None if png_file is not None else compute_cache_key(
+        string, get_package_version('rosidl_parser'))
     if cache_key:
         cached_result = restore_object_from_cache(cache_key, 'idl_parse')
         if cached_result is not None:

--- a/rosidl_parser/test/test_cache.py
+++ b/rosidl_parser/test/test_cache.py
@@ -1,0 +1,138 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import time
+
+import pytest
+
+import rosidl_parser.cache as cache_module
+from rosidl_parser.cache import cleanup_cache_if_needed
+from rosidl_parser.cache import compute_cache_key
+from rosidl_parser.cache import get_cache_config
+from rosidl_parser.cache import restore_files_from_cache
+from rosidl_parser.cache import restore_object_from_cache
+from rosidl_parser.cache import save_files_to_cache
+from rosidl_parser.cache import save_object_to_cache
+
+
+@pytest.fixture(autouse=True)
+def reset_cache_config():
+    """Reset the cached config and env vars before each test."""
+    cache_module._cache_config = None
+    saved_env = {}
+    for key in ('ROSIDL_CACHE_DIR', 'ROSIDL_CACHE_DEBUG',
+                'ROSIDL_CACHE_MAX_SIZE', 'ROSIDL_CACHE_CONFIG'):
+        saved_env[key] = os.environ.pop(key, None)
+    yield
+    cache_module._cache_config = None
+    for key, val in saved_env.items():
+        if val is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = val
+
+
+@pytest.fixture
+def cache_dir(tmp_path):
+    """Provide a temporary cache directory and set env vars."""
+    d = tmp_path / 'cache'
+    d.mkdir()
+    os.environ['ROSIDL_CACHE_DIR'] = str(d)
+    yield d
+
+
+def test_config_defaults():
+    config = get_cache_config()
+    assert config['cache_dir'] is None
+    assert config['cache_debug'] is False
+    assert config['cache_max_size'] == 1073741824
+
+
+def test_config_env_override(tmp_path):
+    os.environ['ROSIDL_CACHE_DIR'] = str(tmp_path)
+    os.environ['ROSIDL_CACHE_DEBUG'] = '1'
+    os.environ['ROSIDL_CACHE_MAX_SIZE'] = '500'
+    config = get_cache_config()
+    assert config['cache_dir'] == str(tmp_path)
+    assert config['cache_debug'] is True
+    assert config['cache_max_size'] == 500
+
+
+def test_cache_key_none_without_cache_dir():
+    assert compute_cache_key('hello') is None
+
+
+def test_cache_key_deterministic(cache_dir):
+    key1 = compute_cache_key('hello', 'world')
+    cache_module._cache_config = None
+    key2 = compute_cache_key('hello', 'world')
+    assert key1 == key2
+
+
+def test_object_cache_round_trip(cache_dir):
+    obj = {'key': 'value', 'list': [1, 2, 3]}
+    save_object_to_cache('test_key', 'sub', obj)
+    assert restore_object_from_cache('test_key', 'sub') == obj
+
+
+def test_object_cache_miss(cache_dir):
+    assert restore_object_from_cache('nonexistent', 'sub') is None
+
+
+def test_files_cache_round_trip(cache_dir, tmp_path):
+    src_dir = tmp_path / 'src'
+    src_dir.mkdir()
+    (src_dir / 'a.txt').write_text('aaa')
+    (src_dir / 'sub').mkdir()
+    (src_dir / 'sub' / 'b.txt').write_text('bbb')
+
+    save_files_to_cache('fkey', 'fsub', ['a.txt', 'sub/b.txt'], str(src_dir))
+
+    out_dir = tmp_path / 'out'
+    out_dir.mkdir()
+    result = restore_files_from_cache('fkey', 'fsub', str(out_dir))
+    assert result is not None
+    assert (out_dir / 'a.txt').read_text() == 'aaa'
+    assert (out_dir / 'sub' / 'b.txt').read_text() == 'bbb'
+
+
+def test_save_error_cleans_up(cache_dir, tmp_path):
+    """Saving with a nonexistent source file should not leave partial cache."""
+    save_files_to_cache('bad_key', 'fsub', ['nonexistent.txt'], str(tmp_path))
+    assert restore_files_from_cache('bad_key', 'fsub', str(tmp_path)) is None
+
+
+def test_cleanup_removes_oldest(cache_dir):
+    os.environ['ROSIDL_CACHE_MAX_SIZE'] = '100'
+    cache_module._cache_config = None
+
+    sub_dir = cache_dir / 'sub'
+    sub_dir.mkdir()
+
+    old_entry = sub_dir / 'old_key'
+    old_entry.mkdir()
+    (old_entry / 'data.bin').write_bytes(b'x' * 60)
+
+    time.sleep(0.05)
+
+    new_entry = sub_dir / 'new_key'
+    new_entry.mkdir()
+    (new_entry / 'data.bin').write_bytes(b'x' * 60)
+
+    # Total 120 > 100, should remove oldest
+    cleanup_cache_if_needed('sub')
+
+    assert not old_entry.exists()
+    assert new_entry.exists()

--- a/rosidl_parser/test/test_cache.py
+++ b/rosidl_parser/test/test_cache.py
@@ -22,6 +22,7 @@ import rosidl_parser.cache as cache_module
 from rosidl_parser.cache import cleanup_cache_if_needed
 from rosidl_parser.cache import compute_cache_key
 from rosidl_parser.cache import get_cache_config
+from rosidl_parser.cache import get_package_version
 from rosidl_parser.cache import restore_files_from_cache
 from rosidl_parser.cache import restore_object_from_cache
 from rosidl_parser.cache import save_files_to_cache
@@ -206,3 +207,13 @@ def test_idl_file_cache_round_trip(cache_dir):
     assert len(msg_r.constants) == 1
     assert msg_r.constants[0].name == 'MY_CONST'
     assert msg_r.constants[0].value == 42
+
+
+def test_package_version_in_cache_key(cache_dir):
+    version = get_package_version('pytest')
+    assert version != 'unknown'
+    assert '.' in version
+    assert get_package_version('nonexistent_package_xyz') == 'unknown'
+    key1 = compute_cache_key('data', '1.0.0')
+    key2 = compute_cache_key('data', '2.0.0')
+    assert key1 != key2

--- a/rosidl_parser/test/test_cache.py
+++ b/rosidl_parser/test/test_cache.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import pathlib
 import time
 
 import pytest
@@ -136,3 +137,72 @@ def test_cleanup_removes_oldest(cache_dir):
 
     assert not old_entry.exists()
     assert new_entry.exists()
+
+
+def test_idl_file_cache_round_trip(cache_dir):
+    from rosidl_parser.definition import (
+        Array,
+        BasicType,
+        BoundedSequence,
+        BoundedString,
+        Constant,
+        IdlContent,
+        IdlFile,
+        IdlLocator,
+        Include,
+        Member,
+        Message,
+        NamespacedType,
+        Structure,
+        UnboundedSequence,
+        UnboundedString,
+    )
+
+    locator = IdlLocator(pathlib.Path('/base'), pathlib.Path('msg/Test.idl'))
+    content = IdlContent()
+
+    ns_type = NamespacedType(['test_pkg', 'msg'], 'TestMessage')
+    structure = Structure(ns_type, members=[
+        Member(BasicType('int32'), 'field_a'),
+        Member(BasicType('boolean'), 'field_b'),
+        Member(UnboundedString(), 'field_c'),
+        Member(BoundedString(100), 'field_d'),
+        Member(Array(BasicType('double'), 5), 'field_e'),
+        Member(BoundedSequence(BasicType('uint8'), 10), 'field_f'),
+        Member(UnboundedSequence(BasicType('int64')), 'field_g'),
+        Member(NamespacedType(['other_pkg', 'msg'], 'OtherType'), 'field_h'),
+    ])
+    msg = Message(structure)
+    msg.constants = [
+        Constant('MY_CONST', BasicType('int32'), 42),
+    ]
+
+    content.elements.append(Include('other_pkg/msg/OtherType.idl'))
+    content.elements.append(msg)
+
+    idl_file = IdlFile(locator, content)
+
+    save_object_to_cache('idl_key', 'sub', idl_file)
+    restored = restore_object_from_cache('idl_key', 'sub')
+
+    assert restored is not None
+    assert isinstance(restored, IdlFile)
+    assert str(restored.locator.basepath) == '/base'
+    assert str(restored.locator.relative_path) == 'msg/Test.idl'
+    assert len(restored.content.elements) == 2
+    assert isinstance(restored.content.elements[0], Include)
+    assert restored.content.elements[0].locator == 'other_pkg/msg/OtherType.idl'
+    msg_r = restored.content.elements[1]
+    assert isinstance(msg_r, Message)
+    assert msg_r.structure.namespaced_type.name == 'TestMessage'
+    assert len(msg_r.structure.members) == 8
+    assert isinstance(msg_r.structure.members[0].type, BasicType)
+    assert msg_r.structure.members[0].type.typename == 'int32'
+    assert isinstance(msg_r.structure.members[4].type, Array)
+    assert msg_r.structure.members[4].type.size == 5
+    assert isinstance(msg_r.structure.members[5].type, BoundedSequence)
+    assert msg_r.structure.members[5].type.maximum_size == 10
+    assert isinstance(msg_r.structure.members[6].type, UnboundedSequence)
+    assert len(msg_r.constants) == 1
+    assert msg_r.constants[0].name == 'MY_CONST'
+    assert msg_r.constants[0].value == 42

--- a/rosidl_parser/test/test_cache.py
+++ b/rosidl_parser/test/test_cache.py
@@ -217,3 +217,31 @@ def test_package_version_in_cache_key(cache_dir):
     key1 = compute_cache_key('data', '1.0.0')
     key2 = compute_cache_key('data', '2.0.0')
     assert key1 != key2
+
+
+def test_cache_key_changes_with_type_description(cache_dir):
+    """Cache key must change when type_description_info changes."""
+    type_desc_v1 = {
+        'type_description': {
+            'type_name': 'pkg/msg/Foo',
+            'fields': [{'name': 'x', 'type': 'int32'}],
+        },
+        'type_hash': 'RIHS01_aaaa',
+    }
+    type_desc_v2 = {
+        'type_description': {
+            'type_name': 'pkg/msg/Foo',
+            'fields': [
+                {'name': 'x', 'type': 'int32'},
+                {'name': 'y', 'type': 'float64'},
+            ],
+        },
+        'type_hash': 'RIHS01_bbbb',
+    }
+    context = {'package_name': 'pkg', 'generator_name': 'gen'}
+    key1 = compute_cache_key('idl_content', context, type_desc_v1)
+    key2 = compute_cache_key('idl_content', context, type_desc_v2)
+    key_none = compute_cache_key('idl_content', context, None)
+    assert key1 != key2
+    assert key1 != key_none
+    assert key2 != key_none

--- a/rosidl_pycommon/rosidl_pycommon/__init__.py
+++ b/rosidl_pycommon/rosidl_pycommon/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 from io import StringIO
 import json
 import os
@@ -29,10 +30,25 @@ except ImportError:
     em_has_configuration = False
 
 from rosidl_parser.cache import compute_cache_key
+from rosidl_parser.cache import get_package_version
 from rosidl_parser.cache import restore_files_from_cache
 from rosidl_parser.cache import save_files_to_cache
 from rosidl_parser.definition import IdlLocator
 from rosidl_parser.parser import parse_idl_file
+
+
+def _get_caller_package_name() -> Optional[str]:
+    frame = inspect.currentframe()
+    try:
+        # Walk up: _get_caller_package_name -> generate_files -> caller
+        caller = frame.f_back.f_back if frame and frame.f_back else None
+        if caller is None:
+            return None
+        module = caller.f_globals.get('__name__', '')
+        # e.g. 'rosidl_generator_cpp' from 'rosidl_generator_cpp.__init__'
+        return module.split('.')[0] if module else None
+    finally:
+        del frame
 
 
 def convert_camel_case_to_lower_case_underscore(value: str) -> str:
@@ -114,9 +130,12 @@ def generate_files(
         generator_name = pathlib.Path(generator_arguments_file).stem
         if generator_name.endswith('__arguments'):
             generator_name = generator_name[:-len('__arguments')]
+        caller_pkg = _get_caller_package_name()
         cache_context = {
             'package_name': args['package_name'],
             'generator_name': generator_name,
+            'rosidl_parser_version': get_package_version('rosidl_parser'),
+            'generator_version': get_package_version(caller_pkg or generator_name),
             'output_mapping': output_mapping,
         }
         if additional_context:

--- a/rosidl_pycommon/rosidl_pycommon/__init__.py
+++ b/rosidl_pycommon/rosidl_pycommon/__init__.py
@@ -28,6 +28,9 @@ try:
 except ImportError:
     em_has_configuration = False
 
+from rosidl_parser.cache import compute_cache_key
+from rosidl_parser.cache import restore_files_from_cache
+from rosidl_parser.cache import save_files_to_cache
 from rosidl_parser.definition import IdlLocator
 from rosidl_parser.parser import parse_idl_file
 
@@ -72,6 +75,7 @@ def generate_files(
 
     latest_target_timestamp = get_newest_modification_time(args['target_dependencies'])
     generated_files: List[str] = []
+    output_dir = args['output_dir']
 
     type_description_files = {}
     for description_tuple in args.get('type_description_tuples', []):
@@ -102,12 +106,36 @@ def generate_files(
         type_source_file = ros_interface_files.get(type_source_key, locator.get_absolute_path())
         if not keep_case:
             idl_stem = convert_camel_case_to_lower_case_underscore(idl_stem)
+
+        output_mapping = {
+            template_file: os.path.join(str(idl_rel_path.parent), generated_filename % idl_stem)
+            for template_file, generated_filename in mapping.items()
+        }
+        generator_name = pathlib.Path(generator_arguments_file).stem
+        if generator_name.endswith('__arguments'):
+            generator_name = generator_name[:-len('__arguments')]
+        cache_context = {
+            'package_name': args['package_name'],
+            'generator_name': generator_name,
+            'output_mapping': output_mapping,
+        }
+        if additional_context:
+            cache_context.update(additional_context)
+        cache_key = compute_cache_key(
+            locator.get_absolute_path(),
+            *[template_basepath / tf for tf in sorted(mapping.keys())],
+            cache_context
+        )
+        if cache_key:
+            output_files = restore_files_from_cache(cache_key, generator_name, output_dir)
+            if output_files:
+                generated_files.extend(output_files)
+                continue
+
         try:
             idl_file = parse_idl_file(locator)
-            for template_file, generated_filename in mapping.items():
-                generated_file = os.path.join(
-                    args['output_dir'], str(idl_rel_path.parent),
-                    generated_filename % idl_stem)
+            for template_file, rel_generated_file in output_mapping.items():
+                generated_file = os.path.join(output_dir, rel_generated_file)
                 generated_files.append(generated_file)
                 data = {
                     'package_name': args['package_name'],
@@ -123,6 +151,10 @@ def generate_files(
                     generated_file, minimum_timestamp=latest_target_timestamp,
                     template_basepath=template_basepath,
                     post_process_callback=post_process_callback)
+            if cache_key:
+                save_files_to_cache(
+                    cache_key, generator_name,
+                    list(output_mapping.values()), output_dir)
         except Exception as e:
             print(
                 'Error processing idl file: ' +

--- a/rosidl_pycommon/rosidl_pycommon/__init__.py
+++ b/rosidl_pycommon/rosidl_pycommon/__init__.py
@@ -143,7 +143,8 @@ def generate_files(
         cache_key = compute_cache_key(
             locator.get_absolute_path(),
             *[template_basepath / tf for tf in sorted(mapping.keys())],
-            cache_context
+            cache_context,
+            type_description_info
         )
         if cache_key:
             output_files = restore_files_from_cache(cache_key, generator_name, output_dir)


### PR DESCRIPTION
## Description

Add a cache mechanism for rosidl code generation to speed up rebuilds when IDL files and templates have not changed.
This caches two stages of the rosidl pipeline (see #931 for motivation and benchmarks):

1. IDL parsing results (`rosidl_parser/parser.py`): Caches the `IdlFile` object returned by `parse_idl_file()`. 
2. Generated code files (`rosidl_pycommon/__init__.py`): Caches the output files produced by each generator (e.g., `rosidl_generator_py`, `rosidl_generator_cpp`). 

The cache is opt-in and disabled by default. It is only activated when `ROSIDL_CACHE_DIR` or  `ROSIDL_CACHE_CONFIG` is set.

### Is this user-facing behavior change?

Users can set the `ROSIDL_CACHE_DIR` environment variable to enable caching of rosidl code generation, which can speed up incremental builds.

### Did you use Generative AI?

Claude Opus 4.6 was used for code review feedback.

### Additional Information
