### PR TITLE
Add support for rosidl::Buffer in rosidl C path for rclpy

### DIFF
--- a/rosidl_buffer/include/rosidl_buffer/c_helpers.h
+++ b/rosidl_buffer/include/rosidl_buffer/c_helpers.h
@@ -22,21 +22,24 @@ extern "C" {
 #endif
 
 /// Throw std::runtime_error if the buffer is not CPU-backed.
-/// @param buffer_ptr Opaque pointer to an rosidl::Buffer<uint8_t>
+/**
+ * \param[in] buffer_ptr Opaque pointer to an rosidl::Buffer<uint8_t>
+ */
 ROSIDL_BUFFER_PUBLIC
 void rosidl_buffer_uint8_throw_if_not_cpu(const void * buffer_ptr);
 
 /// Destroy a heap-allocated rosidl::Buffer<uint8_t>.
-///
-/// This is the canonical destruction function for Buffer pointers that were
-/// created with `new rosidl::Buffer<uint8_t>()` during deserialization.
-/// The virtual destructor chain in BufferImplBase ensures backend-specific
-/// cleanup (e.g. GPU memory) happens automatically.
-///
-/// Safe to call with NULL (no-op).
-///
-/// @param buffer_ptr Opaque pointer to a heap-allocated rosidl::Buffer<uint8_t>,
-///                   or NULL.
+/**
+ * This is the canonical destruction function for Buffer pointers that were
+ * created with `new rosidl::Buffer<uint8_t>()` during deserialization.
+ * The virtual destructor chain in BufferImplBase ensures backend-specific
+ * cleanup (e.g. GPU memory) happens automatically.
+ *
+ * Safe to call with NULL (no-op).
+ *
+ * \param[in] buffer_ptr Opaque pointer to a heap-allocated rosidl::Buffer<uint8_t>,
+ *   or NULL.
+ */
 ROSIDL_BUFFER_PUBLIC
 void rosidl_buffer_uint8_destroy(void * buffer_ptr);
 

--- a/rosidl_buffer/include/rosidl_buffer/c_helpers.h
+++ b/rosidl_buffer/include/rosidl_buffer/c_helpers.h
@@ -26,6 +26,20 @@ extern "C" {
 ROSIDL_BUFFER_PUBLIC
 void rosidl_buffer_uint8_throw_if_not_cpu(const void * buffer_ptr);
 
+/// Destroy a heap-allocated rosidl::Buffer<uint8_t>.
+///
+/// This is the canonical destruction function for Buffer pointers that were
+/// created with `new rosidl::Buffer<uint8_t>()` during deserialization.
+/// The virtual destructor chain in BufferImplBase ensures backend-specific
+/// cleanup (e.g. GPU memory) happens automatically.
+///
+/// Safe to call with NULL (no-op).
+///
+/// @param buffer_ptr Opaque pointer to a heap-allocated rosidl::Buffer<uint8_t>,
+///                   or NULL.
+ROSIDL_BUFFER_PUBLIC
+void rosidl_buffer_uint8_destroy(void * buffer_ptr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/rosidl_buffer/src/c_helpers.cpp
+++ b/rosidl_buffer/src/c_helpers.cpp
@@ -26,4 +26,11 @@ void rosidl_buffer_uint8_throw_if_not_cpu(const void * buffer_ptr)
   buf->throw_if_not_cpu_backend();
 }
 
+void rosidl_buffer_uint8_destroy(void * buffer_ptr)
+{
+  if (buffer_ptr) {
+    delete static_cast<rosidl::Buffer<uint8_t> *>(buffer_ptr);
+  }
+}
+
 }  // extern "C"

--- a/rosidl_buffer/test/test_c_helpers.cpp
+++ b/rosidl_buffer/test/test_c_helpers.cpp
@@ -43,6 +43,24 @@ TEST(TestCHelpers, throw_if_not_cpu_throws_for_non_cpu_backend) {
   EXPECT_THROW(rosidl_buffer_uint8_throw_if_not_cpu(&buf), std::runtime_error);
 }
 
+// -- rosidl_buffer_uint8_destroy --
+
+TEST(TestCHelpers, destroy_null_is_noop) {
+  EXPECT_NO_THROW(rosidl_buffer_uint8_destroy(nullptr));
+}
+
+TEST(TestCHelpers, destroy_cpu_buffer) {
+  auto * buf = new Buffer<uint8_t>({1, 2, 3, 4, 5});
+  EXPECT_EQ(buf->size(), 5u);
+  rosidl_buffer_uint8_destroy(buf);
+}
+
+TEST(TestCHelpers, destroy_non_cpu_buffer) {
+  auto * buf = new Buffer<uint8_t>(std::make_unique<NonCpuBufferImpl<uint8_t>>(10));
+  EXPECT_EQ(buf->get_backend_type(), "non_cpu_test");
+  rosidl_buffer_uint8_destroy(buf);
+}
+
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/rosidl_buffer_py/CMakeLists.txt
+++ b/rosidl_buffer_py/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.5)
+project(rosidl_buffer_py)
+
+# Default to C++17
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
+find_package(rosidl_buffer REQUIRED)
+
+# Find python before pybind11
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+find_package(pybind11 REQUIRED)
+
+# Build the pybind11 C++ extension module
+pybind11_add_module(_rosidl_buffer_py
+  src/rosidl_buffer_py.cpp
+)
+
+target_link_libraries(_rosidl_buffer_py PRIVATE
+  rosidl_buffer::rosidl_buffer
+)
+
+# Install the Python package (must come before install(TARGETS) to set PYTHON_INSTALL_DIR)
+ament_python_install_package(rosidl_buffer)
+
+# Install the C++ extension module into the Python package directory
+install(TARGETS _rosidl_buffer_py
+  DESTINATION "${PYTHON_INSTALL_DIR}/rosidl_buffer"
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/rosidl_buffer_py/package.xml
+++ b/rosidl_buffer_py/package.xml
@@ -25,6 +25,8 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 
+  <member_of_group>rosidl_runtime_packages</member_of_group>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/rosidl_buffer_py/package.xml
+++ b/rosidl_buffer_py/package.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rosidl_buffer_py</name>
+  <version>5.1.2</version>
+  <description>
+    Python bindings for rosidl::Buffer, providing a Buffer class that
+    supports vendor-specific memory backends (CPU, GPU, custom) for rclpy users.
+  </description>
+
+  <maintainer email="cyc@nvidia.com">CY Chen</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <author email="cyc@nvidia.com">CY Chen</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
+
+  <depend>rosidl_buffer</depend>
+
+  <build_depend>pybind11</build_depend>
+  <build_depend>python3-dev</build_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/rosidl_buffer_py/rosidl_buffer/__init__.py
+++ b/rosidl_buffer_py/rosidl_buffer/__init__.py
@@ -1,0 +1,123 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""
+rosidl_buffer - Python bindings for ROS 2 native buffer feature.
+
+Provides a Buffer type that wraps rosidl::Buffer<uint8_t> and
+supports vendor-specific memory backends (CPU, GPU, custom).
+
+CPU-based buffer data is always delivered to rclpy subscribers as
+plain ``array.array('B')``, so existing code works unchanged.  The
+Buffer class is only instantiated for non-CPU (vendor-backed) data
+where users interact with it through vendor-specific APIs.
+
+Users never construct Buffer directly.  Instead, backend providers
+supply factory functions (e.g. demo_buffer.DemoBuffer) that return
+Buffer objects for publishing vendor-backed data.
+
+Example usage:
+    from demo_buffer import DemoBuffer
+
+    buf = DemoBuffer(b'\x00\x01\x02\x03')
+    assert buf.backend_type == 'demo'
+    assert len(buf) == 4
+    assert buf.to_bytes() == b'\x00\x01\x02\x03'
+
+    msg = Image()
+    msg.data = buf
+"""
+
+from rosidl_buffer import _rosidl_buffer_py
+
+
+class Buffer:
+    """
+    Vendor-backed buffer for non-CPU memory backends.
+
+    This wraps a C++ ``rosidl::Buffer<uint8_t>`` with a vendor-specific
+    backend (e.g. GPU, FPGA, demo).  CPU-based data never reaches Python
+    as a Buffer — it arrives as ``array.array('B')`` — so this class
+    only needs to expose backend-specific metadata and a ``to_bytes()``
+    escape hatch for diagnostics/logging.
+    """
+
+    __slots__ = ('_native',)
+
+    def __init__(self, native_buffer):
+        object.__setattr__(self, '_native', native_buffer)
+
+    @property
+    def backend_type(self):
+        """Backend type identifier (e.g. 'cpu', 'demo', 'cuda')."""
+        return object.__getattribute__(self, '_native').backend_type
+
+    def to_bytes(self):
+        """Return buffer contents as bytes (handles any backend)."""
+        return object.__getattribute__(self, '_native').to_bytes()
+
+    @property
+    def is_cpu(self):
+        """Check whether the buffer is backed by CPU memory."""
+        return self.backend_type == 'cpu'
+
+    def __len__(self):
+        return len(object.__getattribute__(self, '_native'))
+
+    def __repr__(self):
+        native = object.__getattribute__(self, '_native')
+        return (
+            f'Buffer(size={len(native)}, '
+            f"backend='{native.backend_type}')"
+        )
+
+    __hash__ = None
+
+
+# ------------------------------------------------------------------
+# Pipeline helper functions used by generated message code
+# ------------------------------------------------------------------
+
+def _take_buffer_from_ptr(ptr):
+    """
+    Take ownership of a heap-allocated Buffer* and return a Python Buffer.
+
+    Called by generated C->Python conversion code (_msg_support.c).
+    """
+    native = _rosidl_buffer_py._take_buffer_from_ptr(ptr)
+    return Buffer(native)
+
+
+def _get_buffer_ptr(buf):
+    """
+    Get the raw C++ Buffer pointer as an integer.
+
+    Called by generated Python->C conversion code (_msg_support.c).
+    Accepts both the new Python Buffer wrapper and the native pybind11 Buffer.
+    """
+    if isinstance(buf, Buffer):
+        return _rosidl_buffer_py._get_buffer_ptr(
+            object.__getattribute__(buf, '_native'))
+    return _rosidl_buffer_py._get_buffer_ptr(buf)
+
+
+def is_buffer(obj):
+    """Check if the given object is an rosidl_buffer.Buffer (not array.array)."""
+    return isinstance(obj, Buffer) or _rosidl_buffer_py.is_buffer(obj)
+
+
+__all__ = [
+    'Buffer',
+    'is_buffer',
+]

--- a/rosidl_buffer_py/rosidl_buffer/__init__.py
+++ b/rosidl_buffer_py/rosidl_buffer/__init__.py
@@ -24,100 +24,29 @@ Buffer class is only instantiated for non-CPU (vendor-backed) data
 where users interact with it through vendor-specific APIs.
 
 Users never construct Buffer directly.  Instead, backend providers
-supply factory functions (e.g. demo_buffer.DemoBuffer) that return
-Buffer objects for publishing vendor-backed data.
+supply factory functions (e.g. ``DemoBuffer.from_cpu()``) that
+return Buffer objects for publishing vendor-backed data.
 
-Example usage:
+Example usage::
+
     from demo_buffer import DemoBuffer
 
-    buf = DemoBuffer(b'\x00\x01\x02\x03')
+    buf = DemoBuffer.from_cpu(b'\x00\x01\x02\x03')
     assert buf.backend_type == 'demo'
     assert len(buf) == 4
     assert buf.to_bytes() == b'\x00\x01\x02\x03'
 
+    cpu_array = buf.to_array()  # array.array('B', ...)
+
     msg = Image()
-    msg.data = buf
+    msg.data = buf  # or, for CPU route: msg.data = cpu_array
 """
 
-from rosidl_buffer import _rosidl_buffer_py
-
-
-class Buffer:
-    """
-    Vendor-backed buffer for non-CPU memory backends.
-
-    This wraps a C++ ``rosidl::Buffer<uint8_t>`` with a vendor-specific
-    backend (e.g. GPU, FPGA, demo).  CPU-based data never reaches Python
-    as a Buffer — it arrives as ``array.array('B')`` — so this class
-    only needs to expose backend-specific metadata and a ``to_bytes()``
-    escape hatch for diagnostics/logging.
-    """
-
-    __slots__ = ('_native',)
-
-    def __init__(self, native_buffer):
-        object.__setattr__(self, '_native', native_buffer)
-
-    @property
-    def backend_type(self):
-        """Backend type identifier (e.g. 'cpu', 'demo', 'cuda')."""
-        return object.__getattribute__(self, '_native').backend_type
-
-    def to_bytes(self):
-        """Return buffer contents as bytes (handles any backend)."""
-        return object.__getattribute__(self, '_native').to_bytes()
-
-    @property
-    def is_cpu(self):
-        """Check whether the buffer is backed by CPU memory."""
-        return self.backend_type == 'cpu'
-
-    def __len__(self):
-        return len(object.__getattribute__(self, '_native'))
-
-    def __repr__(self):
-        native = object.__getattribute__(self, '_native')
-        return (
-            f'Buffer(size={len(native)}, '
-            f"backend='{native.backend_type}')"
-        )
-
-    __hash__ = None
-
-
-# ------------------------------------------------------------------
-# Pipeline helper functions used by generated message code
-# ------------------------------------------------------------------
-
-def _take_buffer_from_ptr(ptr):
-    """
-    Take ownership of a heap-allocated Buffer* and return a Python Buffer.
-
-    Called by generated C->Python conversion code (_msg_support.c).
-    """
-    native = _rosidl_buffer_py._take_buffer_from_ptr(ptr)
-    return Buffer(native)
-
-
-def _get_buffer_ptr(buf):
-    """
-    Get the raw C++ Buffer pointer as an integer.
-
-    Called by generated Python->C conversion code (_msg_support.c).
-    Accepts both the new Python Buffer wrapper and the native pybind11 Buffer.
-    """
-    if isinstance(buf, Buffer):
-        return _rosidl_buffer_py._get_buffer_ptr(
-            object.__getattribute__(buf, '_native'))
-    return _rosidl_buffer_py._get_buffer_ptr(buf)
-
-
-def is_buffer(obj):
-    """Check if the given object is an rosidl_buffer.Buffer (not array.array)."""
-    return isinstance(obj, Buffer) or _rosidl_buffer_py.is_buffer(obj)
+from rosidl_buffer._rosidl_buffer_py import _get_buffer_ptr  # noqa: F401
+from rosidl_buffer._rosidl_buffer_py import _take_buffer_from_ptr  # noqa: F401
+from rosidl_buffer._rosidl_buffer_py import Buffer
 
 
 __all__ = [
     'Buffer',
-    'is_buffer',
 ]

--- a/rosidl_buffer_py/rosidl_buffer/_rosidl_buffer_py.pyi
+++ b/rosidl_buffer_py/rosidl_buffer/_rosidl_buffer_py.pyi
@@ -1,0 +1,39 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import array
+
+
+class Buffer:
+    """Python wrapper around rosidl::Buffer<uint8_t>."""
+
+    @property
+    def backend_type(self) -> str:
+        """Backend type identifier (e.g. 'cpu', 'cuda')."""
+        ...
+
+    def to_bytes(self) -> bytes:
+        """Copy buffer contents to Python bytes."""
+        ...
+
+    def to_array(self) -> array.array[int]:
+        """Convert to array.array('B') -- the rclpy CPU storage type."""
+        ...
+
+    def __len__(self) -> int: ...
+    def __repr__(self) -> str: ...
+
+
+def _get_buffer_ptr(buf: Buffer) -> int: ...
+def _take_buffer_from_ptr(ptr: int) -> Buffer: ...

--- a/rosidl_buffer_py/rosidl_buffer/py.typed
+++ b/rosidl_buffer_py/rosidl_buffer/py.typed
@@ -1,0 +1,1 @@
+See https://peps.python.org/pep-0561/ for details about py.typed files.

--- a/rosidl_buffer_py/src/rosidl_buffer_py.cpp
+++ b/rosidl_buffer_py/src/rosidl_buffer_py.cpp
@@ -93,10 +93,16 @@ PYBIND11_MODULE(_rosidl_buffer_py, m)
   // Internal helpers for generated _msg_support.c (plain C code).
   // These use uintptr_t because the C caller cannot unwrap pybind11 types.
 
+  // Returns a raw pointer to the underlying Buffer. Ownership is not
+  // transferred; the PyBuffer retains ownership and the pointer is only
+  // valid for the lifetime of this PyBuffer (borrow semantics).
   m.def("_get_buffer_ptr", [](PyBuffer & buf) -> uintptr_t {
       return reinterpret_cast<uintptr_t>(buf.get_raw_buffer());
     });
 
+  // Takes ownership of a heap-allocated Buffer<uint8_t>. The pointer
+  // must have been allocated with `new` so that the default `delete`
+  // deleter is valid. Ownership is transferred to the returned PyBuffer.
   m.def("_take_buffer_from_ptr", [](uintptr_t ptr) -> PyBuffer {
       auto * buf = reinterpret_cast<rosidl::Buffer<uint8_t> *>(ptr);
       auto shared_buf = std::shared_ptr<rosidl::Buffer<uint8_t>>(buf);

--- a/rosidl_buffer_py/src/rosidl_buffer_py.cpp
+++ b/rosidl_buffer_py/src/rosidl_buffer_py.cpp
@@ -1,0 +1,100 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rosidl_buffer/buffer.hpp"
+
+namespace py = pybind11;
+
+/// Minimal Python wrapper around rosidl::Buffer<uint8_t>.
+///
+/// This class exists solely to:
+///   1. Provide a Python type for isinstance checks in generated message code
+///   2. Hold shared_ptr ownership so the C++ buffer stays alive
+///   3. Expose the few properties/methods the pipeline needs
+///
+/// Users never construct this directly.  Backend factory functions
+/// (e.g. demo_buffer.DemoBuffer) create the underlying C++ Buffer and
+/// return it via _take_buffer_from_ptr.
+class PyBuffer
+{
+public:
+  explicit PyBuffer(std::shared_ptr<rosidl::Buffer<uint8_t>> buf)
+  : buffer_(std::move(buf))
+  {
+  }
+
+  size_t size() const {return buffer_->size();}
+
+  std::string get_backend_type() const {return buffer_->get_backend_type();}
+
+  py::bytes to_bytes() const
+  {
+    if (buffer_->get_backend_type() == "cpu") {
+      return py::bytes(
+        reinterpret_cast<const char *>(buffer_->data()),
+        buffer_->size());
+    }
+    std::vector<uint8_t> vec = buffer_->to_vector();
+    return py::bytes(
+      reinterpret_cast<const char *>(vec.data()),
+      vec.size());
+  }
+
+  rosidl::Buffer<uint8_t> * get_raw_buffer() {return buffer_.get();}
+
+  std::string repr() const
+  {
+    return "rosidl_buffer.Buffer(size=" + std::to_string(buffer_->size()) +
+           ", backend='" + buffer_->get_backend_type() + "')";
+  }
+
+private:
+  std::shared_ptr<rosidl::Buffer<uint8_t>> buffer_;
+};
+
+PYBIND11_MODULE(_rosidl_buffer_py, m)
+{
+  m.doc() = "Python bindings for rosidl::Buffer<uint8_t>";
+
+  py::class_<PyBuffer>(m, "Buffer")
+  .def("__len__", &PyBuffer::size)
+  .def("to_bytes", &PyBuffer::to_bytes,
+    "Copy buffer contents to Python bytes (handles non-CPU backends via to_vector)")
+  .def_property_readonly("backend_type", &PyBuffer::get_backend_type,
+    "Backend type identifier (e.g. 'cpu', 'demo', 'cuda')")
+  .def("__repr__", &PyBuffer::repr)
+  ;
+
+  m.def("is_buffer", [](py::object obj) -> bool {
+      return py::isinstance<PyBuffer>(obj);
+    }, "Check if the given object is an rosidl_buffer.Buffer");
+
+  m.def("_get_buffer_ptr", [](PyBuffer & buf) -> uintptr_t {
+      return reinterpret_cast<uintptr_t>(buf.get_raw_buffer());
+    }, "Get the raw C++ Buffer pointer as an integer (internal use only)");
+
+  m.def("_take_buffer_from_ptr", [](uintptr_t ptr) -> PyBuffer {
+      auto * buf = reinterpret_cast<rosidl::Buffer<uint8_t> *>(ptr);
+      auto shared_buf = std::shared_ptr<rosidl::Buffer<uint8_t>>(buf);
+      return PyBuffer(shared_buf);
+    }, "Take ownership of a heap-allocated Buffer* and return a Python Buffer (internal use only)");
+}

--- a/rosidl_buffer_py/src/rosidl_buffer_py.cpp
+++ b/rosidl_buffer_py/src/rosidl_buffer_py.cpp
@@ -24,16 +24,15 @@
 
 namespace py = pybind11;
 
-/// Minimal Python wrapper around rosidl::Buffer<uint8_t>.
+/// Thin Python wrapper around rosidl::Buffer<uint8_t>.
 ///
-/// This class exists solely to:
-///   1. Provide a Python type for isinstance checks in generated message code
-///   2. Hold shared_ptr ownership so the C++ buffer stays alive
-///   3. Expose the few properties/methods the pipeline needs
+/// This wrapper exists to:
+///   1. Hold shared_ptr ownership so the C++ buffer stays alive
+///   2. Expose only the narrow API that Python users and the pipeline need
 ///
 /// Users never construct this directly.  Backend factory functions
-/// (e.g. demo_buffer.DemoBuffer) create the underlying C++ Buffer and
-/// return it via _take_buffer_from_ptr.
+/// (e.g. DemoBuffer.from_cpu()) create the underlying C++ Buffer
+/// and return it via _take_buffer_from_ptr.
 class PyBuffer
 {
 public:
@@ -46,24 +45,29 @@ public:
 
   std::string get_backend_type() const {return buffer_->get_backend_type();}
 
+  /// Copy buffer contents to Python bytes (all backends).
+  /// Used by rosidl_runtime_py (message_to_ordereddict, message_to_yaml)
+  /// to serialize buffer data to dicts, YAML, and CSV.
   py::bytes to_bytes() const
   {
-    if (buffer_->get_backend_type() == "cpu") {
-      return py::bytes(
-        reinterpret_cast<const char *>(buffer_->data()),
-        buffer_->size());
-    }
     std::vector<uint8_t> vec = buffer_->to_vector();
     return py::bytes(
       reinterpret_cast<const char *>(vec.data()),
       vec.size());
   }
 
+  /// Convert to array.array('B') — the rclpy CPU storage type.
+  py::object to_array() const
+  {
+    py::module_ array_mod = py::module_::import("array");
+    return array_mod.attr("array")("B", to_bytes());
+  }
+
   rosidl::Buffer<uint8_t> * get_raw_buffer() {return buffer_.get();}
 
   std::string repr() const
   {
-    return "rosidl_buffer.Buffer(size=" + std::to_string(buffer_->size()) +
+    return "Buffer(size=" + std::to_string(buffer_->size()) +
            ", backend='" + buffer_->get_backend_type() + "')";
   }
 
@@ -77,24 +81,25 @@ PYBIND11_MODULE(_rosidl_buffer_py, m)
 
   py::class_<PyBuffer>(m, "Buffer")
   .def("__len__", &PyBuffer::size)
-  .def("to_bytes", &PyBuffer::to_bytes,
-    "Copy buffer contents to Python bytes (handles non-CPU backends via to_vector)")
   .def_property_readonly("backend_type", &PyBuffer::get_backend_type,
-    "Backend type identifier (e.g. 'cpu', 'demo', 'cuda')")
+    "Backend type identifier (e.g. 'cpu')")
+  .def("to_bytes", &PyBuffer::to_bytes,
+    "Copy buffer contents to Python bytes.")
+  .def("to_array", &PyBuffer::to_array,
+    "Convert to array.array('B') — the rclpy CPU storage type.")
   .def("__repr__", &PyBuffer::repr)
   ;
 
-  m.def("is_buffer", [](py::object obj) -> bool {
-      return py::isinstance<PyBuffer>(obj);
-    }, "Check if the given object is an rosidl_buffer.Buffer");
+  // Internal helpers for generated _msg_support.c (plain C code).
+  // These use uintptr_t because the C caller cannot unwrap pybind11 types.
 
   m.def("_get_buffer_ptr", [](PyBuffer & buf) -> uintptr_t {
       return reinterpret_cast<uintptr_t>(buf.get_raw_buffer());
-    }, "Get the raw C++ Buffer pointer as an integer (internal use only)");
+    });
 
   m.def("_take_buffer_from_ptr", [](uintptr_t ptr) -> PyBuffer {
       auto * buf = reinterpret_cast<rosidl::Buffer<uint8_t> *>(ptr);
       auto shared_buf = std::shared_ptr<rosidl::Buffer<uint8_t>>(buf);
       return PyBuffer(shared_buf);
-    }, "Take ownership of a heap-allocated Buffer* and return a Python Buffer (internal use only)");
+    });
 }

--- a/rosidl_generator_c/resource/msg__functions.c.em
+++ b/rosidl_generator_c/resource/msg__functions.c.em
@@ -9,7 +9,6 @@ from rosidl_parser.definition import Array
 from rosidl_parser.definition import BasicType
 from rosidl_parser.definition import AbstractGenericString
 from rosidl_parser.definition import NamespacedType
-from rosidl_parser.definition import UnboundedSequence
 from rosidl_generator_c import basetype_to_c
 from rosidl_generator_c import idl_structure_type_sequence_to_c_typename
 from rosidl_generator_c import idl_structure_type_to_c_include_prefix
@@ -26,15 +25,7 @@ array_typename = idl_structure_type_sequence_to_c_typename(
 @# Collect necessary include directives for all members
 @{
 from collections import OrderedDict
-from rosidl_parser.definition import UnboundedSequence
 includes = OrderedDict()
-
-# Check if this message has any uint8[] buffer fields (for is_rosidl_buffer-aware fini)
-has_buffer_fields = False
-for member in message.structure.members:
-    if isinstance(member.type, UnboundedSequence) and isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'uint8':
-        has_buffer_fields = True
-        break
 
 for member in message.structure.members:
     if isinstance(member.type, AbstractSequence) and isinstance(member.type.value_type, BasicType):
@@ -79,7 +70,6 @@ for member in message.structure.members:
 @[    end for]@
 @[end if]@
 @#>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-@# Buffer-backed uint8[] fields use the is_rosidl_buffer flag on the sequence struct.
 
 @#######################################################################
 @# message functions
@@ -233,19 +223,8 @@ for member in message.structure.members:
             lines.append('  %s__fini(&msg->%s[i]);' % (basetype_to_c(member.type.value_type), member.name))
             lines.append('}')
     elif isinstance(member.type, AbstractSequence):
-        if isinstance(member.type, UnboundedSequence) and isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'uint8':
-            lines.append('if (msg->%s.is_rosidl_buffer) {' % member.name)
-            lines.append('  // Buffer-backed: data is a borrowed pointer, do not free')
-            lines.append('  msg->%s.data = NULL;' % member.name)
-            lines.append('  msg->%s.size = 0;' % member.name)
-            lines.append('  msg->%s.capacity = 0;' % member.name)
-            lines.append('  msg->%s.is_rosidl_buffer = false;' % member.name)
-            lines.append('} else {')
-            lines.append('  %s__fini(&msg->%s);' % (idl_type_to_c(member.type), member.name))
-            lines.append('}')
-        else:
-            # finalize the dynamic array
-            lines.append('%s__fini(&msg->%s);' % (idl_type_to_c(member.type), member.name))
+        # finalize the dynamic array
+        lines.append('%s__fini(&msg->%s);' % (idl_type_to_c(member.type), member.name))
     elif not isinstance(member.type, BasicType):
         # finalize non-array sub messages and strings
         lines.append('%s__fini(&msg->%s);' % (basetype_to_c(member.type), member.name))

--- a/rosidl_generator_c/resource/msg__functions.c.em
+++ b/rosidl_generator_c/resource/msg__functions.c.em
@@ -9,6 +9,7 @@ from rosidl_parser.definition import Array
 from rosidl_parser.definition import BasicType
 from rosidl_parser.definition import AbstractGenericString
 from rosidl_parser.definition import NamespacedType
+from rosidl_parser.definition import UnboundedSequence
 from rosidl_generator_c import basetype_to_c
 from rosidl_generator_c import idl_structure_type_sequence_to_c_typename
 from rosidl_generator_c import idl_structure_type_to_c_include_prefix
@@ -25,7 +26,16 @@ array_typename = idl_structure_type_sequence_to_c_typename(
 @# Collect necessary include directives for all members
 @{
 from collections import OrderedDict
+from rosidl_parser.definition import UnboundedSequence
 includes = OrderedDict()
+
+# Check if this message has any uint8[] buffer fields (for is_rosidl_buffer-aware fini)
+has_buffer_fields = False
+for member in message.structure.members:
+    if isinstance(member.type, UnboundedSequence) and isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'uint8':
+        has_buffer_fields = True
+        break
+
 for member in message.structure.members:
     if isinstance(member.type, AbstractSequence) and isinstance(member.type.value_type, BasicType):
         member_names = includes.setdefault(
@@ -69,6 +79,7 @@ for member in message.structure.members:
 @[    end for]@
 @[end if]@
 @#>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+@# Buffer-backed uint8[] fields use the is_rosidl_buffer flag on the sequence struct.
 
 @#######################################################################
 @# message functions
@@ -222,8 +233,19 @@ for member in message.structure.members:
             lines.append('  %s__fini(&msg->%s[i]);' % (basetype_to_c(member.type.value_type), member.name))
             lines.append('}')
     elif isinstance(member.type, AbstractSequence):
-        # finalize the dynamic array
-        lines.append('%s__fini(&msg->%s);' % (idl_type_to_c(member.type), member.name))
+        if isinstance(member.type, UnboundedSequence) and isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'uint8':
+            lines.append('if (msg->%s.is_rosidl_buffer) {' % member.name)
+            lines.append('  // Buffer-backed: data is a borrowed pointer, do not free')
+            lines.append('  msg->%s.data = NULL;' % member.name)
+            lines.append('  msg->%s.size = 0;' % member.name)
+            lines.append('  msg->%s.capacity = 0;' % member.name)
+            lines.append('  msg->%s.is_rosidl_buffer = false;' % member.name)
+            lines.append('} else {')
+            lines.append('  %s__fini(&msg->%s);' % (idl_type_to_c(member.type), member.name))
+            lines.append('}')
+        else:
+            # finalize the dynamic array
+            lines.append('%s__fini(&msg->%s);' % (idl_type_to_c(member.type), member.name))
     elif not isinstance(member.type, BasicType):
         # finalize non-array sub messages and strings
         lines.append('%s__fini(&msg->%s);' % (basetype_to_c(member.type), member.name))

--- a/rosidl_generator_c/resource/msg__functions.c.em
+++ b/rosidl_generator_c/resource/msg__functions.c.em
@@ -26,7 +26,6 @@ array_typename = idl_structure_type_sequence_to_c_typename(
 @{
 from collections import OrderedDict
 includes = OrderedDict()
-
 for member in message.structure.members:
     if isinstance(member.type, AbstractSequence) and isinstance(member.type.value_type, BasicType):
         member_names = includes.setdefault(

--- a/rosidl_runtime_c/CMakeLists.txt
+++ b/rosidl_runtime_c/CMakeLists.txt
@@ -20,6 +20,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_ros_core REQUIRED)
 find_package(rcutils REQUIRED)
+find_package(rosidl_buffer REQUIRED)
 find_package(rosidl_typesupport_interface REQUIRED)
 
 file(GLOB type_description_sources "src/type_description/*.c")
@@ -40,6 +41,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 target_link_libraries(${PROJECT_NAME} PUBLIC
   rcutils::rcutils
+  rosidl_buffer::rosidl_buffer
   rosidl_typesupport_interface::rosidl_typesupport_interface
 )
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
@@ -55,7 +57,7 @@ if(BUILD_TESTING AND NOT RCUTILS_DISABLE_FAULT_INJECTION)
   target_compile_definitions(${PROJECT_NAME} PUBLIC RCUTILS_ENABLE_FAULT_INJECTION)
 endif()
 
-ament_export_dependencies(rcutils rosidl_typesupport_interface)
+ament_export_dependencies(rcutils rosidl_buffer rosidl_typesupport_interface)
 
 # Export old-style CMake variables
 ament_export_include_directories("include/${PROJECT_NAME}")

--- a/rosidl_runtime_c/include/rosidl_runtime_c/primitives_sequence.h
+++ b/rosidl_runtime_c/include/rosidl_runtime_c/primitives_sequence.h
@@ -26,6 +26,7 @@
     size_t size; /*!< The number of valid items in data */ \
     size_t capacity; /*!< The number of allocated items in data */ \
     bool is_rosidl_buffer; /*!< When true, data points to an rosidl::Buffer<T>* */ \
+    bool owns_rosidl_buffer; /*!< When true, Sequence__fini will destroy the Buffer */ \
   } rosidl_runtime_c__ ## STRUCT_NAME ## __Sequence;
 
 // sequence types for all basic types

--- a/rosidl_runtime_c/include/rosidl_runtime_c/primitives_sequence.h
+++ b/rosidl_runtime_c/include/rosidl_runtime_c/primitives_sequence.h
@@ -25,6 +25,7 @@
     TYPE_NAME * data; /*!< The pointer to an array of STRUCT_NAME */ \
     size_t size; /*!< The number of valid items in data */ \
     size_t capacity; /*!< The number of allocated items in data */ \
+    bool is_rosidl_buffer; /*!< When true, data points to an rosidl::Buffer<T>* */ \
   } rosidl_runtime_c__ ## STRUCT_NAME ## __Sequence;
 
 // sequence types for all basic types

--- a/rosidl_runtime_c/package.xml
+++ b/rosidl_runtime_c/package.xml
@@ -27,6 +27,7 @@
   <build_export_depend>rosidl_typesupport_interface</build_export_depend>
 
   <depend>rcutils</depend>
+  <depend>rosidl_buffer</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/rosidl_runtime_c/src/primitives_sequence_functions.c
+++ b/rosidl_runtime_c/src/primitives_sequence_functions.c
@@ -19,6 +19,7 @@
 
 #include <rcutils/allocator.h>
 
+#include "rosidl_buffer/c_helpers.h"
 #include "rosidl_runtime_c/primitives_sequence_functions.h"
 
 #define ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(STRUCT_NAME, TYPE_NAME) \
@@ -40,6 +41,7 @@
     sequence->size = size; \
     sequence->capacity = size; \
     sequence->is_rosidl_buffer = false; \
+    sequence->owns_rosidl_buffer = false; \
     return true; \
   } \
  \
@@ -50,11 +52,14 @@
       return; \
     } \
     if (sequence->is_rosidl_buffer) { \
-      /* data points to an rosidl_buffer::Buffer — do not free it here */ \
+      if (sequence->owns_rosidl_buffer) { \
+        rosidl_buffer_uint8_destroy(sequence->data); \
+      } \
       sequence->data = NULL; \
       sequence->size = 0; \
       sequence->capacity = 0; \
       sequence->is_rosidl_buffer = false; \
+      sequence->owns_rosidl_buffer = false; \
       return; \
     } \
     if (sequence->data) { \
@@ -110,6 +115,7 @@
     memcpy(output->data, input->data, sizeof(TYPE_NAME) * input->size); \
     output->size = input->size; \
     output->is_rosidl_buffer = input->is_rosidl_buffer; \
+    output->owns_rosidl_buffer = input->owns_rosidl_buffer; \
     return true; \
   }
 

--- a/rosidl_runtime_c/src/primitives_sequence_functions.c
+++ b/rosidl_runtime_c/src/primitives_sequence_functions.c
@@ -39,6 +39,7 @@
     sequence->data = data; \
     sequence->size = size; \
     sequence->capacity = size; \
+    sequence->is_rosidl_buffer = false; \
     return true; \
   } \
  \
@@ -46,6 +47,14 @@
     rosidl_runtime_c__ ## STRUCT_NAME ## __Sequence * sequence) \
   { \
     if (!sequence) { \
+      return; \
+    } \
+    if (sequence->is_rosidl_buffer) { \
+      /* data points to an rosidl_buffer::Buffer — do not free it here */ \
+      sequence->data = NULL; \
+      sequence->size = 0; \
+      sequence->capacity = 0; \
+      sequence->is_rosidl_buffer = false; \
       return; \
     } \
     if (sequence->data) { \
@@ -100,6 +109,7 @@
     } \
     memcpy(output->data, input->data, sizeof(TYPE_NAME) * input->size); \
     output->size = input->size; \
+    output->is_rosidl_buffer = input->is_rosidl_buffer; \
     return true; \
   }
 

--- a/rosidl_typesupport_introspection_c/cmake/rosidl_typesupport_introspection_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_introspection_c/cmake/rosidl_typesupport_introspection_c_generate_interfaces.cmake
@@ -22,6 +22,7 @@ find_package(rosidl_cmake REQUIRED)
 find_package(rosidl_runtime_c REQUIRED)
 find_package(rosidl_typesupport_interface REQUIRED)
 find_package(rosidl_typesupport_introspection_c REQUIRED)
+find_package(rosidl_buffer REQUIRED)
 
 set(_output_path
   "${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_introspection_c/${PROJECT_NAME}")
@@ -152,7 +153,8 @@ target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix} PUBL
 target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix} PUBLIC
   rosidl_runtime_c::rosidl_runtime_c
   rosidl_typesupport_interface::rosidl_typesupport_interface
-  rosidl_typesupport_introspection_c::rosidl_typesupport_introspection_c)
+  rosidl_typesupport_introspection_c::rosidl_typesupport_introspection_c
+  rosidl_buffer::rosidl_buffer)
 
 foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
   target_link_libraries(

--- a/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/message_introspection.h
+++ b/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/message_introspection.h
@@ -103,8 +103,6 @@ typedef struct rosidl_typesupport_introspection_c__MessageMembers_s
   void (* init_function)(void *, enum rosidl_runtime_c__message_initialization);
   /// The function used to clean up the interface's in-memory representation
   void (* fini_function)(void *);
-  /// True if any member has is_rosidl_buffer_ == true.
-  bool has_buffer_fields_;
 } rosidl_typesupport_introspection_c__MessageMembers;
 
 #endif  // ROSIDL_TYPESUPPORT_INTROSPECTION_C__MESSAGE_INTROSPECTION_H_

--- a/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/message_introspection.h
+++ b/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/message_introspection.h
@@ -78,6 +78,9 @@ typedef struct rosidl_typesupport_introspection_c__MessageMember_s
   void (* assign_function)(void *, size_t index, const void *);
   /// If is_array_ is true, a pointer to a function that resizes the array.
   bool (* resize_function)(void *, size_t size);
+  /// True if this field is an rosidl::Buffer<T> (e.g. uint8[] fields).
+  /// Introspection accessors (except size_function) throw for non-CPU backends.
+  bool is_rosidl_buffer_;
 } rosidl_typesupport_introspection_c__MessageMember;
 
 /// Structure used to describe all fields of a single interface type.
@@ -100,6 +103,8 @@ typedef struct rosidl_typesupport_introspection_c__MessageMembers_s
   void (* init_function)(void *, enum rosidl_runtime_c__message_initialization);
   /// The function used to clean up the interface's in-memory representation
   void (* fini_function)(void *);
+  /// True if any member has is_rosidl_buffer_ == true.
+  bool has_buffer_fields_;
 } rosidl_typesupport_introspection_c__MessageMembers;
 
 #endif  // ROSIDL_TYPESUPPORT_INTROSPECTION_C__MESSAGE_INTROSPECTION_H_

--- a/rosidl_typesupport_introspection_c/package.xml
+++ b/rosidl_typesupport_introspection_c/package.xml
@@ -29,6 +29,7 @@
   <build_export_depend>rosidl_cmake</build_export_depend>
   <build_export_depend>rosidl_runtime_c</build_export_depend>
   <build_export_depend>rosidl_typesupport_interface</build_export_depend>
+  <build_export_depend>rosidl_buffer</build_export_depend>
 
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>rosidl_cli</exec_depend>

--- a/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
+++ b/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
@@ -15,6 +15,15 @@ from rosidl_parser.definition import Array
 from rosidl_parser.definition import BasicType
 from rosidl_parser.definition import BoundedSequence
 from rosidl_parser.definition import NamespacedType
+from rosidl_parser.definition import UnboundedSequence
+
+buffer_field_names = set()
+for m in message.structure.members:
+    if (isinstance(m.type, UnboundedSequence) and
+            isinstance(m.type.value_type, BasicType) and
+            m.type.value_type.typename == 'uint8'):
+        buffer_field_names.add(m.name)
+any_buffer_field = len(buffer_field_names) > 0
 
 include_parts = [package_name] + list(interface_path.parents[0].parts) + [
     'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
@@ -32,6 +41,8 @@ header_files = [
 ]
 
 function_prefix = '__'.join([package_name] + list(interface_path.parents[0].parts) + [message.structure.namespaced_type.name]) + '__rosidl_typesupport_introspection_c'
+if any_buffer_field:
+    header_files.append('rosidl_buffer/c_helpers.h')
 }@
 @[for header_file in header_files]@
 @[    if header_file in include_directives]@
@@ -125,45 +136,112 @@ void @(function_prefix)__@(message.structure.namespaced_type.name)_fini_function
 @[for member in message.structure.members]@
 @[  if isinstance(member.type, AbstractNestedType)]@
 @{from rosidl_generator_c import basetype_to_c, idl_type_to_c}@
+@[    if member.name in buffer_field_names]@
 size_t @(function_prefix)__size_function__@(message.structure.namespaced_type.name)__@(member.name)(
   const void * untyped_member)
 {
-@[    if isinstance(member.type, Array)]@
-  (void)untyped_member;
-  return @(member.type.size);
-@[    else]@
   const @(idl_type_to_c(member.type)) * member =
     (const @(idl_type_to_c(member.type)) *)(untyped_member);
+  if (member->is_rosidl_buffer) {
+    rosidl_buffer_uint8_throw_if_not_cpu((const void *)member->data);
+  }
   return member->size;
-@[    end if]@
 }
 
 const void * @(function_prefix)__get_const_function__@(message.structure.namespaced_type.name)__@(member.name)(
   const void * untyped_member, size_t index)
 {
-@[    if isinstance(member.type, Array)]@
-  const @(basetype_to_c(member.type.value_type)) * member =
-    (const @(basetype_to_c(member.type.value_type)) *)(untyped_member);
-  return &member[index];
-@[    else]@
   const @(idl_type_to_c(member.type)) * member =
     (const @(idl_type_to_c(member.type)) *)(untyped_member);
+  if (member->is_rosidl_buffer) {
+    rosidl_buffer_uint8_throw_if_not_cpu((const void *)member->data);
+  }
   return &member->data[index];
-@[    end if]@
 }
 
 void * @(function_prefix)__get_function__@(message.structure.namespaced_type.name)__@(member.name)(
   void * untyped_member, size_t index)
 {
-@[    if isinstance(member.type, Array)]@
+  @(idl_type_to_c(member.type)) * member =
+    (@(idl_type_to_c(member.type)) *)(untyped_member);
+  if (member->is_rosidl_buffer) {
+    rosidl_buffer_uint8_throw_if_not_cpu((const void *)member->data);
+  }
+  return &member->data[index];
+}
+
+void @(function_prefix)__fetch_function__@(message.structure.namespaced_type.name)__@(member.name)(
+  const void * untyped_member, size_t index, void * untyped_value)
+{
+  const uint8_t * item =
+    ((const uint8_t *)
+    @(function_prefix)__get_const_function__@(message.structure.namespaced_type.name)__@(member.name)(untyped_member, index));
+  uint8_t * value = (uint8_t *)(untyped_value);
+  *value = *item;
+}
+
+void @(function_prefix)__assign_function__@(message.structure.namespaced_type.name)__@(member.name)(
+  void * untyped_member, size_t index, const void * untyped_value)
+{
+  uint8_t * item =
+    ((uint8_t *)
+    @(function_prefix)__get_function__@(message.structure.namespaced_type.name)__@(member.name)(untyped_member, index));
+  const uint8_t * value = (const uint8_t *)(untyped_value);
+  *item = *value;
+}
+
+bool @(function_prefix)__resize_function__@(message.structure.namespaced_type.name)__@(member.name)(
+  void * untyped_member, size_t size)
+{
+  @(idl_type_to_c(member.type)) * member =
+    (@(idl_type_to_c(member.type)) *)(untyped_member);
+  if (member->is_rosidl_buffer) {
+    rosidl_buffer_uint8_throw_if_not_cpu((const void *)member->data);
+  }
+  @(idl_type_to_c(member.type))__fini(member);
+  return @(idl_type_to_c(member.type))__init(member, size);
+}
+
+@[    else]@
+size_t @(function_prefix)__size_function__@(message.structure.namespaced_type.name)__@(member.name)(
+  const void * untyped_member)
+{
+@[      if isinstance(member.type, Array)]@
+  (void)untyped_member;
+  return @(member.type.size);
+@[      else]@
+  const @(idl_type_to_c(member.type)) * member =
+    (const @(idl_type_to_c(member.type)) *)(untyped_member);
+  return member->size;
+@[      end if]@
+}
+
+const void * @(function_prefix)__get_const_function__@(message.structure.namespaced_type.name)__@(member.name)(
+  const void * untyped_member, size_t index)
+{
+@[      if isinstance(member.type, Array)]@
+  const @(basetype_to_c(member.type.value_type)) * member =
+    (const @(basetype_to_c(member.type.value_type)) *)(untyped_member);
+  return &member[index];
+@[      else]@
+  const @(idl_type_to_c(member.type)) * member =
+    (const @(idl_type_to_c(member.type)) *)(untyped_member);
+  return &member->data[index];
+@[      end if]@
+}
+
+void * @(function_prefix)__get_function__@(message.structure.namespaced_type.name)__@(member.name)(
+  void * untyped_member, size_t index)
+{
+@[      if isinstance(member.type, Array)]@
   @(basetype_to_c(member.type.value_type)) * member =
     (@(basetype_to_c(member.type.value_type)) *)(untyped_member);
   return &member[index];
-@[    else]@
+@[      else]@
   @(idl_type_to_c(member.type)) * member =
     (@(idl_type_to_c(member.type)) *)(untyped_member);
   return &member->data[index];
-@[    end if]@
+@[      end if]@
 }
 
 void @(function_prefix)__fetch_function__@(message.structure.namespaced_type.name)__@(member.name)(
@@ -188,7 +266,7 @@ void @(function_prefix)__assign_function__@(message.structure.namespaced_type.na
   *item = *value;
 }
 
-@[    if isinstance(member.type, AbstractSequence)]@
+@[      if isinstance(member.type, AbstractSequence)]@
 bool @(function_prefix)__resize_function__@(message.structure.namespaced_type.name)__@(member.name)(
   void * untyped_member, size_t size)
 {
@@ -198,6 +276,7 @@ bool @(function_prefix)__resize_function__@(message.structure.namespaced_type.na
   return @(idl_type_to_c(member.type))__init(member, size);
 }
 
+@[      end if]@
 @[    end if]@
 @[  end if]@
 @[end for]@
@@ -264,7 +343,9 @@ for index, member in enumerate(message.structure.members):
     # void(void *, size_t, const void *) assign_function
     print('    %s,  // assign(index, value) function pointer' % ('%s__assign_function__%s' % (function_prefix, function_suffix) if function_suffix else 'NULL'))
     # void(void *, size_t) resize_function
-    print('    %s  // resize(index) function pointer' % ('%s__resize_function__%s' % (function_prefix, function_suffix) if function_suffix and isinstance(member.type, AbstractSequence) else 'NULL'))
+    print('    %s,  // resize(index) function pointer' % ('%s__resize_function__%s' % (function_prefix, function_suffix) if function_suffix and isinstance(member.type, AbstractSequence) else 'NULL'))
+    # bool is_rosidl_buffer_
+    print('    %s  // is_rosidl_buffer' % ('true' if member.name in buffer_field_names else 'false'))
 
     if index < len(message.structure.members) - 1:
         print('  },')
@@ -285,7 +366,12 @@ static const rosidl_typesupport_introspection_c__MessageMembers @(function_prefi
 @[  end if]@
   @(function_prefix)__@(message.structure.namespaced_type.name)_message_member_array,  // message members
   @(function_prefix)__@(message.structure.namespaced_type.name)_init_function,  // function to initialize message memory (memory has to be allocated)
-  @(function_prefix)__@(message.structure.namespaced_type.name)_fini_function  // function to terminate message instance (will not free memory)
+  @(function_prefix)__@(message.structure.namespaced_type.name)_fini_function,  // function to terminate message instance (will not free memory)
+@[  if any_buffer_field]@
+  true  // has_buffer_fields_
+@[  else]@
+  false  // has_buffer_fields_
+@[  end if]@
 };
 
 // this is not const since it must be initialized on first access

--- a/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
+++ b/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
@@ -366,12 +366,7 @@ static const rosidl_typesupport_introspection_c__MessageMembers @(function_prefi
 @[  end if]@
   @(function_prefix)__@(message.structure.namespaced_type.name)_message_member_array,  // message members
   @(function_prefix)__@(message.structure.namespaced_type.name)_init_function,  // function to initialize message memory (memory has to be allocated)
-  @(function_prefix)__@(message.structure.namespaced_type.name)_fini_function,  // function to terminate message instance (will not free memory)
-@[  if any_buffer_field]@
-  true  // has_buffer_fields_
-@[  else]@
-  false  // has_buffer_fields_
-@[  end if]@
+  @(function_prefix)__@(message.structure.namespaced_type.name)_fini_function  // function to terminate message instance (will not free memory)
 };
 
 // this is not const since it must be initialized on first access

--- a/rosidl_typesupport_introspection_tests/CMakeLists.txt
+++ b/rosidl_typesupport_introspection_tests/CMakeLists.txt
@@ -41,6 +41,7 @@ if(BUILD_TESTING)
     SKIP_INSTALL
   )
 
+  find_package(rosidl_buffer REQUIRED)
   find_package(rcutils REQUIRED)
   find_package(rcpputils REQUIRED)
   find_package(rosidl_typesupport_interface REQUIRED)
@@ -48,6 +49,7 @@ if(BUILD_TESTING)
   add_library(${PROJECT_NAME}_library INTERFACE)
   target_include_directories(${PROJECT_NAME}_library INTERFACE include/)
   target_link_libraries(${PROJECT_NAME}_library INTERFACE
+    rosidl_buffer::rosidl_buffer
     rcutils::rcutils
     rcpputils::rcpputils
     rosidl_typesupport_interface::rosidl_typesupport_interface

--- a/rosidl_typesupport_introspection_tests/include/rosidl_typesupport_introspection_tests/helpers.hpp
+++ b/rosidl_typesupport_introspection_tests/include/rosidl_typesupport_introspection_tests/helpers.hpp
@@ -25,6 +25,7 @@
 #include <stdexcept>
 #include <vector>
 
+#include <rosidl_buffer/buffer.hpp>
 #include <rosidl_runtime_cpp/bounded_vector.hpp>
 
 /// Performs a deep-copy of the given `value`.
@@ -87,6 +88,14 @@ length(const std::vector<T> & vector)
   return vector.size();
 }
 
+/// Returns the size of an rosidl::Buffer.
+template<typename T>
+inline size_t
+length(const rosidl::Buffer<T> & buffer)
+{
+  return buffer.size();
+}
+
 /// Gets a reference to the item at `index` in `array`.
 template<typename T>
 inline const T &
@@ -108,6 +117,14 @@ inline bool
 getitem(const std::vector<bool> & vector, const size_t index)
 {
   return vector[index];
+}
+
+/// Gets a reference to the item at `index` in `buffer`.
+template<typename T>
+inline const T &
+getitem(const rosidl::Buffer<T> & buffer, const size_t index)
+{
+  return buffer[index];
 }
 
 /// Gets a reference to the item at `index` in `vector`.

--- a/rosidl_typesupport_introspection_tests/package.xml
+++ b/rosidl_typesupport_introspection_tests/package.xml
@@ -20,6 +20,7 @@
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>rosidl_buffer</test_depend>
   <test_depend>rcutils</test_depend>
   <test_depend>rcpputils</test_depend>
   <test_depend>rosidl_cmake</test_depend>

--- a/rosidl_typesupport_introspection_tests/test/test_unbounded_sequences_message_introspection.cpp
+++ b/rosidl_typesupport_introspection_tests/test/test_unbounded_sequences_message_introspection.cpp
@@ -59,7 +59,6 @@ TYPED_TEST(UnboundedSequencesMessageIntrospectionTest, MessageDescriptorIsCorrec
     get_message_size(message_descriptor),
     sizeof(UnboundedSequencesMessageT));
   ASSERT_EQ(get_member_count(message_descriptor), 32u);
-  EXPECT_TRUE(message_descriptor->has_buffer_fields_);
 
   {
     auto * member_descriptor = get_member_descriptor(message_descriptor, 0u);

--- a/rosidl_typesupport_introspection_tests/test/test_unbounded_sequences_message_introspection.cpp
+++ b/rosidl_typesupport_introspection_tests/test/test_unbounded_sequences_message_introspection.cpp
@@ -59,6 +59,7 @@ TYPED_TEST(UnboundedSequencesMessageIntrospectionTest, MessageDescriptorIsCorrec
     get_message_size(message_descriptor),
     sizeof(UnboundedSequencesMessageT));
   ASSERT_EQ(get_member_count(message_descriptor), 32u);
+  EXPECT_TRUE(message_descriptor->has_buffer_fields_);
 
   {
     auto * member_descriptor = get_member_descriptor(message_descriptor, 0u);
@@ -108,6 +109,7 @@ TYPED_TEST(UnboundedSequencesMessageIntrospectionTest, MessageDescriptorIsCorrec
     EXPECT_STREQ(get_member_name(member_descriptor), "uint8_values");
     EXPECT_TRUE(is_base_type_member(member_descriptor, ROS_TYPE_UINT8));
     EXPECT_TRUE(has_sequence_structure(member_descriptor));
+    EXPECT_TRUE(member_descriptor->is_rosidl_buffer_);
   }
 
   {
@@ -234,6 +236,7 @@ TYPED_TEST(UnboundedSequencesMessageIntrospectionTest, MessageDescriptorIsCorrec
     EXPECT_STREQ(get_member_name(member_descriptor), "uint8_values_default");
     EXPECT_TRUE(is_base_type_member(member_descriptor, ROS_TYPE_UINT8));
     EXPECT_TRUE(has_sequence_structure(member_descriptor));
+    EXPECT_TRUE(member_descriptor->is_rosidl_buffer_);
   }
 
   {


### PR DESCRIPTION
## Description

This pull request makes the rosidl C layer Buffer-aware and adds Python bindings for `rosidl::Buffer`, enabling rclpy message types to work with vendor-backed buffer memory. 

This pull request consists of the following key changes:

- **`rosidl_runtime_c`**: Adds `is_rosidl_buffer` field (bool) in each primitive sequence struct (e.g., `rosidl_runtime_c__uint8__Sequence`). When true, `data` points to an `rosidl::Buffer<T>*`.
- **`rosidl_generator_c`**: For messages with `uint8[]` fields, the generated fini logic (`msg__functions.c.em`) checks `msg->field.is_rosidl_buffer` and clears the sequence fields without calling normal sequence fini, avoiding double-free of a borrowed `rosidl::Buffer*` used by the Python C extension.
- **`rosidl_typesupport_introspection_c`**: The goal for the changes in C introspection is to keep it working with CPU-based path. The introspection accessors throw exceptions for non-CPU backends.
- **`rosidl_buffer_py`** (new): Python bindings (pybind11) for `rosidl::Buffer`.

### Is this user-facing behavior change?

This pull request does not change existing rclpy behavior. The `is_rosidl_buffer` flag defaults to false, so all existing C sequence code paths are unchanged. The `rosidl_buffer_py.Buffer` class is new and only used when vendor-backed (non-CPU) buffers are received by rclpy subscribers. CPU-based data continues to be delivered as `array.array`.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

Yes. Claude (claude-4.6-opus) via Cursor was used to assist with creating an initial prototype version of the changes contained in this PR.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

This PR is part of the broader ROS 2 native buffer feature introduced in this [post](https://discourse.openrobotics.org/t/working-prototype-of-native-buffers-accelerated-memory-transport/52399).

It depends on PRs #941, #942 and https://github.com/ros2/rosidl_typesupport_fastrtps/pull/144 (core buffer types, C++ rosidl changes, and C++ serialization).
