### PR TITLE
Add rosidl_buffer for native Buffer type support

### DIFF
--- a/rosidl_buffer/CMakeLists.txt
+++ b/rosidl_buffer/CMakeLists.txt
@@ -1,0 +1,57 @@
+cmake_minimum_required(VERSION 3.5)
+project(rosidl_buffer)
+
+# Default to C++17
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# Find dependencies
+find_package(ament_cmake REQUIRED)
+
+add_library(${PROJECT_NAME}
+  src/c_helpers.cpp
+)
+
+target_include_directories(${PROJECT_NAME} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
+)
+
+# Install headers
+install(
+  DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
+)
+
+# Install library target
+install(
+  TARGETS ${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include/${PROJECT_NAME}
+)
+
+# Export modern CMake targets
+ament_export_targets(${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_gtest REQUIRED)
+
+  ament_add_gtest(test_buffer test/test_buffer.cpp)
+  if(TARGET test_buffer)
+    target_link_libraries(test_buffer ${PROJECT_NAME})
+  endif()
+endif()
+
+ament_package()

--- a/rosidl_buffer/include/rosidl_buffer/buffer.hpp
+++ b/rosidl_buffer/include/rosidl_buffer/buffer.hpp
@@ -1,0 +1,428 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_BUFFER__BUFFER_HPP_
+#define ROSIDL_BUFFER__BUFFER_HPP_
+
+#include <algorithm>
+#include <initializer_list>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "rosidl_buffer/buffer_impl_base.hpp"
+#include "rosidl_buffer/cpu_buffer_impl.hpp"
+
+namespace rosidl
+{
+
+/// Buffer<T> provides a drop-in replacement for std::vector<T> with support
+/// for vendor-specific memory backends (CPU, GPU, etc.).
+///
+/// For CPU backends, it provides implicit conversion to std::vector<T>&
+/// for seamless backward compatibility. For non-CPU backends, direct access
+/// throws exceptions, requiring explicit conversion via to_vector().
+template<typename T, typename Allocator = std::allocator<T>>
+class Buffer
+{
+public:
+  // Type aliases for std::vector compatibility
+  using value_type = T;
+  using allocator_type = Allocator;
+  using size_type = size_t;
+  using difference_type = std::ptrdiff_t;
+  using reference = T &;
+  using const_reference = const T &;
+  using pointer = T *;
+  using const_pointer = const T *;
+  using iterator = T *;
+  using const_iterator = const T *;
+
+  /// Default constructor creates CPU buffer
+  Buffer()
+  : backend_type_("cpu"),
+    impl_(std::make_unique<CpuBufferImpl<T>>())
+  {
+  }
+
+  /// Construct with initial size (CPU backend)
+  explicit Buffer(size_t count)
+  : backend_type_("cpu"),
+    impl_(std::make_unique<CpuBufferImpl<T>>())
+  {
+    get_cpu_impl()->get_storage().resize(count);
+  }
+
+  /// Construct with initial size and value (CPU backend)
+  Buffer(size_t count, const T & value)
+  : backend_type_("cpu"),
+    impl_(std::make_unique<CpuBufferImpl<T>>())
+  {
+    get_cpu_impl()->get_storage().assign(count, value);
+  }
+
+  /// Construct from std::vector (copy) - for backward compatibility
+  Buffer(const std::vector<T> & vec)  // NOLINT(runtime/explicit) - intentionally implicit
+  : backend_type_("cpu"),
+    impl_(std::make_unique<CpuBufferImpl<T>>())
+  {
+    get_cpu_impl()->get_storage() = vec;
+  }
+
+  /// Construct from std::vector (move) - for backward compatibility
+  Buffer(std::vector<T> && vec)  // NOLINT(runtime/explicit) - intentionally implicit
+  : backend_type_("cpu"),
+    impl_(std::make_unique<CpuBufferImpl<T>>())
+  {
+    get_cpu_impl()->get_storage() = std::move(vec);
+  }
+
+  /// Construct from initializer list - for backward compatibility
+  Buffer(std::initializer_list<T> init)
+  : backend_type_("cpu"),
+    impl_(std::make_unique<CpuBufferImpl<T>>())
+  {
+    get_cpu_impl()->get_storage() = init;
+  }
+
+  /// Copy constructor (deep copy via clone())
+  Buffer(const Buffer & other)
+  : backend_type_(other.backend_type_),
+    impl_(other.impl_ ? other.impl_->clone() : nullptr)
+  {
+  }
+
+  /// Move constructor
+  Buffer(Buffer && other) noexcept
+  : backend_type_(std::move(other.backend_type_)),
+    impl_(std::move(other.impl_))
+  {
+  }
+
+  /// Copy assignment (deep copy via clone())
+  Buffer & operator=(const Buffer & other)
+  {
+    if (this != &other) {
+      backend_type_ = other.backend_type_;
+      impl_ = other.impl_ ? other.impl_->clone() : nullptr;
+    }
+    return *this;
+  }
+
+  /// Move assignment
+  Buffer & operator=(Buffer && other) noexcept
+  {
+    if (this != &other) {
+      backend_type_ = std::move(other.backend_type_);
+      impl_ = std::move(other.impl_);
+    }
+    return *this;
+  }
+
+  /// Assignment from initializer list - for backward compatibility
+  /// This must come before vector assignment to resolve ambiguity with {{...}} syntax
+  Buffer & operator=(std::initializer_list<T> init)
+  {
+    backend_type_ = "cpu";
+    impl_ = std::make_unique<CpuBufferImpl<T>>();
+    get_cpu_impl()->get_storage() = init;
+    return *this;
+  }
+
+  /// Assignment from std::vector (copy) - for backward compatibility
+  /// Uses SFINAE to avoid ambiguity with initializer lists
+  template<typename U = std::vector<T>,
+    typename std::enable_if<std::is_same<U, std::vector<T>>::value, int>::type = 0>
+  Buffer & operator=(const U & vec)
+  {
+    backend_type_ = "cpu";
+    impl_ = std::make_unique<CpuBufferImpl<T>>();
+    get_cpu_impl()->get_storage() = vec;
+    return *this;
+  }
+
+  /// Assignment from std::vector (move) - for backward compatibility
+  /// Uses SFINAE to avoid ambiguity with initializer lists
+  template<typename U = std::vector<T>,
+    typename std::enable_if<std::is_same<U, std::vector<T>>::value, int>::type = 0>
+  Buffer & operator=(U && vec)
+  {
+    backend_type_ = "cpu";
+    impl_ = std::make_unique<CpuBufferImpl<T>>();
+    get_cpu_impl()->get_storage() = std::move(vec);
+    return *this;
+  }
+
+  // ========== Element Access (CPU only) ==========
+
+  /// Access element at position (CPU only)
+  reference operator[](size_t pos)
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage()[pos];
+  }
+
+  const_reference operator[](size_t pos) const
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage()[pos];
+  }
+
+  /// Access element with bounds checking (CPU only)
+  reference at(size_t pos)
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage().at(pos);
+  }
+
+  const_reference at(size_t pos) const
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage().at(pos);
+  }
+
+  /// Access first element (CPU only)
+  reference front()
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage().front();
+  }
+
+  const_reference front() const
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage().front();
+  }
+
+  /// Access last element (CPU only)
+  reference back()
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage().back();
+  }
+
+  const_reference back() const
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage().back();
+  }
+
+  /// Get pointer to data (CPU only)
+  pointer data()
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage().data();
+  }
+
+  const_pointer data() const
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage().data();
+  }
+
+  // ========== Iterators (CPU only) ==========
+
+  iterator begin()
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage().data();
+  }
+
+  const_iterator begin() const
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage().data();
+  }
+
+  const_iterator cbegin() const
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage().data();
+  }
+
+  iterator end()
+  {
+    throw_if_not_cpu_backend();
+    auto & s = get_cpu_impl()->get_storage();
+    return s.data() + s.size();
+  }
+
+  const_iterator end() const
+  {
+    throw_if_not_cpu_backend();
+    auto & s = get_cpu_impl()->get_storage();
+    return s.data() + s.size();
+  }
+
+  const_iterator cend() const
+  {
+    throw_if_not_cpu_backend();
+    auto & s = get_cpu_impl()->get_storage();
+    return s.data() + s.size();
+  }
+
+  // ========== Capacity ==========
+
+  /// Works for all backends (delegates to BufferImplBase::size()).
+  bool empty() const {return !impl_ || impl_->size() == 0;}
+
+  /// Works for all backends (delegates to BufferImplBase::size()).
+  size_t size() const {return impl_ ? impl_->size() : 0;}
+
+  void reserve(size_t new_cap)
+  {
+    throw_if_not_cpu_backend();
+    get_cpu_impl()->get_storage().reserve(new_cap);
+  }
+
+  size_t capacity() const
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage().capacity();
+  }
+
+  void shrink_to_fit()
+  {
+    throw_if_not_cpu_backend();
+    get_cpu_impl()->get_storage().shrink_to_fit();
+  }
+
+  // ========== Modifiers (CPU only) ==========
+
+  void clear()
+  {
+    throw_if_not_cpu_backend();
+    get_cpu_impl()->get_storage().clear();
+  }
+
+  void resize(size_t n)
+  {
+    throw_if_not_cpu_backend();
+    get_cpu_impl()->get_storage().resize(n);
+  }
+
+  void resize(size_t n, const T & value)
+  {
+    throw_if_not_cpu_backend();
+    get_cpu_impl()->get_storage().resize(n, value);
+  }
+
+  void push_back(const T & value)
+  {
+    throw_if_not_cpu_backend();
+    get_cpu_impl()->get_storage().push_back(value);
+  }
+
+  void push_back(T && value)
+  {
+    throw_if_not_cpu_backend();
+    get_cpu_impl()->get_storage().push_back(std::move(value));
+  }
+
+  void pop_back()
+  {
+    throw_if_not_cpu_backend();
+    get_cpu_impl()->get_storage().pop_back();
+  }
+
+  template<typename ... Args>
+  void emplace_back(Args && ... args)
+  {
+    throw_if_not_cpu_backend();
+    get_cpu_impl()->get_storage().emplace_back(std::forward<Args>(args)...);
+  }
+
+  // ========== Conversion Operators ==========
+
+  /// Implicit conversion to std::vector<T>& (CPU only).
+  /// Provides backward compatibility with existing code.
+  /// @throws std::runtime_error if backend is not CPU.
+  operator std::vector<T> &()
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage();
+  }
+
+  operator const std::vector<T> &() const
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage();
+  }
+
+  /// Escape hatch: Explicit conversion to std::vector<T> (all backends).
+  /// For non-CPU backends, this triggers a copy to CPU memory.
+  /// @return A std::vector containing a copy of the buffer data.
+  std::vector<T> to_vector() const
+  {
+    if (backend_type_ == "cpu") {
+      return get_cpu_impl()->get_storage();
+    } else {
+      // Call backend's to_cpu() and extract vector
+      auto cpu_impl_ptr = impl_->to_cpu();
+      auto * cpu_impl = static_cast<CpuBufferImpl<T> *>(cpu_impl_ptr.get());
+      return cpu_impl->get_storage();
+    }
+  }
+
+  // ========== Backend Management ==========
+
+  /// Get the backend type identifier (e.g., "cpu", "cuda").
+  std::string get_backend_type() const {return backend_type_;}
+
+  /// Set buffer implementation (for backend libraries).
+  /// This allows vendor-specific backend libraries to inject their
+  /// implementations.
+  /// @param impl Backend implementation instance.
+  /// @param backend_type Backend identifier string.
+  void set_impl(
+    std::unique_ptr<BufferImplBase<T>> impl,
+    const std::string & backend_type)
+  {
+    impl_ = std::move(impl);
+    backend_type_ = backend_type;
+  }
+
+  /// Get the implementation pointer (for serialization) - returns raw pointer
+  /// for read-only access
+  const BufferImplBase<T> * get_impl() const {return impl_.get();}
+
+  /// Throw exception if not CPU backend.
+  /// @throws std::runtime_error if backend is not CPU.
+  void throw_if_not_cpu_backend() const
+  {
+    if (backend_type_ != "cpu") {
+      throw std::runtime_error(
+              "Operation requires CPU backend. Current backend: " + backend_type_ +
+              ". Use to_vector() for explicit conversion to CPU.");
+    }
+  }
+
+private:
+  std::string backend_type_;  ///< Backend identifier ("cpu", "cuda", etc.)
+  /// Unique pointer for proper ownership and value semantics
+  std::unique_ptr<BufferImplBase<T>> impl_;
+
+  /// Get CPU implementation (assumes throw_if_not_cpu_backend() was called)
+  CpuBufferImpl<T> * get_cpu_impl() const
+  {
+    return static_cast<CpuBufferImpl<T> *>(impl_.get());
+  }
+};
+
+}  // namespace rosidl
+
+#endif  // ROSIDL_BUFFER__BUFFER_HPP_

--- a/rosidl_buffer/include/rosidl_buffer/buffer_impl_base.hpp
+++ b/rosidl_buffer/include/rosidl_buffer/buffer_impl_base.hpp
@@ -1,0 +1,53 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_BUFFER__BUFFER_IMPL_BASE_HPP_
+#define ROSIDL_BUFFER__BUFFER_IMPL_BASE_HPP_
+
+#include <cstddef>
+#include <memory>
+
+namespace rosidl
+{
+
+/// Abstract base class for all buffer implementations (CPU, CUDA, ROCm, etc.).
+///
+/// This base keeps only what the Buffer<T> pimpl and the serialization layer
+/// need.  Backend-specific APIs (element access, resize, iterators,
+/// descriptor serialization, etc.) are the responsibility of each concrete
+/// implementation or the BufferBackend plugin; the CPU path goes through
+/// CpuBufferImpl directly.
+template<typename T>
+class BufferImplBase
+{
+public:
+  virtual ~BufferImplBase() = default;
+
+  /// Get the number of elements in the buffer.
+  /// Required by the serialization layer for all backends.
+  virtual size_t size() const = 0;
+
+  /// Create a CPU copy of this buffer.
+  /// If already on CPU, may return a copy or the same instance.
+  /// @return New BufferImplBase instance on CPU
+  virtual std::unique_ptr<BufferImplBase<T>> to_cpu() const = 0;
+
+  /// Create a deep copy of this buffer.
+  /// @return New BufferImplBase instance with copied data
+  virtual std::unique_ptr<BufferImplBase<T>> clone() const = 0;
+};
+
+}  // namespace rosidl
+
+#endif  // ROSIDL_BUFFER__BUFFER_IMPL_BASE_HPP_

--- a/rosidl_buffer/include/rosidl_buffer/c_helpers.h
+++ b/rosidl_buffer/include/rosidl_buffer/c_helpers.h
@@ -1,0 +1,50 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_BUFFER__C_HELPERS_H_
+#define ROSIDL_BUFFER__C_HELPERS_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Get the size of a Buffer<uint8_t>. Works for all backends.
+/// @param buffer_ptr Opaque pointer to an rosidl::Buffer<uint8_t>
+size_t rosidl_buffer_uint8_size(const void * buffer_ptr);
+
+/// Get a const pointer to the underlying CPU data. Throws for non-CPU backends.
+/// @param buffer_ptr Opaque pointer to an rosidl::Buffer<uint8_t>
+const uint8_t * rosidl_buffer_uint8_data(const void * buffer_ptr);
+
+/// Get a mutable pointer to the underlying CPU data. Throws for non-CPU backends.
+/// @param buffer_ptr Opaque pointer to an rosidl::Buffer<uint8_t>
+uint8_t * rosidl_buffer_uint8_data_mut(void * buffer_ptr);
+
+/// Resize a Buffer<uint8_t>. Throws for non-CPU backends.
+/// @param buffer_ptr Opaque pointer to an rosidl::Buffer<uint8_t>
+/// @param size New size
+void rosidl_buffer_uint8_resize(void * buffer_ptr, size_t size);
+
+/// Throw std::runtime_error if the buffer is not CPU-backed.
+/// @param buffer_ptr Opaque pointer to an rosidl::Buffer<uint8_t>
+void rosidl_buffer_uint8_throw_if_not_cpu(const void * buffer_ptr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // ROSIDL_BUFFER__C_HELPERS_H_

--- a/rosidl_buffer/include/rosidl_buffer/cpu_buffer_impl.hpp
+++ b/rosidl_buffer/include/rosidl_buffer/cpu_buffer_impl.hpp
@@ -1,0 +1,64 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_BUFFER__CPU_BUFFER_IMPL_HPP_
+#define ROSIDL_BUFFER__CPU_BUFFER_IMPL_HPP_
+
+#include <memory>
+#include <vector>
+
+#include "rosidl_buffer/buffer_impl_base.hpp"
+
+namespace rosidl
+{
+
+/// CPU buffer implementation wrapping std::vector.
+/// Provides the reference implementation for CPU memory buffers.
+template<typename T>
+class CpuBufferImpl : public BufferImplBase<T>
+{
+public:
+  CpuBufferImpl() = default;
+
+  /// Get mutable reference to underlying std::vector.
+  std::vector<T> & get_storage() {return storage_;}
+
+  /// Get const reference to underlying std::vector.
+  const std::vector<T> & get_storage() const {return storage_;}
+
+  // ========== BufferImplBase overrides ==========
+
+  size_t size() const override {return storage_.size();}
+
+  std::unique_ptr<BufferImplBase<T>> to_cpu() const override
+  {
+    auto copy = std::make_unique<CpuBufferImpl<T>>();
+    copy->storage_ = storage_;
+    return copy;
+  }
+
+  std::unique_ptr<BufferImplBase<T>> clone() const override
+  {
+    auto copy = std::make_unique<CpuBufferImpl<T>>();
+    copy->storage_ = storage_;
+    return copy;
+  }
+
+private:
+  std::vector<T> storage_;
+};
+
+}  // namespace rosidl
+
+#endif  // ROSIDL_BUFFER__CPU_BUFFER_IMPL_HPP_

--- a/rosidl_buffer/package.xml
+++ b/rosidl_buffer/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rosidl_buffer</name>
+  <version>1.0.0</version>
+  <description>
+    Core Buffer types and implementations for ROS2 native buffer feature.
+    Provides Buffer container type with support for multiple memory backends (CPU, GPU, custom).
+  </description>
+  
+  <maintainer email="cyc@nvidia.com">CY Chen</maintainer>
+  
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/rosidl_buffer/src/c_helpers.cpp
+++ b/rosidl_buffer/src/c_helpers.cpp
@@ -1,0 +1,53 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rosidl_buffer/c_helpers.h"
+#include "rosidl_buffer/buffer.hpp"
+
+extern "C" {
+
+size_t rosidl_buffer_uint8_size(const void * buffer_ptr)
+{
+  const auto * buf = static_cast<const rosidl::Buffer<uint8_t> *>(buffer_ptr);
+  return buf->size();
+}
+
+const uint8_t * rosidl_buffer_uint8_data(const void * buffer_ptr)
+{
+  const auto * buf = static_cast<const rosidl::Buffer<uint8_t> *>(buffer_ptr);
+  buf->throw_if_not_cpu_backend();
+  return buf->data();
+}
+
+uint8_t * rosidl_buffer_uint8_data_mut(void * buffer_ptr)
+{
+  auto * buf = static_cast<rosidl::Buffer<uint8_t> *>(buffer_ptr);
+  buf->throw_if_not_cpu_backend();
+  return buf->data();
+}
+
+void rosidl_buffer_uint8_resize(void * buffer_ptr, size_t size)
+{
+  auto * buf = static_cast<rosidl::Buffer<uint8_t> *>(buffer_ptr);
+  buf->throw_if_not_cpu_backend();
+  buf->resize(size);
+}
+
+void rosidl_buffer_uint8_throw_if_not_cpu(const void * buffer_ptr)
+{
+  const auto * buf = static_cast<const rosidl::Buffer<uint8_t> *>(buffer_ptr);
+  buf->throw_if_not_cpu_backend();
+}
+
+}  // extern "C"

--- a/rosidl_buffer/test/test_buffer.cpp
+++ b/rosidl_buffer/test/test_buffer.cpp
@@ -1,0 +1,488 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <stdexcept>
+#include <vector>
+
+#include "rosidl_buffer/buffer.hpp"
+#include "rosidl_buffer/buffer_impl_base.hpp"
+#include "rosidl_buffer/cpu_buffer_impl.hpp"
+
+using rosidl::Buffer;
+using rosidl::BufferImplBase;
+using rosidl::CpuBufferImpl;
+
+// Test default construction
+TEST(TestBuffer, default_construction) {
+  Buffer<int> buffer;
+  EXPECT_EQ(0u, buffer.size());
+  EXPECT_TRUE(buffer.empty());
+  EXPECT_EQ("cpu", buffer.get_backend_type());
+}
+
+// Test construction with size
+TEST(TestBuffer, sized_construction) {
+  Buffer<int> buffer(10);
+  EXPECT_EQ(10u, buffer.size());
+  EXPECT_FALSE(buffer.empty());
+  EXPECT_EQ("cpu", buffer.get_backend_type());
+}
+
+// Test construction with size and value
+TEST(TestBuffer, sized_value_construction) {
+  Buffer<int> buffer(5, 42);
+  EXPECT_EQ(5u, buffer.size());
+  for (size_t i = 0; i < buffer.size(); ++i) {
+    EXPECT_EQ(42, buffer[i]);
+  }
+}
+
+// Test copy construction
+TEST(TestBuffer, copy_construction) {
+  Buffer<int> buffer1(3, 100);
+  Buffer<int> buffer2(buffer1);
+
+  EXPECT_EQ(buffer1.size(), buffer2.size());
+  EXPECT_EQ(buffer1.get_backend_type(), buffer2.get_backend_type());
+  for (size_t i = 0; i < buffer1.size(); ++i) {
+    EXPECT_EQ(buffer1[i], buffer2[i]);
+  }
+}
+
+// Test move construction
+TEST(TestBuffer, move_construction) {
+  Buffer<int> buffer1(3, 100);
+  Buffer<int> buffer2(std::move(buffer1));
+
+  EXPECT_EQ(3u, buffer2.size());
+  EXPECT_EQ("cpu", buffer2.get_backend_type());
+}
+
+// Test copy assignment
+TEST(TestBuffer, copy_assignment) {
+  Buffer<int> buffer1(3, 100);
+  Buffer<int> buffer2;
+  buffer2 = buffer1;
+
+  EXPECT_EQ(buffer1.size(), buffer2.size());
+  for (size_t i = 0; i < buffer1.size(); ++i) {
+    EXPECT_EQ(buffer1[i], buffer2[i]);
+  }
+}
+
+// Test move assignment
+TEST(TestBuffer, move_assignment) {
+  Buffer<int> buffer1(3, 100);
+  Buffer<int> buffer2;
+  buffer2 = std::move(buffer1);
+
+  EXPECT_EQ(3u, buffer2.size());
+}
+
+// Test element access via operator[]
+TEST(TestBuffer, element_access) {
+  Buffer<int> buffer(5);
+  for (size_t i = 0; i < buffer.size(); ++i) {
+    buffer[i] = static_cast<int>(i * 10);
+  }
+
+  for (size_t i = 0; i < buffer.size(); ++i) {
+    EXPECT_EQ(static_cast<int>(i * 10), buffer[i]);
+  }
+}
+
+// Test const element access
+TEST(TestBuffer, const_element_access) {
+  Buffer<int> buffer(3, 42);
+  const Buffer<int> & const_buffer = buffer;
+
+  EXPECT_EQ(42, const_buffer[0]);
+  EXPECT_EQ(42, const_buffer[1]);
+  EXPECT_EQ(42, const_buffer[2]);
+}
+
+// Test at() with bounds checking
+TEST(TestBuffer, at_access) {
+  Buffer<int> buffer(3, 99);
+  EXPECT_EQ(99, buffer.at(0));
+  EXPECT_EQ(99, buffer.at(2));
+  EXPECT_THROW(buffer.at(3), std::out_of_range);
+}
+
+// Test front() and back()
+TEST(TestBuffer, front_back_access) {
+  Buffer<int> buffer;
+  buffer.push_back(10);
+  buffer.push_back(20);
+  buffer.push_back(30);
+
+  EXPECT_EQ(10, buffer.front());
+  EXPECT_EQ(30, buffer.back());
+}
+
+// Test data() pointer access
+TEST(TestBuffer, data_access) {
+  Buffer<int> buffer(5, 7);
+  int * ptr = buffer.data();
+  ASSERT_NE(nullptr, ptr);
+  EXPECT_EQ(7, ptr[0]);
+  EXPECT_EQ(7, ptr[4]);
+
+  ptr[2] = 100;
+  EXPECT_EQ(100, buffer[2]);
+}
+
+// Test iterators
+TEST(TestBuffer, iterators) {
+  Buffer<int> buffer;
+  buffer.push_back(1);
+  buffer.push_back(2);
+  buffer.push_back(3);
+
+  int sum = 0;
+  for (auto it = buffer.begin(); it != buffer.end(); ++it) {
+    sum += *it;
+  }
+  EXPECT_EQ(6, sum);
+
+  // Test const iterators
+  const Buffer<int> & const_buffer = buffer;
+  int const_sum = 0;
+  for (auto it = const_buffer.begin(); it != const_buffer.end(); ++it) {
+    const_sum += *it;
+  }
+  EXPECT_EQ(6, const_sum);
+}
+
+// Test resize
+TEST(TestBuffer, resize) {
+  Buffer<int> buffer(5, 10);
+  EXPECT_EQ(5u, buffer.size());
+
+  buffer.resize(10);
+  EXPECT_EQ(10u, buffer.size());
+  EXPECT_EQ(10, buffer[4]);  // Old values preserved
+
+  buffer.resize(3);
+  EXPECT_EQ(3u, buffer.size());
+}
+
+// Test resize with value
+TEST(TestBuffer, resize_with_value) {
+  Buffer<int> buffer(2, 5);
+  buffer.resize(5, 99);
+
+  EXPECT_EQ(5u, buffer.size());
+  EXPECT_EQ(5, buffer[0]);
+  EXPECT_EQ(5, buffer[1]);
+  EXPECT_EQ(99, buffer[2]);
+  EXPECT_EQ(99, buffer[4]);
+}
+
+// Test push_back
+TEST(TestBuffer, push_back) {
+  Buffer<int> buffer;
+  EXPECT_TRUE(buffer.empty());
+
+  buffer.push_back(10);
+  EXPECT_EQ(1u, buffer.size());
+  EXPECT_EQ(10, buffer[0]);
+
+  buffer.push_back(20);
+  EXPECT_EQ(2u, buffer.size());
+  EXPECT_EQ(20, buffer[1]);
+}
+
+// Test push_back with rvalue
+TEST(TestBuffer, push_back_rvalue) {
+  Buffer<std::string> buffer;
+  std::string str = "hello";
+  buffer.push_back(std::move(str));
+
+  EXPECT_EQ(1u, buffer.size());
+  EXPECT_EQ("hello", buffer[0]);
+}
+
+// Test pop_back
+TEST(TestBuffer, pop_back) {
+  Buffer<int> buffer;
+  buffer.push_back(1);
+  buffer.push_back(2);
+  buffer.push_back(3);
+
+  EXPECT_EQ(3u, buffer.size());
+  buffer.pop_back();
+  EXPECT_EQ(2u, buffer.size());
+  EXPECT_EQ(2, buffer.back());
+}
+
+// Test emplace_back
+TEST(TestBuffer, emplace_back) {
+  Buffer<std::string> buffer;
+  buffer.emplace_back("test");
+  buffer.emplace_back(5, 'x');  // Creates "xxxxx"
+
+  EXPECT_EQ(2u, buffer.size());
+  EXPECT_EQ("test", buffer[0]);
+  EXPECT_EQ("xxxxx", buffer[1]);
+}
+
+// Test clear
+TEST(TestBuffer, clear) {
+  Buffer<int> buffer(10, 42);
+  EXPECT_EQ(10u, buffer.size());
+  EXPECT_FALSE(buffer.empty());
+
+  buffer.clear();
+  EXPECT_EQ(0u, buffer.size());
+  EXPECT_TRUE(buffer.empty());
+}
+
+// Test reserve and capacity (CPU backend only)
+TEST(TestBuffer, reserve_capacity) {
+  Buffer<int> buffer;
+  buffer.reserve(100);
+
+  EXPECT_EQ(0u, buffer.size());
+  EXPECT_GE(buffer.capacity(), 100u);
+}
+
+// Test shrink_to_fit
+TEST(TestBuffer, shrink_to_fit) {
+  Buffer<int> buffer;
+  buffer.reserve(100);
+  buffer.push_back(1);
+  buffer.push_back(2);
+
+  EXPECT_GE(buffer.capacity(), 100u);
+  buffer.shrink_to_fit();
+  EXPECT_EQ(2u, buffer.size());
+  EXPECT_LE(buffer.capacity(), 100u);
+}
+
+// Test implicit conversion to std::vector&
+TEST(TestBuffer, implicit_conversion_to_vector) {
+  Buffer<int> buffer;
+  buffer.push_back(1);
+  buffer.push_back(2);
+  buffer.push_back(3);
+
+  // Implicit conversion
+  std::vector<int> & vec_ref = buffer;
+  EXPECT_EQ(3u, vec_ref.size());
+  EXPECT_EQ(1, vec_ref[0]);
+  EXPECT_EQ(2, vec_ref[1]);
+  EXPECT_EQ(3, vec_ref[2]);
+
+  // Modify through vector reference
+  vec_ref[1] = 99;
+  EXPECT_EQ(99, buffer[1]);
+}
+
+// Test const implicit conversion
+TEST(TestBuffer, const_implicit_conversion) {
+  Buffer<int> buffer(3, 42);
+  const Buffer<int> & const_buffer = buffer;
+
+  const std::vector<int> & vec_ref = const_buffer;
+  EXPECT_EQ(3u, vec_ref.size());
+  EXPECT_EQ(42, vec_ref[0]);
+}
+
+// Test to_vector() escape hatch
+TEST(TestBuffer, to_vector_escape_hatch) {
+  Buffer<int> buffer;
+  buffer.push_back(10);
+  buffer.push_back(20);
+  buffer.push_back(30);
+
+  std::vector<int> copied = buffer.to_vector();
+  EXPECT_EQ(buffer.size(), copied.size());
+  EXPECT_EQ(10, copied[0]);
+  EXPECT_EQ(20, copied[1]);
+  EXPECT_EQ(30, copied[2]);
+
+  // Verify it's a copy
+  copied[0] = 999;
+  EXPECT_EQ(10, buffer[0]);  // Original unchanged
+}
+
+// Test backend type
+TEST(TestBuffer, backend_type) {
+  Buffer<int> buffer;
+  EXPECT_EQ("cpu", buffer.get_backend_type());
+}
+
+// Test using Buffer with algorithms
+TEST(TestBuffer, with_algorithms) {
+  Buffer<int> buffer;
+  for (int i = 0; i < 10; ++i) {
+    buffer.push_back(i);
+  }
+
+  // Test std::find
+  auto it = std::find(buffer.begin(), buffer.end(), 5);
+  ASSERT_NE(buffer.end(), it);
+  EXPECT_EQ(5, *it);
+
+  // Test std::count
+  buffer.push_back(5);
+  int count = std::count(buffer.begin(), buffer.end(), 5);
+  EXPECT_EQ(2, count);
+
+  // Test std::sort
+  Buffer<int> buffer2;
+  buffer2.push_back(3);
+  buffer2.push_back(1);
+  buffer2.push_back(2);
+  std::sort(buffer2.begin(), buffer2.end());
+  EXPECT_EQ(1, buffer2[0]);
+  EXPECT_EQ(2, buffer2[1]);
+  EXPECT_EQ(3, buffer2[2]);
+}
+
+// Test CpuBufferImpl directly
+TEST(TestCpuBufferImpl, basic_operations) {
+  CpuBufferImpl<int> impl;
+  EXPECT_EQ(0u, impl.get_storage().size());
+
+  impl.get_storage().resize(5);
+  EXPECT_EQ(5u, impl.get_storage().size());
+
+  auto & storage = impl.get_storage();
+  storage[0] = 100;
+  EXPECT_EQ(100, storage[0]);
+
+  impl.get_storage().clear();
+  EXPECT_EQ(0u, impl.get_storage().size());
+}
+
+// Test CpuBufferImpl::to_cpu()
+TEST(TestCpuBufferImpl, to_cpu) {
+  CpuBufferImpl<int> impl;
+  impl.get_storage().resize(3);
+  auto & storage = impl.get_storage();
+  storage[0] = 1;
+  storage[1] = 2;
+  storage[2] = 3;
+
+  auto cpu_copy = impl.to_cpu();
+  ASSERT_NE(nullptr, cpu_copy);
+
+  auto * cpu_impl = static_cast<CpuBufferImpl<int> *>(cpu_copy.get());
+  EXPECT_EQ(3u, cpu_impl->get_storage().size());
+  EXPECT_EQ(1, cpu_impl->get_storage()[0]);
+  EXPECT_EQ(2, cpu_impl->get_storage()[1]);
+  EXPECT_EQ(3, cpu_impl->get_storage()[2]);
+}
+
+// Test CpuBufferImpl storage data pointer
+TEST(TestCpuBufferImpl, storage_data_pointer) {
+  CpuBufferImpl<int> impl;
+
+  EXPECT_TRUE(impl.get_storage().empty());
+
+  impl.get_storage().resize(5);
+  const int * data_ptr = impl.get_storage().data();
+  ASSERT_NE(nullptr, data_ptr);
+
+  impl.get_storage()[0] = 42;
+  EXPECT_EQ(42, data_ptr[0]);
+}
+
+// Test Buffer copy creates independent clone (deep copy via unique_ptr)
+TEST(TestBuffer, deep_copy_semantics) {
+  Buffer<int> buffer1;
+  buffer1.push_back(10);
+  buffer1.push_back(20);
+
+  Buffer<int> buffer2 = buffer1;  // Deep copy via clone()
+
+  // Verify they have the same values
+  EXPECT_EQ(buffer1.size(), buffer2.size());
+  EXPECT_EQ(buffer1[0], buffer2[0]);
+  EXPECT_EQ(buffer1[1], buffer2[1]);
+
+  // Modify buffer2 and verify buffer1 is unchanged (independent copies)
+  buffer2[0] = 999;
+  EXPECT_EQ(10, buffer1[0]);  // Original unchanged
+  EXPECT_EQ(999, buffer2[0]);  // Copy modified
+}
+
+// Test Buffer::set_impl() for backend injection
+TEST(TestBuffer, set_impl) {
+  Buffer<int> buffer;
+
+  // Create a custom impl
+  auto custom_impl = std::make_unique<CpuBufferImpl<int>>();
+  custom_impl->get_storage().resize(3);
+  custom_impl->get_storage()[0] = 100;
+  custom_impl->get_storage()[1] = 200;
+  custom_impl->get_storage()[2] = 300;
+
+  // Inject the impl
+  buffer.set_impl(std::move(custom_impl), "cpu");
+
+  EXPECT_EQ(3u, buffer.size());
+  EXPECT_EQ(100, buffer[0]);
+  EXPECT_EQ(200, buffer[1]);
+  EXPECT_EQ(300, buffer[2]);
+}
+
+// Test that Buffer works with complex types
+TEST(TestBuffer, with_string) {
+  Buffer<std::string> buffer;
+  buffer.push_back("hello");
+  buffer.push_back("world");
+
+  EXPECT_EQ(2u, buffer.size());
+  EXPECT_EQ("hello", buffer[0]);
+  EXPECT_EQ("world", buffer[1]);
+
+  std::vector<std::string> copied = buffer.to_vector();
+  EXPECT_EQ("hello", copied[0]);
+  EXPECT_EQ("world", copied[1]);
+}
+
+// Test Buffer with struct types
+TEST(TestBuffer, with_struct)
+{
+  struct Point
+  {
+    double x;
+    double y;
+    double z;
+  };
+
+  Buffer<Point> buffer;
+  buffer.push_back({1.0, 2.0, 3.0});
+  buffer.push_back({4.0, 5.0, 6.0});
+
+  EXPECT_EQ(2u, buffer.size());
+  EXPECT_DOUBLE_EQ(1.0, buffer[0].x);
+  EXPECT_DOUBLE_EQ(5.0, buffer[1].y);
+
+  std::vector<Point> copied = buffer.to_vector();
+  EXPECT_DOUBLE_EQ(3.0, copied[0].z);
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Description

This pull request adds the `rosidl_buffer` package - core C++ buffer types for the ROS 2 native buffer feature. This package introduces `rosidl::Buffer<T>`, a polymorphic container that's designed to replace `std::vector<T>` for `uint8[]` message fields (to be adopted in later pull requests; we focus on only the core buffer types in this pull request.) The native buffer type enables vendor-specific memory backends (CUDA, ROCm, etc.) while maintaining backward compatibility for existing CPU-based `std::vector<T>` user code.

This pull request consists of the following key components:
- **`Buffer<T>`**: PIMPL-based container providing `std::vector<T>`-compatible API. All vector-compatible operations (element access, iterators, modifiers) are CPU-only and throw `std::runtime_error` for non-CPU backends. Backend management APIs (`get_backend_type()`, `set_impl()`, `get_impl()`, `to_vector()`) and copy/move semantics work for all backends.
- **`BufferImplBase<T>`**: Minimal abstract base class of buffer implementation. All backend-specific APIs are to be provided by the vendor-specific backend implementations.
- **`CpuBufferImpl<T>`**: CPU-based buffer implementation wrapping `std::vector<T>`.

### Is this user-facing behavior change?

This pull request does not change existing behavior.
When adopted in later pull requests, message types with `uint8[]` fields (e.g., `sensor_msgs/msg/Image.data`) will use `rosidl::Buffer<uint8_t>` instead of `std::vector<uint8_t>`. For CPU backends (the default), `Buffer<T>` is a transparent drop-in replacement.


### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

Yes. Claude (claude-4.6-opus) via Cursor was used to assist with the `std::vector<T>` compatibility feature in the `rosidl::Buffer<T>` class and generate portions of the unit tests.


### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

This package/PL is part of the broader ROS2 native buffer feature introduced in this [post](https://discourse.openrobotics.org/t/working-prototype-of-native-buffers-accelerated-memory-transport/52399).