### PR TITLE
`std::byte` take 2

### DIFF
--- a/rosidl_generator_cpp/resource/idl__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/idl__struct.hpp.em
@@ -33,6 +33,7 @@ include_directives = set()
 #include <string>
 #include <vector>
 
+#include "rosidl_runtime_cpp/byte_helpers.hpp"
 #include "rosidl_runtime_cpp/bounded_vector.hpp"
 #include "rosidl_runtime_cpp/message_initialization.hpp"
 

--- a/rosidl_generator_cpp/resource/msg__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.em
@@ -241,11 +241,13 @@ non_defaulted_zero_initialized_members = [
 @[ else]@
   static constexpr @(MSG_TYPE_TO_CPP[constant.type.typename]) @(constant.name) =
 @[  if isinstance(constant.type, BasicType)]@
-@[   if constant.type.typename in (*INTEGER_TYPES, *CHARACTER_TYPES, BOOLEAN_TYPE, OCTET_TYPE)]@
+@[   if constant.type.typename in (*INTEGER_TYPES, *CHARACTER_TYPES, BOOLEAN_TYPE)]@
     @(int(constant.value))@
 @[    if constant.type.typename in UNSIGNED_INTEGER_TYPES]@
 u@
 @[    end if]@
+@[   elif constant.type.typename == OCTET_TYPE]@
+    std::byte{@(constant.value)}@
 @[   elif constant.type.typename == 'float']@
     @(constant.value)f@
 @[   else]@

--- a/rosidl_generator_cpp/resource/msg__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.em
@@ -4,7 +4,7 @@ from rosidl_generator_cpp import create_init_alloc_and_member_lists
 from rosidl_generator_cpp import escape_string
 from rosidl_generator_cpp import escape_wstring
 from rosidl_generator_cpp import msg_type_to_cpp
-from rosidl_generator_cpp import MSG_TYPE_TO_CPP
+from rosidl_generator_cpp import MSG_TYPE_TO_CPP_CONVERSION
 from rosidl_generator_cpp import generate_zero_string
 from rosidl_generator_cpp import generate_default_string
 from rosidl_parser.definition import AbstractNestedType
@@ -235,11 +235,11 @@ non_defaulted_zero_initialized_members = [
 #endif
 @[ end if]@
 @[ if isinstance(constant.type, AbstractString)]@
-  static const @(MSG_TYPE_TO_CPP['string']) @(constant.name);
+  static const @(MSG_TYPE_TO_CPP_CONVERSION['string']) @(constant.name);
 @[ elif isinstance(constant.type, AbstractWString)]@
-  static const @(MSG_TYPE_TO_CPP['wstring']) @(constant.name);
+  static const @(MSG_TYPE_TO_CPP_CONVERSION['wstring']) @(constant.name);
 @[ else]@
-  static constexpr @(MSG_TYPE_TO_CPP[constant.type.typename]) @(constant.name) =
+  static constexpr @(MSG_TYPE_TO_CPP_CONVERSION[constant.type.typename]) @(constant.name) =
 @[  if isinstance(constant.type, BasicType)]@
 @[   if constant.type.typename in (*INTEGER_TYPES, *CHARACTER_TYPES, BOOLEAN_TYPE)]@
     @(int(constant.value))@
@@ -338,17 +338,17 @@ using @(message.structure.namespaced_type.name) =
 @[ end if]@
 @[ if isinstance(c.type, AbstractString)]@
 template<typename ContainerAllocator>
-const @(MSG_TYPE_TO_CPP['string'])
+const @(MSG_TYPE_TO_CPP_CONVERSION['string'])
 @(message.structure.namespaced_type.name)_<ContainerAllocator>::@(c.name) = "@(escape_string(c.value))";
 @[ elif isinstance(c.type, AbstractWString)]@
 template<typename ContainerAllocator>
-const @(MSG_TYPE_TO_CPP['wstring'])
+const @(MSG_TYPE_TO_CPP_CONVERSION['wstring'])
 @(message.structure.namespaced_type.name)_<ContainerAllocator>::@(c.name) = u"@(escape_wstring(c.value))";
 @[ else ]@
 #if __cplusplus < 201703L
 // static constexpr member variable definitions are only needed in C++14 and below, deprecated in C++17
 template<typename ContainerAllocator>
-constexpr @(MSG_TYPE_TO_CPP[c.type.typename]) @(message.structure.namespaced_type.name)_<ContainerAllocator>::@(c.name);
+constexpr @(MSG_TYPE_TO_CPP_CONVERSION[c.type.typename]) @(message.structure.namespaced_type.name)_<ContainerAllocator>::@(c.name);
 #endif  // __cplusplus < 201703L
 @[ end if]@
 @[ if c.name in msvc_common_macros]@

--- a/rosidl_generator_cpp/resource/msg__traits.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__traits.hpp.em
@@ -93,8 +93,10 @@ inline void to_flow_style_yaml(
   {
 @[    if isinstance(member.type, BasicType)]@
     out << "@(member.name): ";
-@[      if member.type.typename in ('octet', 'char', 'wchar')]@
+@[      if member.type.typename in ('char', 'wchar')]@
     rosidl_generator_traits::character_value_to_yaml(msg.@(member.name), out);
+@[      elif member.type.typename == 'octet']@
+    rosidl_generator_traits::value_to_yaml(static_cast<std::byte>(msg.@(member.name)), out);
 @[      else]@
     rosidl_generator_traits::value_to_yaml(msg.@(member.name), out);
 @[      end if]@
@@ -112,8 +114,10 @@ inline void to_flow_style_yaml(
       size_t pending_items = msg.@(member.name).size();
       for (auto item : msg.@(member.name)) {
 @[      if isinstance(member.type.value_type, BasicType)]@
-@[        if member.type.value_type.typename in ('octet', 'char', 'wchar')]@
+@[        if member.type.value_type.typename in ('char', 'wchar')]@
         rosidl_generator_traits::character_value_to_yaml(item, out);
+@[        elif member.type.value_type.typename == 'octet']@
+        rosidl_generator_traits::value_to_yaml(static_cast<std::byte>(item), out);
 @[        else]@
         rosidl_generator_traits::value_to_yaml(item, out);
 @[        end if]@
@@ -158,8 +162,10 @@ inline void to_block_style_yaml(
     }
 @[    if isinstance(member.type, BasicType)]@
     out << "@(member.name): ";
-@[      if member.type.typename in ('octet', 'char', 'wchar')]@
+@[      if member.type.typename in ('char', 'wchar')]@
     rosidl_generator_traits::character_value_to_yaml(msg.@(member.name), out);
+@[      elif member.type.typename == 'octet']@
+    rosidl_generator_traits::value_to_yaml(static_cast<std::byte>(msg.@(member.name)), out);
 @[      else]@
     rosidl_generator_traits::value_to_yaml(msg.@(member.name), out);
 @[      end if]@
@@ -182,8 +188,10 @@ inline void to_block_style_yaml(
         }
 @[      if isinstance(member.type.value_type, BasicType)]@
         out << "- ";
-@[        if member.type.value_type.typename in ('octet', 'char', 'wchar')]@
+@[        if member.type.value_type.typename in ('char', 'wchar')]@
         rosidl_generator_traits::character_value_to_yaml(item, out);
+@[        elif member.type.value_type.typename == 'octet']@
+        rosidl_generator_traits::value_to_yaml(static_cast<std::byte>(item), out);
 @[        else]@
         rosidl_generator_traits::value_to_yaml(item, out);
 @[        end if]@

--- a/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
+++ b/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
@@ -55,7 +55,7 @@ def prefix_with_bom_if_necessary(content: str) -> str:
 
 MSG_TYPE_TO_CPP = {
     'boolean': 'bool',
-    'octet': 'unsigned char',  # TODO change to std::byte with C++17
+    'octet': 'rosidl_runtime_cpp::ByteConverter',  # TODO change to std::byte with C++17
     'char': 'unsigned char',  # TODO change to char8_t with C++20
     'wchar': 'char16_t',
     'float': 'float',

--- a/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
+++ b/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
@@ -55,7 +55,7 @@ def prefix_with_bom_if_necessary(content: str) -> str:
 
 MSG_TYPE_TO_CPP = {
     'boolean': 'bool',
-    'octet': 'rosidl_runtime_cpp::ByteConverter',  # TODO change to std::byte with C++17
+    'octet': 'std::byte',
     'char': 'unsigned char',  # TODO change to char8_t with C++20
     'wchar': 'char16_t',
     'float': 'float',
@@ -75,6 +75,9 @@ MSG_TYPE_TO_CPP = {
                'std::allocator_traits<ContainerAllocator>::template rebind_alloc<char16_t>>',
 }
 
+MSG_TYPE_TO_CPP_CONVERSION = MSG_TYPE_TO_CPP
+MSG_TYPE_TO_CPP_CONVERSION['octet'] = 'rosidl_runtime_cpp::ByteConverter'
+
 
 def msg_type_only_to_cpp(type_):
     """
@@ -89,11 +92,11 @@ def msg_type_only_to_cpp(type_):
     if isinstance(type_, AbstractNestedType):
         type_ = type_.value_type
     if isinstance(type_, BasicType):
-        cpp_type = MSG_TYPE_TO_CPP[type_.typename]
+        cpp_type = MSG_TYPE_TO_CPP_CONVERSION[type_.typename]
     elif isinstance(type_, AbstractString):
-        cpp_type = MSG_TYPE_TO_CPP['string']
+        cpp_type = MSG_TYPE_TO_CPP_CONVERSION['string']
     elif isinstance(type_, AbstractWString):
-        cpp_type = MSG_TYPE_TO_CPP['wstring']
+        cpp_type = MSG_TYPE_TO_CPP_CONVERSION['wstring']
     elif isinstance(type_, NamespacedType):
         typename = '::'.join(type_.namespaced_name())
         cpp_type = typename + '_<ContainerAllocator>'
@@ -196,10 +199,11 @@ def primitive_value_to_cpp(type_, value):
     if type_.typename == 'boolean':
         return 'true' if value else 'false'
 
-    if type_.typename in [
-        'char', 'octet'
-    ]:
+    if type_.typename == 'char':
         return f'static_cast<unsigned char>({value})'
+
+    if type_.typename == 'octet':
+        return f'std::byte{{{value}}}'
 
     if type_.typename in [
         'short', 'unsigned short',

--- a/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
+++ b/rosidl_generator_cpp/rosidl_generator_cpp/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from ast import literal_eval
+from copy import copy
 from typing import List
 
 from rosidl_parser.definition import AbstractGenericString
@@ -75,7 +76,7 @@ MSG_TYPE_TO_CPP = {
                'std::allocator_traits<ContainerAllocator>::template rebind_alloc<char16_t>>',
 }
 
-MSG_TYPE_TO_CPP_CONVERSION = MSG_TYPE_TO_CPP
+MSG_TYPE_TO_CPP_CONVERSION = copy(MSG_TYPE_TO_CPP)
 MSG_TYPE_TO_CPP_CONVERSION['octet'] = 'rosidl_runtime_cpp::ByteConverter'
 
 

--- a/rosidl_generator_tests/test/rosidl_generator_cpp/test_interfaces.cpp
+++ b/rosidl_generator_tests/test/rosidl_generator_cpp/test_interfaces.cpp
@@ -168,7 +168,7 @@ void test_message_basic_types(rosidl_generator_tests::msg::BasicTypes message)
 #ifdef __linux__
 #pragma GCC diagnostic pop
 #endif
-  TEST_BASIC_TYPE_FIELD_ASSIGNMENT(message, byte_value, 0, 255)
+  TEST_BASIC_TYPE_FIELD_ASSIGNMENT(message, byte_value, std::byte{0}, std::byte{255})
   TEST_BASIC_TYPE_FIELD_ASSIGNMENT(message, char_value, 0, UINT8_MAX)
   TEST_BASIC_TYPE_FIELD_ASSIGNMENT(message, float32_value, FLT_MIN, FLT_MAX)
   TEST_BASIC_TYPE_FIELD_ASSIGNMENT(message, float64_value, DBL_MIN, DBL_MAX)
@@ -487,7 +487,7 @@ TEST(Test_messages, constants_assign) {
 TEST(Test_messages, defaults) {
   rosidl_generator_tests::msg::Defaults message;
   TEST_BASIC_TYPE_FIELD_ASSIGNMENT(message, bool_value, true, false);
-  TEST_BASIC_TYPE_FIELD_ASSIGNMENT(message, byte_value, 50, 255);
+  TEST_BASIC_TYPE_FIELD_ASSIGNMENT(message, byte_value, std::byte{50}, std::byte{255});
   TEST_BASIC_TYPE_FIELD_ASSIGNMENT(message, char_value, 100, UINT8_MAX);
   TEST_BASIC_TYPE_FIELD_ASSIGNMENT(message, float32_value, 1.125f, FLT_MAX);
   TEST_BASIC_TYPE_FIELD_ASSIGNMENT(message, float64_value, 1.125, DBL_MAX);

--- a/rosidl_generator_tests/test/rosidl_generator_cpp/test_msg_builder.cpp
+++ b/rosidl_generator_tests/test/rosidl_generator_cpp/test_msg_builder.cpp
@@ -24,7 +24,7 @@ TEST(Test_msg_initialization, build) {
   ::rosidl_generator_tests::msg::BasicTypes basic =
     ::rosidl_generator_tests::build<::rosidl_generator_tests::msg::BasicTypes>()
     .bool_value(true)
-    .byte_value(5)
+    .byte_value(std::byte{5})
     .char_value(10)
     .float32_value(0.1125f)
     .float64_value(0.01125)
@@ -57,7 +57,7 @@ TEST(Test_msg_initialization, build) {
   {
     rosidl_generator_tests::build<rosidl_generator_tests::msg::BasicTypes>()
     .bool_value(false)
-    .byte_value(10)
+    .byte_value(std::byte{10})
     .char_value(20)
     .float32_value(0.225f)
     .float64_value(0.0225)
@@ -90,7 +90,7 @@ TEST(Test_msg_initialization, build) {
   rosidl_generator_tests::msg::Arrays arrays =
     rosidl_generator_tests::build<rosidl_generator_tests::msg::Arrays>()
     .bool_values({{true, false, true}})
-    .byte_values({{5, 10, 5}})
+    .byte_values({{std::byte{5}, std::byte{10}, std::byte{5}}})
     .char_values({{10, 20, 10}})
     .float32_values({{0.1125f, 0.225f, 0.1125f}})
     .float64_values({{0.01125, 0.0225, 0.01125}})
@@ -107,7 +107,7 @@ TEST(Test_msg_initialization, build) {
     .constants_values({{constants, constants, constants}})
     .defaults_values({{defaults, defaults, defaults}})
     .bool_values_default({{false, true, false}})
-    .byte_values_default({{10, 5, 10}})
+    .byte_values_default({{std::byte{10}, std::byte{5}, std::byte{10}}})
     .char_values_default({{20, 10, 20}})
     .float32_values_default({{0.225f, 0.1125f, 0.225f}})
     .float64_values_default({{0.0225, 0.01125, 0.0225}})

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/byte_helpers.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/byte_helpers.hpp
@@ -104,12 +104,14 @@ struct ByteVector : public std::vector<ByteConverter, Alloc>
     return *reinterpret_cast<const std::vector<std::byte> *>(this);
   }
 
-  [[deprecated("Implicit conversion to std::vector<unsigned char> is deprecated use as std::vector<std::byte>")]]
+  [[deprecated("Implicit conversion to std::vector<unsigned char> is deprecated"
+               "use as std::vector<std::byte>")]]
   operator std::vector<unsigned char> &() {
     return *reinterpret_cast<std::vector<unsigned char> *>(this);
   }
 
-  [[deprecated("Implicit conversion to std::vector<unsigned char> is deprecated use as std::vector<std::byte>")]]
+  [[deprecated("Implicit conversion to std::vector<unsigned char> is deprecated"
+               "use as std::vector<std::byte>")]]
   operator const std::vector<unsigned char> &() const {
     return *reinterpret_cast<const std::vector<unsigned char> *>(this);
   }

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/byte_helpers.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/byte_helpers.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 Open Source Robotics Foundation, Inc.
+// Copyright 2026 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -60,6 +60,11 @@ struct ByteConverter
 
   constexpr operator std::byte() const noexcept {return value;}
 
+  // template conversion to any integral type
+  template<typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  [[deprecated("Using as integral type is deprecated use as std::byte")]]
+  constexpr operator T() const noexcept {return static_cast<T>(value);}
+
   constexpr bool operator==(const ByteConverter & other) const noexcept
   {
     return value == other.value;
@@ -71,7 +76,6 @@ struct ByteConverter
 };
 
 // Equality converted
-
 template<typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
 constexpr bool operator==(const ByteConverter & lhs, T rhs) noexcept
 {
@@ -89,7 +93,6 @@ constexpr bool operator!=(T lhs, const ByteConverter & rhs) noexcept {return !(l
 
 
 // Converter for Vectors
-
 template<typename Alloc = std::allocator<ByteConverter>>
 struct ByteVector : public std::vector<ByteConverter, Alloc>
 {
@@ -105,20 +108,32 @@ struct ByteVector : public std::vector<ByteConverter, Alloc>
   }
 
   [[deprecated("Implicit conversion to std::vector<unsigned char> is deprecated"
-               "use as std::vector<std::byte>")]]
+               " use as std::vector<std::byte>")]]
   operator std::vector<unsigned char> &() {
     return *reinterpret_cast<std::vector<unsigned char> *>(this);
   }
 
   [[deprecated("Implicit conversion to std::vector<unsigned char> is deprecated"
-               "use as std::vector<std::byte>")]]
+               " use as std::vector<std::byte>")]]
   operator const std::vector<unsigned char> &() const {
     return *reinterpret_cast<const std::vector<unsigned char> *>(this);
+  }
+
+  // template conversion to any integral vector
+  template<typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  [[deprecated("Using as template std::vector<integtral type> is deprecated"
+               " use as std::vector<std::byte>")]]
+  operator std::vector<T>() const {
+    std::vector<T> out;
+    out.reserve(this->size());
+    for (auto & b : *this) {
+      out.push_back(static_cast<T>(b));
+    }
+    return out;
   }
 };
 
 // Converter for Array
-
 template<size_t N>
 struct ByteArray : public std::array<ByteConverter, N>
 {
@@ -141,10 +156,21 @@ struct ByteArray : public std::array<ByteConverter, N>
   operator const std::array<unsigned char, N> &() const {
     return reinterpret_cast<const std::array<unsigned char, N> &>(*this);
   }
+
+  // template conversion to any integral array
+  template<typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  [[deprecated("Using as template std::array<intregral type> is deprecated"
+               " use as std::array<std::byte>")]]
+  operator std::array<T, N>() const {
+    std::array<T, N> out{};
+    for (size_t i = 0; i < N; ++i) {
+      out[i] = static_cast<T>((*this)[i]);
+    }
+    return out;
+  }
 };
 
 // Container Conversion equality checks
-
 template<typename ContainerA, typename ContainerB,
   typename = std::enable_if_t<
     (std::is_same_v<typename ContainerA::value_type, ByteConverter>||

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/byte_helpers.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/byte_helpers.hpp
@@ -1,0 +1,167 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+#include <array>
+#include <type_traits>
+#include <algorithm>
+#include <memory>
+
+#ifndef ROSIDL_RUNTIME_CPP__BYTE_HELPERS_HPP_
+#define ROSIDL_RUNTIME_CPP__BYTE_HELPERS_HPP_
+
+namespace rosidl_runtime_cpp
+{
+
+struct ByteConverter
+{
+  std::byte value;
+
+  constexpr ByteConverter() noexcept
+  : value(std::byte{0}) {}
+  constexpr ByteConverter(std::byte b) noexcept  // NOLINT(runtime/explicit)
+  : value(b) {}
+
+  template<typename T,
+    typename = std::enable_if_t<std::is_integral_v<T>>>
+  [[deprecated("Direct numeric assignment is deprecated; use std::byte")]]
+  constexpr ByteConverter(T numeric_value) noexcept  // NOLINT(runtime/explicit)
+  : value(static_cast<std::byte>(numeric_value)) {}
+
+  ByteConverter & operator=(std::byte b) noexcept
+  {
+    value = b;
+    return *this;
+  }
+
+  template<typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  [[deprecated("Assignment from numeric is deprecated; use 'std::byte' instead.")]]
+  ByteConverter & operator=(T c)
+  {
+    value = static_cast<std::byte>(c);
+    return *this;
+  }
+
+  [[deprecated("Reading as 'unsigned char' is deprecated; use 'std::byte' instead.")]]
+  constexpr operator unsigned char() const noexcept {return static_cast<unsigned char>(value);}
+
+  constexpr operator std::byte() const noexcept {return value;}
+
+  constexpr bool operator==(const ByteConverter & other) const noexcept
+  {
+    return value == other.value;
+  }
+  constexpr bool operator!=(const ByteConverter & other) const noexcept
+  {
+    return value != other.value;
+  }
+};
+
+// Equality converted
+
+template<typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+constexpr bool operator==(const ByteConverter & lhs, T rhs) noexcept
+{
+  return static_cast<unsigned char>(lhs.value) == static_cast<unsigned char>(rhs);
+}
+
+template<typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+constexpr bool operator==(T lhs, const ByteConverter & rhs) noexcept {return rhs == lhs;}
+
+template<typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+constexpr bool operator!=(const ByteConverter & lhs, T rhs) noexcept {return !(lhs == rhs);}
+
+template<typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+constexpr bool operator!=(T lhs, const ByteConverter & rhs) noexcept {return !(lhs == rhs);}
+
+
+// Converter for Vectors
+
+template<typename Alloc = std::allocator<ByteConverter>>
+struct ByteVector : public std::vector<ByteConverter, Alloc>
+{
+  using Base = std::vector<ByteConverter, Alloc>;
+  using Base::Base;
+
+  operator std::vector<std::byte> &() {
+    return *reinterpret_cast<std::vector<std::byte> *>(this);
+  }
+
+  operator const std::vector<std::byte> &() const {
+    return *reinterpret_cast<const std::vector<std::byte> *>(this);
+  }
+
+  [[deprecated("Implicit conversion to std::vector<unsigned char> is deprecated use as std::vector<std::byte>")]]
+  operator std::vector<unsigned char> &() {
+    return *reinterpret_cast<std::vector<unsigned char> *>(this);
+  }
+
+  [[deprecated("Implicit conversion to std::vector<unsigned char> is deprecated use as std::vector<std::byte>")]]
+  operator const std::vector<unsigned char> &() const {
+    return *reinterpret_cast<const std::vector<unsigned char> *>(this);
+  }
+};
+
+// Converter for Array
+
+template<size_t N>
+struct ByteArray : public std::array<ByteConverter, N>
+{
+  using Base = std::array<ByteConverter, N>;
+
+  operator std::array<std::byte, N> &() {
+    return reinterpret_cast<std::array<std::byte, N> &>(*this);
+  }
+
+  operator const std::array<std::byte, N> &() const {
+    return reinterpret_cast<const std::array<std::byte, N> &>(*this);
+  }
+
+  [[deprecated("Using as std::array<unsigned char> is deprecated use as std::array<std::byte>")]]
+  operator std::array<unsigned char, N> &() {
+    return reinterpret_cast<std::array<unsigned char, N> &>(*this);
+  }
+
+  [[deprecated("Using as std::array<unsigned char> is deprecated use as std::array<std::byte>")]]
+  operator const std::array<unsigned char, N> &() const {
+    return reinterpret_cast<const std::array<unsigned char, N> &>(*this);
+  }
+};
+
+// Container Conversion equality checks
+
+template<typename ContainerA, typename ContainerB,
+  typename = std::enable_if_t<
+    (std::is_same_v<typename ContainerA::value_type, ByteConverter>||
+    std::is_same_v<typename ContainerB::value_type, ByteConverter>) &&
+    !std::is_integral_v<ContainerA>&& !std::is_integral_v<ContainerB>
+  >>
+bool operator==(const ContainerA & lhs, const ContainerB & rhs)
+{
+  if (lhs.size() != rhs.size()) {return false;}
+  return std::equal(lhs.begin(), lhs.end(), rhs.begin());
+}
+
+template<typename ContainerA, typename ContainerB,
+  typename = std::enable_if_t<
+    (std::is_same_v<typename ContainerA::value_type, ByteConverter>||
+    std::is_same_v<typename ContainerB::value_type, ByteConverter>)
+  >>
+bool operator!=(const ContainerA & lhs, const ContainerB & rhs) {return !(lhs == rhs);}
+
+}  // namespace rosidl_runtime_cpp
+
+#endif  // ROSIDL_RUNTIME_CPP__BYTE_HELPERS_HPP_

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/traits.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/traits.hpp
@@ -38,6 +38,11 @@ inline void character_value_to_yaml(unsigned char value, std::ostream & out)
   out.flags(flags);
 }
 
+inline void value_to_yaml(std::byte value, std::ostream & out)
+{
+  character_value_to_yaml(std::to_integer<unsigned char>(value), out);
+}
+
 inline void character_value_to_yaml(char16_t value, std::ostream & out)
 {
   auto flags = out.flags();

--- a/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
@@ -75,9 +75,9 @@ def is_vector_bool(member):
 @[for member in message.structure.members]@
 @[  if isinstance(member.type, AbstractNestedType)]@
 @{
-from rosidl_generator_cpp import  MSG_TYPE_TO_CPP
+from rosidl_generator_cpp import  MSG_TYPE_TO_CPP_CONVERSION
 if isinstance(member.type.value_type, BasicType):
-    type_ = MSG_TYPE_TO_CPP[member.type.value_type.typename]
+    type_ = MSG_TYPE_TO_CPP_CONVERSION[member.type.value_type.typename]
 elif isinstance(member.type.value_type, AbstractString):
     type_ = 'std::string'
 elif isinstance(member.type.value_type, AbstractWString):

--- a/rosidl_typesupport_introspection_tests/test/introspection_libraries_under_test.hpp
+++ b/rosidl_typesupport_introspection_tests/test/introspection_libraries_under_test.hpp
@@ -933,7 +933,7 @@ struct Example<rosidl_typesupport_introspection_tests::msg::BoundedSequences>
     auto message =
       std::make_unique<rosidl_typesupport_introspection_tests::msg::BoundedSequences>();
     message->bool_values.push_back(true);
-    message->byte_values.push_back(0x1B);
+    message->byte_values.push_back(std::byte{0x1B});
     message->char_values.push_back('z');
     message->float32_values.push_back(12.34f);
     message->float64_values.push_back(1.234);
@@ -1027,7 +1027,7 @@ struct Example<rosidl_typesupport_introspection_tests::msg::UnboundedSequences>
     auto message =
       std::make_unique<rosidl_typesupport_introspection_tests::msg::UnboundedSequences>();
     message->bool_values.push_back(true);
-    message->byte_values.push_back(0x1B);
+    message->byte_values.push_back(std::byte{0x1B});
     message->char_values.push_back('z');
     message->float32_values.push_back(12.34f);
     message->float64_values.push_back(1.234);
@@ -1079,7 +1079,7 @@ struct Example<rosidl_typesupport_introspection_tests::srv::Arrays>
     using MessageT =
       rosidl_typesupport_introspection_tests::srv::Arrays::Response;
     auto message = std::make_unique<MessageT>();
-    message->byte_values[1] = 0xAB;
+    message->byte_values[1] = std::byte{0xAB};
     message->char_values[0] = 'b';
     message->int8_values[2] = 123;
     return message;
@@ -1107,7 +1107,7 @@ struct Example<rosidl_typesupport_introspection_tests::srv::BasicTypes>
       rosidl_typesupport_introspection_tests::srv::BasicTypes::Response;
     auto message = std::make_unique<MessageT>();
     message->bool_value = true;
-    message->byte_value = 0xAB;
+    message->byte_value = std::byte{0xAB};
     message->float64_value = -1.234;
     message->string_value = "bar";
     return message;


### PR DESCRIPTION
## Description

Fixes TODO: To migrate to `std::byte`

### Is this user-facing behavior change?

Yes this will emits lots of deprecation warnings but should be compile compatible.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
