### PR TITLE
Add rosidl_buffer and rosidl_buffer_backend for native Buffer type support

### DIFF
--- a/rosidl_buffer/CMakeLists.txt
+++ b/rosidl_buffer/CMakeLists.txt
@@ -1,0 +1,64 @@
+cmake_minimum_required(VERSION 3.5)
+project(rosidl_buffer)
+
+# Default to C++17
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# Find dependencies
+find_package(ament_cmake REQUIRED)
+
+add_library(${PROJECT_NAME} SHARED
+  src/c_helpers.cpp
+)
+
+target_include_directories(${PROJECT_NAME} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
+)
+
+target_compile_definitions(${PROJECT_NAME} PRIVATE "ROSIDL_BUFFER_BUILDING_DLL")
+
+# Install headers
+install(
+  DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
+)
+
+# Install library target
+install(
+  TARGETS ${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include/${PROJECT_NAME}
+)
+
+# Export modern CMake targets
+ament_export_targets(${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_gtest REQUIRED)
+
+  ament_add_gtest(test_buffer test/test_buffer.cpp)
+  if(TARGET test_buffer)
+    target_link_libraries(test_buffer ${PROJECT_NAME})
+  endif()
+
+  ament_add_gtest(test_c_helpers test/test_c_helpers.cpp)
+  if(TARGET test_c_helpers)
+    target_link_libraries(test_c_helpers ${PROJECT_NAME})
+  endif()
+endif()
+
+ament_package()

--- a/rosidl_buffer/include/rosidl_buffer/buffer.hpp
+++ b/rosidl_buffer/include/rosidl_buffer/buffer.hpp
@@ -1,0 +1,531 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_BUFFER__BUFFER_HPP_
+#define ROSIDL_BUFFER__BUFFER_HPP_
+
+#include <algorithm>
+#include <cstddef>
+#include <initializer_list>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "rosidl_buffer/buffer_impl_base.hpp"
+#include "rosidl_buffer/cpu_buffer_impl.hpp"
+
+namespace rosidl
+{
+
+/// Buffer<T> provides a drop-in replacement for std::vector<T> with support
+/// for vendor-specific memory backends (CPU, GPU, etc.).
+///
+/// For CPU backends, it provides implicit conversion to std::vector<T>&
+/// for seamless backward compatibility. For non-CPU backends, direct access
+/// throws exceptions, requiring explicit conversion via to_vector().
+template<typename T, typename Allocator = std::allocator<T>>
+class Buffer
+{
+public:
+  // Type aliases for std::vector compatibility
+  using value_type = T;
+  using allocator_type = Allocator;
+  using size_type = size_t;
+  using difference_type = std::ptrdiff_t;
+  using reference = T &;
+  using const_reference = const T &;
+  using pointer = T *;
+  using const_pointer = const T *;
+  using iterator = T *;
+  using const_iterator = const T *;
+
+  /// Default constructor creates CPU buffer
+  Buffer()
+  : impl_(std::make_unique<CpuBufferImpl<T>>())
+  {
+  }
+
+  /// Construct with a backend implementation (set once at construction).
+  /// This is the only way to set a non-CPU backend; there is no post-
+  /// construction setter, which avoids race conditions with concurrent reads.
+  explicit Buffer(std::unique_ptr<BufferImplBase<T>> impl)
+  : impl_(std::move(impl))
+  {
+    if (!impl_) {
+      throw std::invalid_argument("Buffer implementation must not be null");
+    }
+  }
+
+  /// Construct with initial size (CPU backend)
+  explicit Buffer(size_t count)
+  : impl_(std::make_unique<CpuBufferImpl<T>>())
+  {
+    get_cpu_impl()->get_storage().resize(count);
+  }
+
+  /// Construct with initial size and value (CPU backend)
+  Buffer(size_t count, const T & value)
+  : impl_(std::make_unique<CpuBufferImpl<T>>())
+  {
+    get_cpu_impl()->get_storage().assign(count, value);
+  }
+
+  /// Construct from std::vector (copy) - for backward compatibility
+  Buffer(const std::vector<T> & vec)  // NOLINT(runtime/explicit) - intentionally implicit
+  : impl_(std::make_unique<CpuBufferImpl<T>>())
+  {
+    get_cpu_impl()->get_storage() = vec;
+  }
+
+  /// Construct from std::vector (move) - for backward compatibility
+  Buffer(std::vector<T> && vec)  // NOLINT(runtime/explicit) - intentionally implicit
+  : impl_(std::make_unique<CpuBufferImpl<T>>())
+  {
+    get_cpu_impl()->get_storage() = std::move(vec);
+  }
+
+  /// Construct from initializer list - for backward compatibility
+  Buffer(std::initializer_list<T> init)
+  : impl_(std::make_unique<CpuBufferImpl<T>>())
+  {
+    get_cpu_impl()->get_storage() = init;
+  }
+
+  /// Copy constructor (deep copy via clone())
+  Buffer(const Buffer & other)
+  : impl_(other.impl_ ? other.impl_->clone() : nullptr)
+  {
+  }
+
+  /// Move constructor
+  Buffer(Buffer && other) noexcept
+  : impl_(std::move(other.impl_))
+  {
+  }
+
+  /// Copy assignment (deep copy via clone())
+  Buffer & operator=(const Buffer & other)
+  {
+    if (this != &other) {
+      impl_ = other.impl_ ? other.impl_->clone() : nullptr;
+    }
+    return *this;
+  }
+
+  /// Move assignment
+  Buffer & operator=(Buffer && other) noexcept
+  {
+    if (this != &other) {
+      impl_ = std::move(other.impl_);
+    }
+    return *this;
+  }
+
+  /// Assignment from initializer list - for backward compatibility
+  /// This must come before vector assignment to resolve ambiguity with {{...}} syntax
+  Buffer & operator=(std::initializer_list<T> init)
+  {
+    impl_ = std::make_unique<CpuBufferImpl<T>>();
+    get_cpu_impl()->get_storage() = init;
+    return *this;
+  }
+
+  /// Assignment from std::vector (copy) - for backward compatibility
+  /// Uses SFINAE to avoid ambiguity with initializer lists
+  template<typename U = std::vector<T>,
+    typename std::enable_if<std::is_same<U, std::vector<T>>::value, int>::type = 0>
+  Buffer & operator=(const U & vec)
+  {
+    impl_ = std::make_unique<CpuBufferImpl<T>>();
+    get_cpu_impl()->get_storage() = vec;
+    return *this;
+  }
+
+  /// Assignment from std::vector (move) - for backward compatibility
+  /// Uses SFINAE to avoid ambiguity with initializer lists
+  template<typename U = std::vector<T>,
+    typename std::enable_if<std::is_same<U, std::vector<T>>::value, int>::type = 0>
+  Buffer & operator=(U && vec)
+  {
+    impl_ = std::make_unique<CpuBufferImpl<T>>();
+    get_cpu_impl()->get_storage() = std::move(vec);
+    return *this;
+  }
+
+  // ========== Element Access (CPU only) ==========
+
+  /// Access element at position (CPU only)
+  reference operator[](size_t pos)
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage()[pos];
+  }
+
+  const_reference operator[](size_t pos) const
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage()[pos];
+  }
+
+  /// Access element with bounds checking (CPU only)
+  reference at(size_t pos)
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage().at(pos);
+  }
+
+  const_reference at(size_t pos) const
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage().at(pos);
+  }
+
+  /// Access first element (CPU only)
+  reference front()
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage().front();
+  }
+
+  const_reference front() const
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage().front();
+  }
+
+  /// Access last element (CPU only)
+  reference back()
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage().back();
+  }
+
+  const_reference back() const
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage().back();
+  }
+
+  /// Get pointer to data (CPU only)
+  pointer data()
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage().data();
+  }
+
+  const_pointer data() const
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage().data();
+  }
+
+  // ========== Iterators (CPU only) ==========
+
+  iterator begin()
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage().data();
+  }
+
+  const_iterator begin() const
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage().data();
+  }
+
+  const_iterator cbegin() const
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage().data();
+  }
+
+  iterator end()
+  {
+    throw_if_not_cpu_backend();
+    auto & s = get_cpu_impl()->get_storage();
+    return s.data() + s.size();
+  }
+
+  const_iterator end() const
+  {
+    throw_if_not_cpu_backend();
+    auto & s = get_cpu_impl()->get_storage();
+    return s.data() + s.size();
+  }
+
+  const_iterator cend() const
+  {
+    throw_if_not_cpu_backend();
+    auto & s = get_cpu_impl()->get_storage();
+    return s.data() + s.size();
+  }
+
+  // ========== Capacity ==========
+
+  /// Works for all backends (delegates to BufferImplBase::size()).
+  bool empty() const {return !impl_ || impl_->size() == 0;}
+
+  /// Works for all backends (delegates to BufferImplBase::size()).
+  size_t size() const {return impl_ ? impl_->size() : 0;}
+
+  void reserve(size_t new_cap)
+  {
+    throw_if_not_cpu_backend();
+    get_cpu_impl()->get_storage().reserve(new_cap);
+  }
+
+  size_t capacity() const
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage().capacity();
+  }
+
+  void shrink_to_fit()
+  {
+    throw_if_not_cpu_backend();
+    get_cpu_impl()->get_storage().shrink_to_fit();
+  }
+
+  // ========== Modifiers (CPU only) ==========
+
+  void assign(size_t count, const T & value)
+  {
+    throw_if_not_cpu_backend();
+    get_cpu_impl()->get_storage().assign(count, value);
+  }
+
+  template<typename InputIt>
+  void assign(InputIt first, InputIt last)
+  {
+    throw_if_not_cpu_backend();
+    get_cpu_impl()->get_storage().assign(first, last);
+  }
+
+  void assign(std::initializer_list<T> ilist)
+  {
+    throw_if_not_cpu_backend();
+    get_cpu_impl()->get_storage().assign(ilist);
+  }
+
+  iterator insert(const_iterator pos, const T & value)
+  {
+    throw_if_not_cpu_backend();
+    auto & s = get_cpu_impl()->get_storage();
+    auto offset = pos - s.data();
+    auto it = s.insert(s.begin() + offset, value);
+    return s.data() + (it - s.begin());
+  }
+
+  iterator insert(const_iterator pos, T && value)
+  {
+    throw_if_not_cpu_backend();
+    auto & s = get_cpu_impl()->get_storage();
+    auto offset = pos - s.data();
+    auto it = s.insert(s.begin() + offset, std::move(value));
+    return s.data() + (it - s.begin());
+  }
+
+  iterator insert(const_iterator pos, size_t count, const T & value)
+  {
+    throw_if_not_cpu_backend();
+    auto & s = get_cpu_impl()->get_storage();
+    auto offset = pos - s.data();
+    auto it = s.insert(s.begin() + offset, count, value);
+    return s.data() + (it - s.begin());
+  }
+
+  template<typename InputIt>
+  iterator insert(const_iterator pos, InputIt first, InputIt last)
+  {
+    throw_if_not_cpu_backend();
+    auto & s = get_cpu_impl()->get_storage();
+    auto offset = pos - s.data();
+    auto it = s.insert(s.begin() + offset, first, last);
+    return s.data() + (it - s.begin());
+  }
+
+  iterator insert(const_iterator pos, std::initializer_list<T> ilist)
+  {
+    throw_if_not_cpu_backend();
+    auto & s = get_cpu_impl()->get_storage();
+    auto offset = pos - s.data();
+    auto it = s.insert(s.begin() + offset, ilist);
+    return s.data() + (it - s.begin());
+  }
+
+  void clear()
+  {
+    throw_if_not_cpu_backend();
+    get_cpu_impl()->get_storage().clear();
+  }
+
+  void resize(size_t n)
+  {
+    throw_if_not_cpu_backend();
+    get_cpu_impl()->get_storage().resize(n);
+  }
+
+  void resize(size_t n, const T & value)
+  {
+    throw_if_not_cpu_backend();
+    get_cpu_impl()->get_storage().resize(n, value);
+  }
+
+  void push_back(const T & value)
+  {
+    throw_if_not_cpu_backend();
+    get_cpu_impl()->get_storage().push_back(value);
+  }
+
+  void push_back(T && value)
+  {
+    throw_if_not_cpu_backend();
+    get_cpu_impl()->get_storage().push_back(std::move(value));
+  }
+
+  void pop_back()
+  {
+    throw_if_not_cpu_backend();
+    get_cpu_impl()->get_storage().pop_back();
+  }
+
+  template<typename ... Args>
+  void emplace_back(Args && ... args)
+  {
+    throw_if_not_cpu_backend();
+    get_cpu_impl()->get_storage().emplace_back(std::forward<Args>(args)...);
+  }
+
+  // ========== Conversion Operators ==========
+
+  /// Implicit conversion to std::vector<T>& (CPU only).
+  /// Provides backward compatibility with existing code.
+  /// @throws std::runtime_error if backend is not CPU.
+  operator std::vector<T> &()
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage();
+  }
+
+  operator const std::vector<T> &() const
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage();
+  }
+
+  /// Escape hatch: Explicit conversion to std::vector<T> (all backends).
+  /// For non-CPU backends, this triggers a copy to CPU memory.
+  /// @return A std::vector containing a copy of the buffer data.
+  std::vector<T> to_vector() const
+  {
+    if (get_backend_type() == "cpu") {
+      return get_cpu_impl()->get_storage();
+    } else {
+      auto cpu_impl_ptr = impl_->to_cpu();
+      auto * cpu_impl = static_cast<CpuBufferImpl<T> *>(cpu_impl_ptr.get());
+      return cpu_impl->get_storage();
+    }
+  }
+
+  // ========== Comparison Operators ==========
+
+  bool operator==(const Buffer & other) const
+  {
+    if (size() != other.size()) {
+      return false;
+    }
+    if (get_backend_type() == "cpu" && other.get_backend_type() == "cpu") {
+      return get_cpu_impl()->get_storage() == other.get_cpu_impl()->get_storage();
+    }
+    return to_vector() == other.to_vector();
+  }
+
+  bool operator!=(const Buffer & other) const
+  {
+    return !(*this == other);
+  }
+
+  // ========== Backend Management ==========
+
+  /// Get the backend type identifier (e.g., "cpu", "cuda").
+  /// Delegates to the underlying implementation — the impl is the single
+  /// source of truth for its own backend type.
+  std::string get_backend_type() const
+  {
+    return impl_ ? impl_->get_backend_type() : "cpu";
+  }
+
+  /// Get the implementation pointer (for serialization) - returns raw pointer
+  /// for read-only access
+  const BufferImplBase<T> * get_impl() const {return impl_.get();}
+
+  /// Throw exception if not CPU backend.
+  /// @throws std::runtime_error if backend is not CPU.
+  void throw_if_not_cpu_backend() const
+  {
+    const std::string bt = get_backend_type();
+    if (bt != "cpu") {
+      throw std::runtime_error(
+              "Operation requires CPU backend. Current backend: " + bt +
+              ". Use to_vector() for explicit conversion to CPU.");
+    }
+  }
+
+private:
+  /// Unique pointer for proper ownership and value semantics.
+  /// The implementation is the sole source of truth for the backend type.
+  std::unique_ptr<BufferImplBase<T>> impl_;
+
+  /// Get CPU implementation (assumes throw_if_not_cpu_backend() was called)
+  CpuBufferImpl<T> * get_cpu_impl() const
+  {
+    return static_cast<CpuBufferImpl<T> *>(impl_.get());
+  }
+};
+
+/// Free-function comparison: std::vector<T> == Buffer<T>
+/// Needed because template argument deduction does not consider implicit conversions.
+template<typename T, typename Allocator>
+bool operator==(const std::vector<T, Allocator> & lhs, const Buffer<T, Allocator> & rhs)
+{
+  if (rhs.get_backend_type() == "cpu") {
+    return lhs == static_cast<const std::vector<T, Allocator> &>(rhs);
+  }
+  return lhs == rhs.to_vector();
+}
+
+template<typename T, typename Allocator>
+bool operator==(const Buffer<T, Allocator> & lhs, const std::vector<T, Allocator> & rhs)
+{
+  return rhs == lhs;
+}
+
+template<typename T, typename Allocator>
+bool operator!=(const std::vector<T, Allocator> & lhs, const Buffer<T, Allocator> & rhs)
+{
+  return !(lhs == rhs);
+}
+
+template<typename T, typename Allocator>
+bool operator!=(const Buffer<T, Allocator> & lhs, const std::vector<T, Allocator> & rhs)
+{
+  return !(lhs == rhs);
+}
+
+}  // namespace rosidl
+
+#endif  // ROSIDL_BUFFER__BUFFER_HPP_

--- a/rosidl_buffer/include/rosidl_buffer/buffer.hpp
+++ b/rosidl_buffer/include/rosidl_buffer/buffer.hpp
@@ -107,30 +107,32 @@ public:
 
   /// Copy constructor (deep copy via clone())
   Buffer(const Buffer & other)
-  : impl_(other.impl_ ? other.impl_->clone() : nullptr)
+  : impl_(other.impl_->clone())
   {
   }
 
-  /// Move constructor
+  /// Move constructor — the moved-from buffer is left in a valid, empty state.
   Buffer(Buffer && other) noexcept
   : impl_(std::move(other.impl_))
   {
+    other.impl_ = std::make_unique<CpuBufferImpl<T>>();
   }
 
   /// Copy assignment (deep copy via clone())
   Buffer & operator=(const Buffer & other)
   {
     if (this != &other) {
-      impl_ = other.impl_ ? other.impl_->clone() : nullptr;
+      impl_ = other.impl_->clone();
     }
     return *this;
   }
 
-  /// Move assignment
+  /// Move assignment — the moved-from buffer is left in a valid, empty state.
   Buffer & operator=(Buffer && other) noexcept
   {
     if (this != &other) {
       impl_ = std::move(other.impl_);
+      other.impl_ = std::make_unique<CpuBufferImpl<T>>();
     }
     return *this;
   }
@@ -139,7 +141,7 @@ public:
   /// This must come before vector assignment to resolve ambiguity with {{...}} syntax
   Buffer & operator=(std::initializer_list<T> init)
   {
-    impl_ = std::make_unique<CpuBufferImpl<T>>();
+    throw_if_not_cpu_backend();
     get_cpu_impl()->get_storage() = init;
     return *this;
   }
@@ -150,7 +152,7 @@ public:
     typename std::enable_if<std::is_same<U, std::vector<T>>::value, int>::type = 0>
   Buffer & operator=(const U & vec)
   {
-    impl_ = std::make_unique<CpuBufferImpl<T>>();
+    throw_if_not_cpu_backend();
     get_cpu_impl()->get_storage() = vec;
     return *this;
   }
@@ -161,7 +163,7 @@ public:
     typename std::enable_if<std::is_same<U, std::vector<T>>::value, int>::type = 0>
   Buffer & operator=(U && vec)
   {
-    impl_ = std::make_unique<CpuBufferImpl<T>>();
+    throw_if_not_cpu_backend();
     get_cpu_impl()->get_storage() = std::move(vec);
     return *this;
   }
@@ -277,10 +279,10 @@ public:
   // ========== Capacity ==========
 
   /// Works for all backends (delegates to BufferImplBase::size()).
-  bool empty() const {return !impl_ || impl_->size() == 0;}
+  bool empty() const {return impl_->size() == 0;}
 
   /// Works for all backends (delegates to BufferImplBase::size()).
-  size_t size() const {return impl_ ? impl_->size() : 0;}
+  size_t size() const {return impl_->size();}
 
   void reserve(size_t new_cap)
   {
@@ -466,7 +468,7 @@ public:
   /// source of truth for its own backend type.
   std::string get_backend_type() const
   {
-    return impl_ ? impl_->get_backend_type() : "cpu";
+    return impl_->get_backend_type();
   }
 
   /// Get the implementation pointer (for serialization) - returns raw pointer

--- a/rosidl_buffer/include/rosidl_buffer/buffer.hpp
+++ b/rosidl_buffer/include/rosidl_buffer/buffer.hpp
@@ -475,9 +475,11 @@ public:
     return impl_->get_backend_type();
   }
 
-  /// Get the implementation pointer (for serialization) - returns raw pointer
-  /// for read-only access
+  /// Get the implementation pointer (read-only).
   const BufferImplBase<T> * get_impl() const {return impl_.get();}
+
+  /// Get the implementation pointer (mutable, e.g. for descriptor creation).
+  BufferImplBase<T> * get_impl() {return impl_.get();}
 
   /// Throw exception if not CPU backend.
   /// @throws std::runtime_error if backend is not CPU.

--- a/rosidl_buffer/include/rosidl_buffer/buffer.hpp
+++ b/rosidl_buffer/include/rosidl_buffer/buffer.hpp
@@ -55,74 +55,74 @@ public:
 
   /// Default constructor creates CPU buffer
   Buffer()
-  : impl_(std::make_unique<CpuBufferImpl<T>>())
   {
+    set_impl(std::make_unique<CpuBufferImpl<T, Allocator>>());
   }
 
   /// Construct with a backend implementation (set once at construction).
   /// This is the only way to set a non-CPU backend; there is no post-
   /// construction setter, which avoids race conditions with concurrent reads.
   explicit Buffer(std::unique_ptr<BufferImplBase<T>> impl)
-  : impl_(std::move(impl))
   {
-    if (!impl_) {
+    if (!impl) {
       throw std::invalid_argument("Buffer implementation must not be null");
     }
+    set_impl(std::move(impl));
   }
 
   /// Construct with initial size (CPU backend)
   explicit Buffer(size_t count)
-  : impl_(std::make_unique<CpuBufferImpl<T>>())
   {
-    get_cpu_impl()->get_storage().resize(count);
+    set_impl(std::make_unique<CpuBufferImpl<T, Allocator>>());
+    cpu_impl_->get_storage().resize(count);
   }
 
   /// Construct with initial size and value (CPU backend)
   Buffer(size_t count, const T & value)
-  : impl_(std::make_unique<CpuBufferImpl<T>>())
   {
-    get_cpu_impl()->get_storage().assign(count, value);
+    set_impl(std::make_unique<CpuBufferImpl<T, Allocator>>());
+    cpu_impl_->get_storage().assign(count, value);
   }
 
   /// Construct from std::vector (copy) - for backward compatibility
-  Buffer(const std::vector<T> & vec)  // NOLINT(runtime/explicit) - intentionally implicit
-  : impl_(std::make_unique<CpuBufferImpl<T>>())
+  Buffer(const std::vector<T, Allocator> & vec)  // NOLINT(runtime/explicit)
   {
-    get_cpu_impl()->get_storage() = vec;
+    set_impl(std::make_unique<CpuBufferImpl<T, Allocator>>());
+    cpu_impl_->get_storage() = vec;
   }
 
   /// Construct from std::vector (move) - for backward compatibility
-  Buffer(std::vector<T> && vec)  // NOLINT(runtime/explicit) - intentionally implicit
-  : impl_(std::make_unique<CpuBufferImpl<T>>())
+  Buffer(std::vector<T, Allocator> && vec)  // NOLINT(runtime/explicit) - intentionally implicit
   {
-    get_cpu_impl()->get_storage() = std::move(vec);
+    set_impl(std::make_unique<CpuBufferImpl<T, Allocator>>());
+    cpu_impl_->get_storage() = std::move(vec);
   }
 
   /// Construct from initializer list - for backward compatibility
   Buffer(std::initializer_list<T> init)
-  : impl_(std::make_unique<CpuBufferImpl<T>>())
   {
-    get_cpu_impl()->get_storage() = init;
+    set_impl(std::make_unique<CpuBufferImpl<T, Allocator>>());
+    cpu_impl_->get_storage() = init;
   }
 
   /// Copy constructor (deep copy via clone())
   Buffer(const Buffer & other)
-  : impl_(other.impl_->clone())
   {
+    set_impl(other.impl_->clone());
   }
 
   /// Move constructor — the moved-from buffer is left in a valid, empty state.
   Buffer(Buffer && other) noexcept
-  : impl_(std::move(other.impl_))
   {
-    other.impl_ = std::make_unique<CpuBufferImpl<T>>();
+    set_impl(std::move(other.impl_));
+    other.set_impl(std::make_unique<CpuBufferImpl<T, Allocator>>());
   }
 
   /// Copy assignment (deep copy via clone())
   Buffer & operator=(const Buffer & other)
   {
     if (this != &other) {
-      impl_ = other.impl_->clone();
+      set_impl(other.impl_->clone());
     }
     return *this;
   }
@@ -131,8 +131,8 @@ public:
   Buffer & operator=(Buffer && other) noexcept
   {
     if (this != &other) {
-      impl_ = std::move(other.impl_);
-      other.impl_ = std::make_unique<CpuBufferImpl<T>>();
+      set_impl(std::move(other.impl_));
+      other.set_impl(std::make_unique<CpuBufferImpl<T, Allocator>>());
     }
     return *this;
   }
@@ -142,29 +142,29 @@ public:
   Buffer & operator=(std::initializer_list<T> init)
   {
     throw_if_not_cpu_backend();
-    get_cpu_impl()->get_storage() = init;
+    cpu_impl_->get_storage() = init;
     return *this;
   }
 
   /// Assignment from std::vector (copy) - for backward compatibility
   /// Uses SFINAE to avoid ambiguity with initializer lists
-  template<typename U = std::vector<T>,
-    typename std::enable_if<std::is_same<U, std::vector<T>>::value, int>::type = 0>
+  template<typename U = std::vector<T, Allocator>,
+    typename std::enable_if<std::is_same<U, std::vector<T, Allocator>>::value, int>::type = 0>
   Buffer & operator=(const U & vec)
   {
     throw_if_not_cpu_backend();
-    get_cpu_impl()->get_storage() = vec;
+    cpu_impl_->get_storage() = vec;
     return *this;
   }
 
   /// Assignment from std::vector (move) - for backward compatibility
   /// Uses SFINAE to avoid ambiguity with initializer lists
-  template<typename U = std::vector<T>,
-    typename std::enable_if<std::is_same<U, std::vector<T>>::value, int>::type = 0>
+  template<typename U = std::vector<T, Allocator>,
+    typename std::enable_if<std::is_same<U, std::vector<T, Allocator>>::value, int>::type = 0>
   Buffer & operator=(U && vec)
   {
     throw_if_not_cpu_backend();
-    get_cpu_impl()->get_storage() = std::move(vec);
+    cpu_impl_->get_storage() = std::move(vec);
     return *this;
   }
 
@@ -414,32 +414,36 @@ public:
 
   // ========== Conversion Operators ==========
 
-  /// Implicit conversion to std::vector<T>& (CPU only).
+  /// Implicit conversion to std::vector<T, Allocator>& (CPU only).
   /// Provides backward compatibility with existing code.
   /// @throws std::runtime_error if backend is not CPU.
-  operator std::vector<T> &()
+  operator std::vector<T, Allocator> &()
   {
     throw_if_not_cpu_backend();
-    return get_cpu_impl()->get_storage();
+    return cpu_impl_->get_storage();
   }
 
-  operator const std::vector<T> &() const
+  operator const std::vector<T, Allocator> &() const
   {
     throw_if_not_cpu_backend();
-    return get_cpu_impl()->get_storage();
+    return cpu_impl_->get_storage();
   }
 
-  /// Escape hatch: Explicit conversion to std::vector<T> (all backends).
+  /// Escape hatch: Explicit conversion to std::vector<T, Allocator> (all backends).
   /// For non-CPU backends, this triggers a copy to CPU memory.
   /// @return A std::vector containing a copy of the buffer data.
-  std::vector<T> to_vector() const
+  std::vector<T, Allocator> to_vector() const
   {
-    if (get_backend_type() == "cpu") {
-      return get_cpu_impl()->get_storage();
+    if (cpu_impl_) {
+      return cpu_impl_->get_storage();
+    }
+    auto cpu_copy = impl_->to_cpu();
+    auto * cpu = static_cast<CpuBufferImpl<T> *>(cpu_copy.get());
+    if constexpr (std::is_same_v<Allocator, std::allocator<T>>) {
+      return std::move(cpu->get_storage());
     } else {
-      auto cpu_impl_ptr = impl_->to_cpu();
-      auto * cpu_impl = static_cast<CpuBufferImpl<T> *>(cpu_impl_ptr.get());
-      return cpu_impl->get_storage();
+      auto & src = cpu->get_storage();
+      return std::vector<T, Allocator>(src.begin(), src.end());
     }
   }
 
@@ -450,8 +454,8 @@ public:
     if (size() != other.size()) {
       return false;
     }
-    if (get_backend_type() == "cpu" && other.get_backend_type() == "cpu") {
-      return get_cpu_impl()->get_storage() == other.get_cpu_impl()->get_storage();
+    if (cpu_impl_ && other.cpu_impl_) {
+      return cpu_impl_->get_storage() == other.cpu_impl_->get_storage();
     }
     return to_vector() == other.to_vector();
   }
@@ -479,10 +483,10 @@ public:
   /// @throws std::runtime_error if backend is not CPU.
   void throw_if_not_cpu_backend() const
   {
-    const std::string bt = get_backend_type();
-    if (bt != "cpu") {
+    if (!cpu_impl_) {
       throw std::runtime_error(
-              "Operation requires CPU backend. Current backend: " + bt +
+              "Operation requires CPU backend. Current backend: " +
+              impl_->get_backend_type() +
               ". Use to_vector() for explicit conversion to CPU.");
     }
   }
@@ -492,10 +496,21 @@ private:
   /// The implementation is the sole source of truth for the backend type.
   std::unique_ptr<BufferImplBase<T>> impl_;
 
-  /// Get CPU implementation (assumes throw_if_not_cpu_backend() was called)
-  CpuBufferImpl<T> * get_cpu_impl() const
+  /// Cached pointer for type-safe CPU backend detection.
+  /// Set by set_impl() via dynamic_cast; null for non-CPU backends.
+  CpuBufferImpl<T, Allocator> * cpu_impl_ = nullptr;
+
+  /// Set the implementation and update the cached CPU pointer.
+  void set_impl(std::unique_ptr<BufferImplBase<T>> impl)
   {
-    return static_cast<CpuBufferImpl<T> *>(impl_.get());
+    impl_ = std::move(impl);
+    cpu_impl_ = dynamic_cast<CpuBufferImpl<T, Allocator> *>(impl_.get());
+  }
+
+  /// Get CPU implementation (assumes throw_if_not_cpu_backend() was called)
+  CpuBufferImpl<T, Allocator> * get_cpu_impl() const
+  {
+    return cpu_impl_;
   }
 };
 

--- a/rosidl_buffer/include/rosidl_buffer/buffer_impl_base.hpp
+++ b/rosidl_buffer/include/rosidl_buffer/buffer_impl_base.hpp
@@ -1,0 +1,58 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_BUFFER__BUFFER_IMPL_BASE_HPP_
+#define ROSIDL_BUFFER__BUFFER_IMPL_BASE_HPP_
+
+#include <cstddef>
+#include <memory>
+#include <string>
+
+namespace rosidl
+{
+
+/// Abstract base class for all buffer implementations (CPU, CUDA, ROCm, etc.).
+///
+/// This base keeps only what the Buffer<T> pimpl and the serialization layer
+/// need.  Backend-specific APIs (element access, resize, iterators,
+/// descriptor serialization, etc.) are the responsibility of each concrete
+/// implementation or the BufferBackend plugin; the CPU path goes through
+/// CpuBufferImpl directly.
+template<typename T>
+class BufferImplBase
+{
+public:
+  virtual ~BufferImplBase() = default;
+
+  /// Get the backend type identifier (e.g., "cpu", "cuda", "demo").
+  /// Each concrete implementation returns its own fixed identifier.
+  virtual std::string get_backend_type() const = 0;
+
+  /// Get the number of elements in the buffer.
+  /// Required by the serialization layer for all backends.
+  virtual size_t size() const = 0;
+
+  /// Create a CPU copy of this buffer.
+  /// If already on CPU, may return a copy or the same instance.
+  /// @return New BufferImplBase instance on CPU
+  virtual std::unique_ptr<BufferImplBase<T>> to_cpu() const = 0;
+
+  /// Create a deep copy of this buffer.
+  /// @return New BufferImplBase instance with copied data
+  virtual std::unique_ptr<BufferImplBase<T>> clone() const = 0;
+};
+
+}  // namespace rosidl
+
+#endif  // ROSIDL_BUFFER__BUFFER_IMPL_BASE_HPP_

--- a/rosidl_buffer/include/rosidl_buffer/c_helpers.h
+++ b/rosidl_buffer/include/rosidl_buffer/c_helpers.h
@@ -1,0 +1,33 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_BUFFER__C_HELPERS_H_
+#define ROSIDL_BUFFER__C_HELPERS_H_
+
+#include "rosidl_buffer/visibility_control.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Throw std::runtime_error if the buffer is not CPU-backed.
+/// @param buffer_ptr Opaque pointer to an rosidl::Buffer<uint8_t>
+ROSIDL_BUFFER_PUBLIC
+void rosidl_buffer_uint8_throw_if_not_cpu(const void * buffer_ptr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // ROSIDL_BUFFER__C_HELPERS_H_

--- a/rosidl_buffer/include/rosidl_buffer/cpu_buffer_impl.hpp
+++ b/rosidl_buffer/include/rosidl_buffer/cpu_buffer_impl.hpp
@@ -1,0 +1,67 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_BUFFER__CPU_BUFFER_IMPL_HPP_
+#define ROSIDL_BUFFER__CPU_BUFFER_IMPL_HPP_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rosidl_buffer/buffer_impl_base.hpp"
+
+namespace rosidl
+{
+
+/// CPU buffer implementation wrapping std::vector.
+/// Provides the reference implementation for CPU memory buffers.
+template<typename T>
+class CpuBufferImpl : public BufferImplBase<T>
+{
+public:
+  CpuBufferImpl() = default;
+
+  /// Get mutable reference to underlying std::vector.
+  std::vector<T> & get_storage() {return storage_;}
+
+  /// Get const reference to underlying std::vector.
+  const std::vector<T> & get_storage() const {return storage_;}
+
+  // ========== BufferImplBase overrides ==========
+
+  std::string get_backend_type() const override {return "cpu";}
+
+  size_t size() const override {return storage_.size();}
+
+  std::unique_ptr<BufferImplBase<T>> to_cpu() const override
+  {
+    auto copy = std::make_unique<CpuBufferImpl<T>>();
+    copy->storage_ = storage_;
+    return copy;
+  }
+
+  std::unique_ptr<BufferImplBase<T>> clone() const override
+  {
+    auto copy = std::make_unique<CpuBufferImpl<T>>();
+    copy->storage_ = storage_;
+    return copy;
+  }
+
+private:
+  std::vector<T> storage_;
+};
+
+}  // namespace rosidl
+
+#endif  // ROSIDL_BUFFER__CPU_BUFFER_IMPL_HPP_

--- a/rosidl_buffer/include/rosidl_buffer/cpu_buffer_impl.hpp
+++ b/rosidl_buffer/include/rosidl_buffer/cpu_buffer_impl.hpp
@@ -26,17 +26,17 @@ namespace rosidl
 
 /// CPU buffer implementation wrapping std::vector.
 /// Provides the reference implementation for CPU memory buffers.
-template<typename T>
+template<typename T, typename Allocator = std::allocator<T>>
 class CpuBufferImpl : public BufferImplBase<T>
 {
 public:
   CpuBufferImpl() = default;
 
   /// Get mutable reference to underlying std::vector.
-  std::vector<T> & get_storage() {return storage_;}
+  std::vector<T, Allocator> & get_storage() {return storage_;}
 
   /// Get const reference to underlying std::vector.
-  const std::vector<T> & get_storage() const {return storage_;}
+  const std::vector<T, Allocator> & get_storage() const {return storage_;}
 
   // ========== BufferImplBase overrides ==========
 
@@ -51,13 +51,13 @@ public:
 
   std::unique_ptr<BufferImplBase<T>> clone() const override
   {
-    auto copy = std::make_unique<CpuBufferImpl<T>>();
+    auto copy = std::make_unique<CpuBufferImpl<T, Allocator>>();
     copy->storage_ = storage_;
     return copy;
   }
 
 private:
-  std::vector<T> storage_;
+  std::vector<T, Allocator> storage_;
 };
 
 }  // namespace rosidl

--- a/rosidl_buffer/include/rosidl_buffer/cpu_buffer_impl.hpp
+++ b/rosidl_buffer/include/rosidl_buffer/cpu_buffer_impl.hpp
@@ -46,9 +46,7 @@ public:
 
   std::unique_ptr<BufferImplBase<T>> to_cpu() const override
   {
-    auto copy = std::make_unique<CpuBufferImpl<T>>();
-    copy->storage_ = storage_;
-    return copy;
+    return clone();
   }
 
   std::unique_ptr<BufferImplBase<T>> clone() const override

--- a/rosidl_buffer/include/rosidl_buffer/visibility_control.h
+++ b/rosidl_buffer/include/rosidl_buffer/visibility_control.h
@@ -1,0 +1,52 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_BUFFER__VISIBILITY_CONTROL_H_
+#define ROSIDL_BUFFER__VISIBILITY_CONTROL_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// This logic was borrowed (then adapted) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define ROSIDL_BUFFER_EXPORT __attribute__ ((dllexport))
+    #define ROSIDL_BUFFER_IMPORT __attribute__ ((dllimport))
+  #else
+    #define ROSIDL_BUFFER_EXPORT __declspec(dllexport)
+    #define ROSIDL_BUFFER_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef ROSIDL_BUFFER_BUILDING_DLL
+    #define ROSIDL_BUFFER_PUBLIC ROSIDL_BUFFER_EXPORT
+  #else
+    #define ROSIDL_BUFFER_PUBLIC ROSIDL_BUFFER_IMPORT
+  #endif
+#else
+  #define ROSIDL_BUFFER_EXPORT __attribute__ ((visibility("default")))
+  #define ROSIDL_BUFFER_IMPORT
+  #if __GNUC__ >= 4
+    #define ROSIDL_BUFFER_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #define ROSIDL_BUFFER_PUBLIC
+  #endif
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // ROSIDL_BUFFER__VISIBILITY_CONTROL_H_

--- a/rosidl_buffer/package.xml
+++ b/rosidl_buffer/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rosidl_buffer</name>
+  <version>5.1.2</version>
+  <description>
+    Core Buffer types and implementations for ROS2 native buffer feature.
+    Provides Buffer container type with support for multiple memory backends (CPU, GPU, custom).
+  </description>
+  
+  <maintainer email="cyc@nvidia.com">CY Chen</maintainer>
+  
+  <license>Apache License 2.0</license>
+
+  <author email="cyc@nvidia.com">CY Chen</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/rosidl_buffer/src/c_helpers.cpp
+++ b/rosidl_buffer/src/c_helpers.cpp
@@ -1,0 +1,26 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rosidl_buffer/c_helpers.h"
+#include "rosidl_buffer/buffer.hpp"
+
+extern "C" {
+
+void rosidl_buffer_uint8_throw_if_not_cpu(const void * buffer_ptr)
+{
+  const auto * buf = static_cast<const rosidl::Buffer<uint8_t> *>(buffer_ptr);
+  buf->throw_if_not_cpu_backend();
+}
+
+}  // extern "C"

--- a/rosidl_buffer/test/non_cpu_buffer_impl.hpp
+++ b/rosidl_buffer/test/non_cpu_buffer_impl.hpp
@@ -1,0 +1,52 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NON_CPU_BUFFER_IMPL_HPP_
+#define NON_CPU_BUFFER_IMPL_HPP_
+
+#include <cstddef>
+#include <memory>
+#include <string>
+
+#include "rosidl_buffer/buffer_impl_base.hpp"
+#include "rosidl_buffer/cpu_buffer_impl.hpp"
+
+/// Minimal non-CPU implementation for testing that CPU-only operations throw.
+template<typename T>
+class NonCpuBufferImpl : public rosidl::BufferImplBase<T>
+{
+public:
+  explicit NonCpuBufferImpl(size_t count)
+  : size_(count) {}
+
+  std::string get_backend_type() const override {return "non_cpu_test";}
+  size_t size() const override {return size_;}
+
+  std::unique_ptr<rosidl::BufferImplBase<T>> to_cpu() const override
+  {
+    auto cpu = std::make_unique<rosidl::CpuBufferImpl<T>>();
+    cpu->get_storage().resize(size_);
+    return cpu;
+  }
+
+  std::unique_ptr<rosidl::BufferImplBase<T>> clone() const override
+  {
+    return std::make_unique<NonCpuBufferImpl<T>>(size_);
+  }
+
+private:
+  size_t size_;
+};
+
+#endif  // NON_CPU_BUFFER_IMPL_HPP_

--- a/rosidl_buffer/test/test_buffer.cpp
+++ b/rosidl_buffer/test/test_buffer.cpp
@@ -70,13 +70,22 @@ TEST(TestBuffer, copy_construction) {
   }
 }
 
-// Test move construction
+// Test move construction — moved-from buffer must be valid and empty
 TEST(TestBuffer, move_construction) {
   Buffer<uint8_t> buffer1(3, 100);
   Buffer<uint8_t> buffer2(std::move(buffer1));
 
   EXPECT_EQ(3u, buffer2.size());
   EXPECT_EQ("cpu", buffer2.get_backend_type());
+
+  // Moved-from buffer is in a valid, empty state (not null)
+  EXPECT_EQ(0u, buffer1.size());
+  EXPECT_TRUE(buffer1.empty());
+  EXPECT_EQ("cpu", buffer1.get_backend_type());
+  // Must not crash — moved-from buffer is usable
+  buffer1.push_back(42);
+  EXPECT_EQ(1u, buffer1.size());
+  EXPECT_EQ(42, buffer1[0]);
 }
 
 // Test copy assignment
@@ -93,13 +102,21 @@ TEST(TestBuffer, copy_assignment) {
   }
 }
 
-// Test move assignment
+// Test move assignment — moved-from buffer must be valid and empty
 TEST(TestBuffer, move_assignment) {
   Buffer<uint8_t> buffer1(3, 100);
   Buffer<uint8_t> buffer2;
   buffer2 = std::move(buffer1);
 
   EXPECT_EQ(3u, buffer2.size());
+
+  // Moved-from buffer is in a valid, empty state (not null)
+  EXPECT_EQ(0u, buffer1.size());
+  EXPECT_TRUE(buffer1.empty());
+  EXPECT_EQ("cpu", buffer1.get_backend_type());
+  buffer1.push_back(7);
+  EXPECT_EQ(1u, buffer1.size());
+  EXPECT_EQ(7, buffer1[0]);
 }
 
 // Test element access via operator[]

--- a/rosidl_buffer/test/test_buffer.cpp
+++ b/rosidl_buffer/test/test_buffer.cpp
@@ -1,0 +1,626 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "rosidl_buffer/buffer.hpp"
+#include "rosidl_buffer/buffer_impl_base.hpp"
+#include "rosidl_buffer/cpu_buffer_impl.hpp"
+
+#include "non_cpu_buffer_impl.hpp"
+
+using rosidl::Buffer;
+using rosidl::BufferImplBase;
+using rosidl::CpuBufferImpl;
+
+// Test default construction
+TEST(TestBuffer, default_construction) {
+  Buffer<uint8_t> buffer;
+  EXPECT_EQ(0u, buffer.size());
+  EXPECT_TRUE(buffer.empty());
+  EXPECT_EQ("cpu", buffer.get_backend_type());
+}
+
+// Test construction with size
+TEST(TestBuffer, sized_construction) {
+  Buffer<uint8_t> buffer(10);
+  EXPECT_EQ(10u, buffer.size());
+  EXPECT_FALSE(buffer.empty());
+  EXPECT_EQ("cpu", buffer.get_backend_type());
+}
+
+// Test construction with size and value
+TEST(TestBuffer, sized_value_construction) {
+  Buffer<uint8_t> buffer(5, 42);
+  EXPECT_EQ(5u, buffer.size());
+  for (size_t i = 0; i < buffer.size(); ++i) {
+    EXPECT_EQ(42, buffer[i]);
+  }
+}
+
+// Test copy construction
+TEST(TestBuffer, copy_construction) {
+  Buffer<uint8_t> buffer1(3, 100);
+  Buffer<uint8_t> buffer2(buffer1);
+
+  EXPECT_EQ(buffer1.size(), buffer2.size());
+  EXPECT_EQ(buffer1.get_backend_type(), buffer2.get_backend_type());
+  EXPECT_NE(buffer1.data(), buffer2.data());
+  for (size_t i = 0; i < buffer1.size(); ++i) {
+    EXPECT_EQ(buffer1[i], buffer2[i]);
+    EXPECT_NE(&buffer1[i], &buffer2[i]);
+  }
+}
+
+// Test move construction
+TEST(TestBuffer, move_construction) {
+  Buffer<uint8_t> buffer1(3, 100);
+  Buffer<uint8_t> buffer2(std::move(buffer1));
+
+  EXPECT_EQ(3u, buffer2.size());
+  EXPECT_EQ("cpu", buffer2.get_backend_type());
+}
+
+// Test copy assignment
+TEST(TestBuffer, copy_assignment) {
+  Buffer<uint8_t> buffer1(3, 100);
+  Buffer<uint8_t> buffer2;
+  buffer2 = buffer1;
+
+  EXPECT_EQ(buffer1.size(), buffer2.size());
+  EXPECT_NE(buffer1.data(), buffer2.data());
+  for (size_t i = 0; i < buffer1.size(); ++i) {
+    EXPECT_EQ(buffer1[i], buffer2[i]);
+    EXPECT_NE(&buffer1[i], &buffer2[i]);
+  }
+}
+
+// Test move assignment
+TEST(TestBuffer, move_assignment) {
+  Buffer<uint8_t> buffer1(3, 100);
+  Buffer<uint8_t> buffer2;
+  buffer2 = std::move(buffer1);
+
+  EXPECT_EQ(3u, buffer2.size());
+}
+
+// Test element access via operator[]
+TEST(TestBuffer, element_access) {
+  Buffer<uint8_t> buffer(5);
+  for (size_t i = 0; i < buffer.size(); ++i) {
+    buffer[i] = static_cast<uint8_t>(i * 10);
+  }
+
+  for (size_t i = 0; i < buffer.size(); ++i) {
+    EXPECT_EQ(static_cast<uint8_t>(i * 10), buffer[i]);
+  }
+}
+
+// Test const element access
+TEST(TestBuffer, const_element_access) {
+  Buffer<uint8_t> buffer(3, 42);
+  const Buffer<uint8_t> & const_buffer = buffer;
+
+  EXPECT_EQ(42, const_buffer[0]);
+  EXPECT_EQ(42, const_buffer[1]);
+  EXPECT_EQ(42, const_buffer[2]);
+}
+
+// Test at() with bounds checking
+TEST(TestBuffer, at_access) {
+  Buffer<uint8_t> buffer(3, 99);
+  EXPECT_EQ(99, buffer.at(0));
+  EXPECT_EQ(99, buffer.at(2));
+  EXPECT_THROW(buffer.at(3), std::out_of_range);
+}
+
+// Test front() and back()
+TEST(TestBuffer, front_back_access) {
+  Buffer<uint8_t> buffer;
+  buffer.push_back(10);
+  buffer.push_back(20);
+  buffer.push_back(30);
+
+  EXPECT_EQ(10, buffer.front());
+  EXPECT_EQ(30, buffer.back());
+}
+
+// Test data() pointer access
+TEST(TestBuffer, data_access) {
+  Buffer<uint8_t> buffer(5, 7);
+  uint8_t * ptr = buffer.data();
+  ASSERT_NE(nullptr, ptr);
+  EXPECT_EQ(7, ptr[0]);
+  EXPECT_EQ(7, ptr[4]);
+
+  ptr[2] = 100;
+  EXPECT_EQ(100, buffer[2]);
+}
+
+// Test iterators
+TEST(TestBuffer, iterators) {
+  Buffer<uint8_t> buffer;
+  buffer.push_back(1);
+  buffer.push_back(2);
+  buffer.push_back(3);
+
+  int sum = 0;
+  for (auto it = buffer.begin(); it != buffer.end(); ++it) {
+    sum += *it;
+  }
+  EXPECT_EQ(6, sum);
+
+  // Test const iterators
+  const Buffer<uint8_t> & const_buffer = buffer;
+  int const_sum = 0;
+  for (auto it = const_buffer.begin(); it != const_buffer.end(); ++it) {
+    const_sum += *it;
+  }
+  EXPECT_EQ(6, const_sum);
+}
+
+// Test resize
+TEST(TestBuffer, resize) {
+  Buffer<uint8_t> buffer(5, 10);
+  EXPECT_EQ(5u, buffer.size());
+
+  buffer.resize(10);
+  EXPECT_EQ(10u, buffer.size());
+  EXPECT_EQ(10, buffer[4]);
+
+  buffer.resize(3);
+  EXPECT_EQ(3u, buffer.size());
+}
+
+// Test resize with value
+TEST(TestBuffer, resize_with_value) {
+  Buffer<uint8_t> buffer(2, 5);
+  buffer.resize(5, 99);
+
+  EXPECT_EQ(5u, buffer.size());
+  EXPECT_EQ(5, buffer[0]);
+  EXPECT_EQ(5, buffer[1]);
+  EXPECT_EQ(99, buffer[2]);
+  EXPECT_EQ(99, buffer[4]);
+}
+
+// Test push_back
+TEST(TestBuffer, push_back) {
+  Buffer<uint8_t> buffer;
+  EXPECT_TRUE(buffer.empty());
+
+  buffer.push_back(10);
+  EXPECT_EQ(1u, buffer.size());
+  EXPECT_EQ(10, buffer[0]);
+
+  buffer.push_back(20);
+  EXPECT_EQ(2u, buffer.size());
+  EXPECT_EQ(20, buffer[1]);
+}
+
+// Test push_back with rvalue
+TEST(TestBuffer, push_back_rvalue) {
+  Buffer<uint8_t> buffer;
+  uint8_t val = 0xAB;
+  buffer.push_back(std::move(val));
+
+  EXPECT_EQ(1u, buffer.size());
+  EXPECT_EQ(0xAB, buffer[0]);
+}
+
+// Test pop_back
+TEST(TestBuffer, pop_back) {
+  Buffer<uint8_t> buffer;
+  buffer.push_back(1);
+  buffer.push_back(2);
+  buffer.push_back(3);
+
+  EXPECT_EQ(3u, buffer.size());
+  buffer.pop_back();
+  EXPECT_EQ(2u, buffer.size());
+  EXPECT_EQ(2, buffer.back());
+}
+
+// Test emplace_back
+TEST(TestBuffer, emplace_back) {
+  Buffer<uint8_t> buffer;
+  buffer.emplace_back(0xFF);
+  buffer.emplace_back(0x00);
+
+  EXPECT_EQ(2u, buffer.size());
+  EXPECT_EQ(0xFF, buffer[0]);
+  EXPECT_EQ(0x00, buffer[1]);
+}
+
+// Test assign with count and value
+TEST(TestBuffer, assign_count_value) {
+  Buffer<uint8_t> buffer;
+  buffer.assign(5, 42);
+  EXPECT_EQ(5u, buffer.size());
+  for (size_t i = 0; i < buffer.size(); ++i) {
+    EXPECT_EQ(42, buffer[i]);
+  }
+
+  buffer.assign(3, 7);
+  EXPECT_EQ(3u, buffer.size());
+  for (size_t i = 0; i < buffer.size(); ++i) {
+    EXPECT_EQ(7, buffer[i]);
+  }
+}
+
+// Test assign with iterator range
+TEST(TestBuffer, assign_iterator_range) {
+  std::vector<uint8_t> source = {10, 20, 30, 40, 50};
+  Buffer<uint8_t> buffer;
+  buffer.assign(source.begin(), source.end());
+
+  EXPECT_EQ(5u, buffer.size());
+  for (size_t i = 0; i < source.size(); ++i) {
+    EXPECT_EQ(source[i], buffer[i]);
+  }
+
+  uint8_t arr[] = {1, 2, 3};
+  buffer.assign(std::begin(arr), std::end(arr));
+  EXPECT_EQ(3u, buffer.size());
+  EXPECT_EQ(1, buffer[0]);
+  EXPECT_EQ(2, buffer[1]);
+  EXPECT_EQ(3, buffer[2]);
+}
+
+// Test assign with initializer list
+TEST(TestBuffer, assign_initializer_list) {
+  Buffer<uint8_t> buffer(10, 0);
+  buffer.assign({5, 10, 15});
+
+  EXPECT_EQ(3u, buffer.size());
+  EXPECT_EQ(5, buffer[0]);
+  EXPECT_EQ(10, buffer[1]);
+  EXPECT_EQ(15, buffer[2]);
+}
+
+// Test clear
+TEST(TestBuffer, clear) {
+  Buffer<uint8_t> buffer(10, 42);
+  EXPECT_EQ(10u, buffer.size());
+  EXPECT_FALSE(buffer.empty());
+
+  buffer.clear();
+  EXPECT_EQ(0u, buffer.size());
+  EXPECT_TRUE(buffer.empty());
+}
+
+// Test reserve and capacity (CPU backend only)
+TEST(TestBuffer, reserve_capacity) {
+  Buffer<uint8_t> buffer;
+  buffer.reserve(100);
+
+  EXPECT_EQ(0u, buffer.size());
+  EXPECT_GE(buffer.capacity(), 100u);
+}
+
+// Test shrink_to_fit
+TEST(TestBuffer, shrink_to_fit) {
+  Buffer<uint8_t> buffer;
+  buffer.reserve(100);
+  buffer.push_back(1);
+  buffer.push_back(2);
+
+  EXPECT_GE(buffer.capacity(), 100u);
+  buffer.shrink_to_fit();
+  EXPECT_EQ(2u, buffer.size());
+  EXPECT_LE(buffer.capacity(), 100u);
+}
+
+// Test implicit conversion to std::vector&
+TEST(TestBuffer, implicit_conversion_to_vector) {
+  Buffer<uint8_t> buffer;
+  buffer.push_back(1);
+  buffer.push_back(2);
+  buffer.push_back(3);
+
+  std::vector<uint8_t> & vec_ref = buffer;
+  EXPECT_EQ(3u, vec_ref.size());
+  EXPECT_EQ(1, vec_ref[0]);
+  EXPECT_EQ(2, vec_ref[1]);
+  EXPECT_EQ(3, vec_ref[2]);
+
+  vec_ref[1] = 99;
+  EXPECT_EQ(99, buffer[1]);
+}
+
+// Test const implicit conversion
+TEST(TestBuffer, const_implicit_conversion) {
+  Buffer<uint8_t> buffer(3, 42);
+  const Buffer<uint8_t> & const_buffer = buffer;
+
+  const std::vector<uint8_t> & vec_ref = const_buffer;
+  EXPECT_EQ(3u, vec_ref.size());
+  EXPECT_EQ(42, vec_ref[0]);
+}
+
+// Test to_vector() escape hatch
+TEST(TestBuffer, to_vector_escape_hatch) {
+  Buffer<uint8_t> buffer;
+  buffer.push_back(10);
+  buffer.push_back(20);
+  buffer.push_back(30);
+
+  std::vector<uint8_t> copied = buffer.to_vector();
+  EXPECT_EQ(buffer.size(), copied.size());
+  EXPECT_EQ(10, copied[0]);
+  EXPECT_EQ(20, copied[1]);
+  EXPECT_EQ(30, copied[2]);
+
+  copied[0] = 255;
+  EXPECT_EQ(10, buffer[0]);
+}
+
+// Test backend type
+TEST(TestBuffer, backend_type) {
+  Buffer<uint8_t> buffer;
+  EXPECT_EQ("cpu", buffer.get_backend_type());
+}
+
+// Test using Buffer with algorithms
+TEST(TestBuffer, with_algorithms) {
+  Buffer<uint8_t> buffer;
+  for (uint8_t i = 0; i < 10; ++i) {
+    buffer.push_back(i);
+  }
+
+  auto it = std::find(buffer.begin(), buffer.end(), 5);
+  ASSERT_NE(buffer.end(), it);
+  EXPECT_EQ(5, *it);
+
+  buffer.push_back(5);
+  auto count = std::count(buffer.begin(), buffer.end(), 5);
+  EXPECT_EQ(2, count);
+
+  Buffer<uint8_t> buffer2;
+  buffer2.push_back(3);
+  buffer2.push_back(1);
+  buffer2.push_back(2);
+  std::sort(buffer2.begin(), buffer2.end());
+  EXPECT_EQ(1, buffer2[0]);
+  EXPECT_EQ(2, buffer2[1]);
+  EXPECT_EQ(3, buffer2[2]);
+}
+
+// Test CpuBufferImpl directly
+TEST(TestCpuBufferImpl, basic_operations) {
+  CpuBufferImpl<uint8_t> impl;
+  EXPECT_EQ(0u, impl.get_storage().size());
+
+  impl.get_storage().resize(5);
+  EXPECT_EQ(5u, impl.get_storage().size());
+
+  auto & storage = impl.get_storage();
+  storage[0] = 100;
+  EXPECT_EQ(100, storage[0]);
+
+  impl.get_storage().clear();
+  EXPECT_EQ(0u, impl.get_storage().size());
+}
+
+// Test CpuBufferImpl::to_cpu()
+TEST(TestCpuBufferImpl, to_cpu) {
+  CpuBufferImpl<uint8_t> impl;
+  impl.get_storage().resize(3);
+  auto & storage = impl.get_storage();
+  storage[0] = 1;
+  storage[1] = 2;
+  storage[2] = 3;
+
+  auto cpu_copy = impl.to_cpu();
+  ASSERT_NE(nullptr, cpu_copy);
+
+  auto * cpu_impl = static_cast<CpuBufferImpl<uint8_t> *>(cpu_copy.get());
+  EXPECT_EQ(3u, cpu_impl->get_storage().size());
+  EXPECT_EQ(1, cpu_impl->get_storage()[0]);
+  EXPECT_EQ(2, cpu_impl->get_storage()[1]);
+  EXPECT_EQ(3, cpu_impl->get_storage()[2]);
+}
+
+// Test CpuBufferImpl storage data pointer
+TEST(TestCpuBufferImpl, storage_data_pointer) {
+  CpuBufferImpl<uint8_t> impl;
+
+  EXPECT_TRUE(impl.get_storage().empty());
+
+  impl.get_storage().resize(5);
+  const uint8_t * data_ptr = impl.get_storage().data();
+  ASSERT_NE(nullptr, data_ptr);
+
+  impl.get_storage()[0] = 42;
+  EXPECT_EQ(42, data_ptr[0]);
+}
+
+// Test Buffer copy creates independent clone (deep copy via unique_ptr)
+TEST(TestBuffer, deep_copy_semantics) {
+  Buffer<uint8_t> buffer1;
+  buffer1.push_back(10);
+  buffer1.push_back(20);
+
+  Buffer<uint8_t> buffer2 = buffer1;
+
+  EXPECT_EQ(buffer1.size(), buffer2.size());
+  EXPECT_EQ(buffer1[0], buffer2[0]);
+  EXPECT_EQ(buffer1[1], buffer2[1]);
+
+  buffer2[0] = 255;
+  EXPECT_EQ(10, buffer1[0]);
+  EXPECT_EQ(255, buffer2[0]);
+}
+
+// Test Buffer construction from a custom impl
+TEST(TestBuffer, construct_from_impl) {
+  auto custom_impl = std::make_unique<CpuBufferImpl<uint8_t>>();
+  custom_impl->get_storage().resize(3);
+  custom_impl->get_storage()[0] = 100;
+  custom_impl->get_storage()[1] = 200;
+  custom_impl->get_storage()[2] = 250;
+
+  Buffer<uint8_t> buffer(std::move(custom_impl));
+
+  EXPECT_EQ("cpu", buffer.get_backend_type());
+  EXPECT_EQ(3u, buffer.size());
+  EXPECT_EQ(100, buffer[0]);
+  EXPECT_EQ(200, buffer[1]);
+  EXPECT_EQ(250, buffer[2]);
+}
+
+// Test that constructing a Buffer with nullptr impl throws
+TEST(TestBuffer, construct_from_null_impl_throws) {
+  EXPECT_THROW(Buffer<uint8_t>(nullptr), std::invalid_argument);
+}
+
+// Test that Buffer works with non-trivial types (template generality)
+TEST(TestBuffer, with_string) {
+  Buffer<std::string> buffer;
+  buffer.push_back("hello");
+  buffer.push_back("world");
+
+  EXPECT_EQ(2u, buffer.size());
+  EXPECT_EQ("hello", buffer[0]);
+  EXPECT_EQ("world", buffer[1]);
+
+  std::vector<std::string> copied = buffer.to_vector();
+  EXPECT_EQ("hello", copied[0]);
+  EXPECT_EQ("world", copied[1]);
+}
+
+// Test Buffer with struct types
+TEST(TestBuffer, with_struct)
+{
+  struct Point
+  {
+    double x;
+    double y;
+    double z;
+  };
+
+  Buffer<Point> buffer;
+  buffer.push_back({1.0, 2.0, 3.0});
+  buffer.push_back({4.0, 5.0, 6.0});
+
+  EXPECT_EQ(2u, buffer.size());
+  EXPECT_DOUBLE_EQ(1.0, buffer[0].x);
+  EXPECT_DOUBLE_EQ(5.0, buffer[1].y);
+
+  std::vector<Point> copied = buffer.to_vector();
+  EXPECT_DOUBLE_EQ(3.0, copied[0].z);
+}
+
+TEST(TestBufferNonCpu, backend_type) {
+  auto impl = std::make_unique<NonCpuBufferImpl<uint8_t>>(4);
+  Buffer<uint8_t> buffer(std::move(impl));
+
+  EXPECT_EQ("non_cpu_test", buffer.get_backend_type());
+  EXPECT_EQ(4u, buffer.size());
+  EXPECT_FALSE(buffer.empty());
+}
+
+TEST(TestBufferNonCpu, element_access_throws) {
+  auto impl = std::make_unique<NonCpuBufferImpl<uint8_t>>(4);
+  Buffer<uint8_t> buffer(std::move(impl));
+
+  EXPECT_THROW(buffer[0], std::runtime_error);
+  EXPECT_THROW(buffer.at(0), std::runtime_error);
+  EXPECT_THROW(buffer.front(), std::runtime_error);
+  EXPECT_THROW(buffer.back(), std::runtime_error);
+  EXPECT_THROW(buffer.data(), std::runtime_error);
+}
+
+TEST(TestBufferNonCpu, const_element_access_throws) {
+  auto impl = std::make_unique<NonCpuBufferImpl<uint8_t>>(4);
+  const Buffer<uint8_t> buffer(std::move(impl));
+
+  EXPECT_THROW(buffer[0], std::runtime_error);
+  EXPECT_THROW(buffer.at(0), std::runtime_error);
+  EXPECT_THROW(buffer.front(), std::runtime_error);
+  EXPECT_THROW(buffer.back(), std::runtime_error);
+  EXPECT_THROW(buffer.data(), std::runtime_error);
+}
+
+TEST(TestBufferNonCpu, iterators_throw) {
+  auto impl = std::make_unique<NonCpuBufferImpl<uint8_t>>(4);
+  Buffer<uint8_t> buffer(std::move(impl));
+
+  EXPECT_THROW(buffer.begin(), std::runtime_error);
+  EXPECT_THROW(buffer.end(), std::runtime_error);
+  EXPECT_THROW(buffer.cbegin(), std::runtime_error);
+  EXPECT_THROW(buffer.cend(), std::runtime_error);
+}
+
+TEST(TestBufferNonCpu, modifiers_throw) {
+  auto impl = std::make_unique<NonCpuBufferImpl<uint8_t>>(4);
+  Buffer<uint8_t> buffer(std::move(impl));
+
+  EXPECT_THROW(buffer.assign(3, 0), std::runtime_error);
+  EXPECT_THROW(buffer.assign({1, 2}), std::runtime_error);
+  std::vector<uint8_t> v = {1};
+  EXPECT_THROW(buffer.assign(v.begin(), v.end()), std::runtime_error);
+  EXPECT_THROW(buffer.resize(10), std::runtime_error);
+  EXPECT_THROW(buffer.resize(10, 0), std::runtime_error);
+  EXPECT_THROW(buffer.clear(), std::runtime_error);
+  EXPECT_THROW(buffer.push_back(1), std::runtime_error);
+  EXPECT_THROW(buffer.pop_back(), std::runtime_error);
+  EXPECT_THROW(buffer.emplace_back(1), std::runtime_error);
+}
+
+TEST(TestBufferNonCpu, capacity_throws) {
+  auto impl = std::make_unique<NonCpuBufferImpl<uint8_t>>(4);
+  Buffer<uint8_t> buffer(std::move(impl));
+
+  EXPECT_THROW(buffer.reserve(10), std::runtime_error);
+  EXPECT_THROW(buffer.capacity(), std::runtime_error);
+  EXPECT_THROW(buffer.shrink_to_fit(), std::runtime_error);
+}
+
+TEST(TestBufferNonCpu, implicit_conversion_throws) {
+  auto impl = std::make_unique<NonCpuBufferImpl<uint8_t>>(4);
+  Buffer<uint8_t> buffer(std::move(impl));
+
+  EXPECT_THROW(
+    {std::vector<uint8_t> & ref = buffer; (void)ref;},
+    std::runtime_error);
+
+  auto impl2 = std::make_unique<NonCpuBufferImpl<uint8_t>>(4);
+  const Buffer<uint8_t> cbuffer(std::move(impl2));
+
+  EXPECT_THROW(
+    {const std::vector<uint8_t> & ref = cbuffer; (void)ref;},
+    std::runtime_error);
+}
+
+TEST(TestBufferNonCpu, to_vector_works) {
+  auto impl = std::make_unique<NonCpuBufferImpl<uint8_t>>(3);
+  Buffer<uint8_t> buffer(std::move(impl));
+
+  std::vector<uint8_t> vec = buffer.to_vector();
+  EXPECT_EQ(3u, vec.size());
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/rosidl_buffer/test/test_c_helpers.cpp
+++ b/rosidl_buffer/test/test_c_helpers.cpp
@@ -1,0 +1,50 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+
+#include "rosidl_buffer/buffer.hpp"
+#include "rosidl_buffer/c_helpers.h"
+
+#include "non_cpu_buffer_impl.hpp"
+
+using rosidl::Buffer;
+
+// -- rosidl_buffer_uint8_throw_if_not_cpu --
+
+TEST(TestCHelpers, throw_if_not_cpu_does_not_throw_for_cpu) {
+  Buffer<uint8_t> buf(5, 1);
+  EXPECT_NO_THROW(rosidl_buffer_uint8_throw_if_not_cpu(&buf));
+}
+
+TEST(TestCHelpers, throw_if_not_cpu_does_not_throw_for_empty_cpu) {
+  Buffer<uint8_t> buf;
+  EXPECT_NO_THROW(rosidl_buffer_uint8_throw_if_not_cpu(&buf));
+}
+
+TEST(TestCHelpers, throw_if_not_cpu_throws_for_non_cpu_backend) {
+  auto impl = std::make_unique<NonCpuBufferImpl<uint8_t>>(4);
+  Buffer<uint8_t> buf(std::move(impl));
+  EXPECT_THROW(rosidl_buffer_uint8_throw_if_not_cpu(&buf), std::runtime_error);
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/rosidl_buffer_backend/CMakeLists.txt
+++ b/rosidl_buffer_backend/CMakeLists.txt
@@ -1,0 +1,54 @@
+cmake_minimum_required(VERSION 3.5)
+project(rosidl_buffer_backend)
+
+# Default to C++17
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# Find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rmw REQUIRED)
+
+# This is a header-only library
+add_library(${PROJECT_NAME} INTERFACE)
+
+target_include_directories(${PROJECT_NAME} INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
+)
+
+target_link_libraries(${PROJECT_NAME} INTERFACE
+  rmw::rmw
+)
+
+# Install headers
+install(
+  DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
+)
+
+# Install library target
+install(
+  TARGETS ${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include/${PROJECT_NAME}
+)
+
+# Export dependencies
+ament_export_targets(${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_dependencies(rmw)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/rosidl_buffer_backend/include/rosidl_buffer_backend/buffer_backend.hpp
+++ b/rosidl_buffer_backend/include/rosidl_buffer_backend/buffer_backend.hpp
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "rmw/topic_endpoint_info.h"
+#include "rosidl_runtime_c/message_type_support_struct.h"
 
 namespace rosidl
 {
@@ -44,6 +45,14 @@ public:
   {
     return "";
   }
+
+  /// Get the descriptor message type support handle for this backend.
+  /// This must return a rosidl_typesupport_fastrtps_cpp handle.
+  virtual const rosidl_message_type_support_t * get_descriptor_type_support() const = 0;
+
+  /// Create an empty descriptor message instance for this backend.
+  /// The returned object must match get_descriptor_type_support().
+  virtual std::shared_ptr<void> create_empty_descriptor() const = 0;
 
   /// Create a descriptor message with endpoint awareness.
   /// @param impl Type-erased BufferImplBase pointer.

--- a/rosidl_buffer_backend/include/rosidl_buffer_backend/buffer_backend.hpp
+++ b/rosidl_buffer_backend/include/rosidl_buffer_backend/buffer_backend.hpp
@@ -55,22 +55,24 @@ public:
   virtual std::shared_ptr<void> create_empty_descriptor() const = 0;
 
   /// Create a descriptor message with endpoint awareness.
-  /// @param impl Type-erased BufferImplBase pointer.
+  /// @param impl Non-owning, type-erased BufferImplBase pointer (read-only).
+  ///        Backends that need internal bookkeeping (e.g. IPC handle setup,
+  ///        memory pinning) should use `mutable` members in their impl class.
   /// @param endpoint_info Endpoint info for the peer.
   /// @return Type-erased descriptor message, or nullptr if the backend cannot
   ///         handle this endpoint (e.g., the peer does not support this backend).
   ///         Returning nullptr signals the serialization layer to fall back to
   ///         CPU-based serialization.
   virtual std::shared_ptr<void> create_descriptor_with_endpoint(
-    const std::shared_ptr<void> & impl,
+    const void * impl,
     const rmw_topic_endpoint_info_t & endpoint_info) const = 0;
 
   /// Create a BufferImpl from descriptor with endpoint awareness.
-  /// @param descriptor Type-erased descriptor message pointer.
+  /// @param descriptor Non-owning, type-erased descriptor message pointer (read-only).
   /// @param endpoint_info Endpoint info for the peer.
   /// @return Type-erased BufferImplBase pointer.
   virtual std::shared_ptr<void> from_descriptor_with_endpoint(
-    const std::shared_ptr<void> & descriptor,
+    const void * descriptor,
     const rmw_topic_endpoint_info_t & endpoint_info) const = 0;
 
   /// Hook invoked when creating a local endpoint.

--- a/rosidl_buffer_backend/include/rosidl_buffer_backend/buffer_backend.hpp
+++ b/rosidl_buffer_backend/include/rosidl_buffer_backend/buffer_backend.hpp
@@ -30,6 +30,12 @@
 namespace rosidl
 {
 
+/// Upper bound (in bytes) on the serialized size of any buffer backend
+/// descriptor message. Backends must ensure that every descriptor produced
+/// by create_descriptor_with_endpoint() serializes to no more than this
+/// many bytes.
+inline constexpr size_t kMaxBufferDescriptorSize = 4096;
+
 /// Abstract interface for vendor-specific buffer backend implementations.
 class BufferBackend
 {
@@ -62,7 +68,8 @@ public:
   /// @return Type-erased descriptor message, or nullptr if the backend cannot
   ///         handle this endpoint (e.g., the peer does not support this backend).
   ///         Returning nullptr signals the serialization layer to fall back to
-  ///         CPU-based serialization.
+  ///         CPU-based serialization. The descriptor must not exceed
+  ///         kMaxBufferDescriptorSize bytes.
   virtual std::shared_ptr<void> create_descriptor_with_endpoint(
     const void * impl,
     const rmw_topic_endpoint_info_t & endpoint_info) const = 0;

--- a/rosidl_buffer_backend/include/rosidl_buffer_backend/buffer_backend.hpp
+++ b/rosidl_buffer_backend/include/rosidl_buffer_backend/buffer_backend.hpp
@@ -38,9 +38,9 @@ public:
   /// Get the backend type name
   virtual std::string get_backend_type() const = 0;
 
-  /// Get the backend aux info string
+  /// Get the backend metadata string.
   /// This is used by the backend to pass backend-specific information to other endpoints.
-  virtual std::string get_backend_aux_info() const
+  virtual std::string get_backend_metadata() const
   {
     return "";
   }
@@ -75,7 +75,7 @@ public:
   /// Returns {compatible, groups of endpoint GID hashes}.
   /// @param endpoint_info Information about the discovered endpoint
   /// @param existing_endpoints List of existing endpoints for grouping decisions
-  /// @param endpoint_supported_backends Map of backend type to aux info string
+  /// @param endpoint_supported_backends Map of backend type to backend metadata string
   ///        for the discovered endpoint
   virtual std::pair<bool, std::vector<std::set<uint32_t>>> on_discovering_endpoint(
     const rmw_topic_endpoint_info_t & endpoint_info,

--- a/rosidl_buffer_backend/include/rosidl_buffer_backend/buffer_backend.hpp
+++ b/rosidl_buffer_backend/include/rosidl_buffer_backend/buffer_backend.hpp
@@ -1,0 +1,94 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_BUFFER_BACKEND__BUFFER_BACKEND_HPP_
+#define ROSIDL_BUFFER_BACKEND__BUFFER_BACKEND_HPP_
+
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <set>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "rmw/topic_endpoint_info.h"
+
+namespace rosidl
+{
+
+/// Abstract interface for vendor-specific buffer backend implementations.
+class BufferBackend
+{
+public:
+  virtual ~BufferBackend() = default;
+
+  /// Get the backend type name
+  virtual std::string get_backend_type() const = 0;
+
+  /// Get the backend aux info string
+  /// This is used by the backend to pass backend-specific information to other endpoints.
+  virtual std::string get_backend_aux_info() const
+  {
+    return "";
+  }
+
+  /// Create a descriptor message with endpoint awareness.
+  /// @param impl Type-erased BufferImplBase pointer.
+  /// @param endpoint_info Endpoint info for the peer.
+  /// @return Type-erased descriptor message, or nullptr if the backend cannot
+  ///         handle this endpoint (e.g., the peer does not support this backend).
+  ///         Returning nullptr signals the serialization layer to fall back to
+  ///         CPU-based serialization.
+  virtual std::shared_ptr<void> create_descriptor_with_endpoint(
+    const std::shared_ptr<void> & impl,
+    const rmw_topic_endpoint_info_t & endpoint_info) const = 0;
+
+  /// Create a BufferImpl from descriptor with endpoint awareness.
+  /// @param descriptor Type-erased descriptor message pointer.
+  /// @param endpoint_info Endpoint info for the peer.
+  /// @return Type-erased BufferImplBase pointer.
+  virtual std::shared_ptr<void> from_descriptor_with_endpoint(
+    const std::shared_ptr<void> & descriptor,
+    const rmw_topic_endpoint_info_t & endpoint_info) const = 0;
+
+  /// Hook invoked when creating a local endpoint.
+  virtual void on_creating_endpoint(
+    const rmw_topic_endpoint_info_t & endpoint_info) const
+  {
+    (void)endpoint_info;
+  }
+
+  /// Hook invoked when discovering a remote endpoint.
+  /// Returns {compatible, groups of endpoint GID hashes}.
+  /// @param endpoint_info Information about the discovered endpoint
+  /// @param existing_endpoints List of existing endpoints for grouping decisions
+  /// @param endpoint_supported_backends Map of backend type to aux info string
+  ///        for the discovered endpoint
+  virtual std::pair<bool, std::vector<std::set<uint32_t>>> on_discovering_endpoint(
+    const rmw_topic_endpoint_info_t & endpoint_info,
+    const std::vector<rmw_topic_endpoint_info_t> & existing_endpoints,
+    const std::unordered_map<std::string, std::string> & endpoint_supported_backends)
+  {
+    (void)endpoint_info;
+    (void)existing_endpoints;
+    (void)endpoint_supported_backends;
+    return {true, {}};
+  }
+};
+
+}  // namespace rosidl
+
+#endif  // ROSIDL_BUFFER_BACKEND__BUFFER_BACKEND_HPP_

--- a/rosidl_buffer_backend/include/rosidl_buffer_backend/buffer_backend.hpp
+++ b/rosidl_buffer_backend/include/rosidl_buffer_backend/buffer_backend.hpp
@@ -70,8 +70,9 @@ public:
   /// Create a BufferImpl from descriptor with endpoint awareness.
   /// @param descriptor Non-owning, type-erased descriptor message pointer (read-only).
   /// @param endpoint_info Endpoint info for the peer.
-  /// @return Type-erased BufferImplBase pointer.
-  virtual std::shared_ptr<void> from_descriptor_with_endpoint(
+  /// @return Type-erased unique pointer to a newly created BufferImplBase instance.
+  ///         The custom deleter ensures correct destruction across the plugin boundary.
+  virtual std::unique_ptr<void, void (*)(void *)> from_descriptor_with_endpoint(
     const void * descriptor,
     const rmw_topic_endpoint_info_t & endpoint_info) const = 0;
 

--- a/rosidl_buffer_backend/include/rosidl_buffer_backend/buffer_descriptor_ops.hpp
+++ b/rosidl_buffer_backend/include/rosidl_buffer_backend/buffer_descriptor_ops.hpp
@@ -1,0 +1,44 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_BUFFER_BACKEND__BUFFER_DESCRIPTOR_OPS_HPP_
+#define ROSIDL_BUFFER_BACKEND__BUFFER_DESCRIPTOR_OPS_HPP_
+
+#include <functional>
+#include <memory>
+
+#include "rmw/topic_endpoint_info.h"
+
+namespace rosidl
+{
+
+/// Type-erased descriptor conversion callbacks used by the serialization layer.
+struct BufferDescriptorOps
+{
+  /// Create descriptor with endpoint awareness.
+  /// Input pointer (`impl`) is a type-erased `BufferImplBase<T>` instance.
+  /// Return value is a type-erased backend descriptor message instance.
+  std::function<std::shared_ptr<void>(const std::shared_ptr<void> &,
+    const rmw_topic_endpoint_info_t &)> create_descriptor_with_endpoint;
+
+  /// Create buffer impl from descriptor with endpoint awareness.
+  /// Input pointer (`descriptor`) is a type-erased backend descriptor message.
+  /// Return value is a type-erased `BufferImplBase<T>` instance.
+  std::function<std::shared_ptr<void>(const std::shared_ptr<void> &,
+    const rmw_topic_endpoint_info_t &)> from_descriptor_with_endpoint;
+};
+
+}  // namespace rosidl
+
+#endif  // ROSIDL_BUFFER_BACKEND__BUFFER_DESCRIPTOR_OPS_HPP_

--- a/rosidl_buffer_backend/include/rosidl_buffer_backend/buffer_descriptor_ops.hpp
+++ b/rosidl_buffer_backend/include/rosidl_buffer_backend/buffer_descriptor_ops.hpp
@@ -36,8 +36,9 @@ struct BufferDescriptorOps
   /// Create buffer impl from descriptor with endpoint awareness.
   /// Input pointer (`descriptor`) is a non-owning, type-erased backend descriptor
   /// message (read-only).
-  /// Return value is a type-erased `BufferImplBase<T>` instance.
-  std::function<std::shared_ptr<void>(const void *,
+  /// Return value is a type-erased unique pointer to a newly created
+  /// `BufferImplBase<T>` instance.
+  std::function<std::unique_ptr<void, void (*)(void *)>(const void *,
     const rmw_topic_endpoint_info_t &)> from_descriptor_with_endpoint;
 };
 

--- a/rosidl_buffer_backend/include/rosidl_buffer_backend/buffer_descriptor_ops.hpp
+++ b/rosidl_buffer_backend/include/rosidl_buffer_backend/buffer_descriptor_ops.hpp
@@ -27,15 +27,17 @@ namespace rosidl
 struct BufferDescriptorOps
 {
   /// Create descriptor with endpoint awareness.
-  /// Input pointer (`impl`) is a type-erased `BufferImplBase<T>` instance.
+  /// Input pointer (`impl`) is a non-owning, read-only, type-erased
+  /// `BufferImplBase<T>` instance.
   /// Return value is a type-erased backend descriptor message instance.
-  std::function<std::shared_ptr<void>(const std::shared_ptr<void> &,
+  std::function<std::shared_ptr<void>(const void *,
     const rmw_topic_endpoint_info_t &)> create_descriptor_with_endpoint;
 
   /// Create buffer impl from descriptor with endpoint awareness.
-  /// Input pointer (`descriptor`) is a type-erased backend descriptor message.
+  /// Input pointer (`descriptor`) is a non-owning, type-erased backend descriptor
+  /// message (read-only).
   /// Return value is a type-erased `BufferImplBase<T>` instance.
-  std::function<std::shared_ptr<void>(const std::shared_ptr<void> &,
+  std::function<std::shared_ptr<void>(const void *,
     const rmw_topic_endpoint_info_t &)> from_descriptor_with_endpoint;
 };
 

--- a/rosidl_buffer_backend/include/rosidl_buffer_backend/visibility_control.h
+++ b/rosidl_buffer_backend/include/rosidl_buffer_backend/visibility_control.h
@@ -1,0 +1,58 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_BUFFER_BACKEND__VISIBILITY_CONTROL_H_
+#define ROSIDL_BUFFER_BACKEND__VISIBILITY_CONTROL_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define ROSIDL_BUFFER_BACKEND_EXPORT __attribute__ ((dllexport))
+    #define ROSIDL_BUFFER_BACKEND_IMPORT __attribute__ ((dllimport))
+  #else
+    #define ROSIDL_BUFFER_BACKEND_EXPORT __declspec(dllexport)
+    #define ROSIDL_BUFFER_BACKEND_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef ROSIDL_BUFFER_BACKEND_BUILDING_DLL
+    #define ROSIDL_BUFFER_BACKEND_PUBLIC ROSIDL_BUFFER_BACKEND_EXPORT
+  #else
+    #define ROSIDL_BUFFER_BACKEND_PUBLIC ROSIDL_BUFFER_BACKEND_IMPORT
+  #endif
+  #define ROSIDL_BUFFER_BACKEND_PUBLIC_TYPE ROSIDL_BUFFER_BACKEND_PUBLIC
+  #define ROSIDL_BUFFER_BACKEND_LOCAL
+#else
+  #define ROSIDL_BUFFER_BACKEND_EXPORT __attribute__ ((visibility("default")))
+  #define ROSIDL_BUFFER_BACKEND_IMPORT
+  #if __GNUC__ >= 4
+    #define ROSIDL_BUFFER_BACKEND_PUBLIC __attribute__ ((visibility("default")))
+    #define ROSIDL_BUFFER_BACKEND_LOCAL  __attribute__ ((visibility("hidden")))
+  #else
+    #define ROSIDL_BUFFER_BACKEND_PUBLIC
+    #define ROSIDL_BUFFER_BACKEND_LOCAL
+  #endif
+  #define ROSIDL_BUFFER_BACKEND_PUBLIC_TYPE
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // ROSIDL_BUFFER_BACKEND__VISIBILITY_CONTROL_H_

--- a/rosidl_buffer_backend/package.xml
+++ b/rosidl_buffer_backend/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rosidl_buffer_backend</name>
+  <version>5.1.2</version>
+  <description>Buffer backend interface for ROS2 buffer types</description>
+  
+  <maintainer email="cyc@nvidia.com">CY Chen</maintainer>
+  
+  <license>Apache License 2.0</license>
+
+  <author email="cyc@nvidia.com">CY Chen</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rmw</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
## Description

This pull request adds `rosidl_buffer` and `rosidl_buffer_backend` packages - core C++ buffer types for the ROS 2 native buffer feature. This package introduces `rosidl::Buffer<T>`, a polymorphic container that's designed to replace `std::vector<T>` for `uint8[]` message fields (to be adopted in later pull requests; we focus on only the core buffer types in this pull request.) The native buffer type and its backend class enable vendor-specific memory buffer implementation (CUDA, ROCm, etc.) while maintaining backward compatibility for existing CPU-based `std::vector<T>` user code.

This pull request consists of the following key components:
- **`Buffer<T>`**: PIMPL-based container providing `std::vector<T>`-compatible API. All vector-compatible operations (element access, iterators, modifiers) are CPU-only and throw `std::runtime_error` for non-CPU backends. Backend management APIs (`get_backend_type()`, `get_impl()`, `to_vector()`) work for all backends.
- **`BufferImplBase<T>`**: Minimal abstract base class of buffer implementation. All backend-specific APIs are to be provided by the vendor-specific backend implementations.
- **`CpuBufferImpl<T>`**: CPU-based buffer implementation wrapping `std::vector<T>`.
- **`BufferBackend`**: Abstract interface for vendor-specific buffer backend implementations. 

### Is this user-facing behavior change?

This pull request does not change existing behavior.
When adopted in later pull requests, message types with `uint8[]` fields (e.g., `sensor_msgs/msg/Image.data`) will use `rosidl::Buffer<uint8_t>` instead of `std::vector<uint8_t>`. For CPU backends (the default), `Buffer<T>` is a transparent drop-in replacement.


### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

Yes. Claude (claude-4.6-opus) via Cursor was used to assist with the `std::vector<T>` compatibility feature in the `rosidl::Buffer<T>` class and generate portions of the unit tests.


### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

This package/PL is part of the broader ROS2 native buffer feature introduced in this [post](https://discourse.openrobotics.org/t/working-prototype-of-native-buffers-accelerated-memory-transport/52399).