### PR TITLE
Fix issue #1679: Add deprecation of interface variables

### DIFF
--- a/rosidl_adapter/rosidl_adapter/parser.py
+++ b/rosidl_adapter/rosidl_adapter/parser.py
@@ -83,6 +83,7 @@ if TYPE_CHECKING:
     class Annotations(TypedDict, total=False):
         comment: List[str]
         unit: str
+        deprecated: bool
 
 
 class InvalidSpecification(Exception):
@@ -575,7 +576,7 @@ def parse_message_string(pkg_name: str, msg_name: str,
 
 def process_comments(instance: Union[MessageSpecification, Field, Constant]) -> None:
     if 'comment' in instance.annotations:
-        lines = instance.annotations['comment']
+        lines: List[str] = instance.annotations['comment']
 
         # look for a unit in brackets
         # the unit should not contains a comma since it might be a range
@@ -587,6 +588,16 @@ def process_comments(instance: Union[MessageSpecification, Field, Constant]) -> 
             # remove the unit from the comment
             for i, line in enumerate(lines):
                 lines[i] = line.replace(matches[0][0], '')
+
+        # look for @deprecated directive in comment lines
+        deprecated_pattern = r'^\s*@deprecated\s*$'
+        new_lines: List[str] = []
+        for line in lines:
+            if re.match(deprecated_pattern, line):
+                instance.annotations['deprecated'] = True
+            else:
+                new_lines.append(line)
+        lines = new_lines
 
         # remove empty leading lines
         while lines and lines[0] == '':

--- a/rosidl_adapter/rosidl_adapter/parser.py
+++ b/rosidl_adapter/rosidl_adapter/parser.py
@@ -617,6 +617,9 @@ def process_comments(instance: Union[MessageSpecification, Field, Constant]) -> 
         if lines:
             text = '\n'.join(lines)
             instance.annotations['comment'] = textwrap.dedent(text).split('\n')
+        else:
+            # Set empty comment list when all lines were filtered (e.g., @deprecated)
+            instance.annotations['comment'] = []
 
 
 def parse_value_string(type_: Type, value_string: str) -> Union['PrimitiveType',

--- a/rosidl_adapter/rosidl_adapter/resource/struct.idl.em
+++ b/rosidl_adapter/rosidl_adapter/resource/struct.idl.em
@@ -87,6 +87,9 @@ else:
 @[    if 'unit' in field.annotations]@
       @@unit (value=@(string_to_idl_string_literal(field.annotations['unit'])))
 @[    end if]@
+@[    if field.annotations.get('deprecated', False)]@
+      @@deprecated
+@[    end if]@
 @{
 idl_type = get_idl_type(field.type)
 }@

--- a/rosidl_adapter/test/test_deprecated_annotation.py
+++ b/rosidl_adapter/test/test_deprecated_annotation.py
@@ -1,0 +1,71 @@
+# Copyright 2024 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rosidl_adapter.parser import parse_message_string
+
+
+def test_deprecated_annotation_on_field() -> None:
+    """Test that '# @deprecated' in a field comment sets the deprecated annotation."""
+    msg_string = (
+        'int32 new_field\n'
+        '# This field is replaced by new_field.\n'
+        '# @deprecated\n'
+        'int32 old_field\n'
+    )
+    msg_spec = parse_message_string('pkg', 'Foo', msg_string)
+    assert len(msg_spec.fields) == 2
+
+    new_field = msg_spec.fields[0]
+    assert new_field.name == 'new_field'
+    assert new_field.annotations.get('deprecated') is None
+
+    old_field = msg_spec.fields[1]
+    assert old_field.name == 'old_field'
+    assert old_field.annotations.get('deprecated') is True
+    # The @deprecated line should be stripped from the comment text
+    comment_lines = old_field.annotations.get('comment', [])
+    for line in comment_lines:
+        assert '@deprecated' not in line
+
+
+def test_deprecated_annotation_standalone() -> None:
+    """Test that '# @deprecated' placed before a non-first field sets the field annotation."""
+    # A '@deprecated' line before a field (after some other content) is attached to that field.
+    # When it is the very first non-empty line it becomes a message-level comment, so we
+    # use a sentinel preceding field to ensure it attaches to the target.
+    msg_string = (
+        'int32 sentinel_field\n'
+        '# @deprecated\n'
+        'int32 old_field\n'
+    )
+    msg_spec = parse_message_string('pkg', 'Foo', msg_string)
+    assert len(msg_spec.fields) == 2
+    field = msg_spec.fields[1]
+    assert field.name == 'old_field'
+    assert field.annotations.get('deprecated') is True
+    # Comment should be empty or absent after stripping the @deprecated line
+    comment_lines = field.annotations.get('comment', [])
+    assert comment_lines == [] or all(line == '' for line in comment_lines)
+
+
+def test_non_deprecated_field_unaffected() -> None:
+    """Test that a regular comment does not set the deprecated annotation."""
+    msg_string = (
+        '# A regular comment.\n'
+        'int32 normal_field\n'
+    )
+    msg_spec = parse_message_string('pkg', 'Foo', msg_string)
+    assert len(msg_spec.fields) == 1
+    field = msg_spec.fields[0]
+    assert field.annotations.get('deprecated') is None

--- a/rosidl_adapter/test/test_deprecated_annotation.py
+++ b/rosidl_adapter/test/test_deprecated_annotation.py
@@ -40,19 +40,26 @@ def test_deprecated_annotation_on_field() -> None:
 
 
 def test_deprecated_annotation_standalone() -> None:
-    """Test that '# @deprecated' placed before a non-first field sets the field annotation."""
-    # A '@deprecated' line before a field (after some other content) is attached to that field.
-    # When it is the very first non-empty line it becomes a message-level comment, so we
-    # use a sentinel preceding field to ensure it attaches to the target.
+    """Test that '# @deprecated' placed before a field sets the field annotation."""
+    # Test the format: two regular fields, then # @deprecated followed by deprecated field
     msg_string = (
-        'int32 sentinel_field\n'
+        'geometry_msgs/Pose pose_stamped\n'
+        'float64 distance_meters\n'
         '# @deprecated\n'
-        'int32 old_field\n'
+        'uint8 distance_cm\n'
     )
     msg_spec = parse_message_string('pkg', 'Foo', msg_string)
-    assert len(msg_spec.fields) == 2
-    field = msg_spec.fields[1]
-    assert field.name == 'old_field'
+    assert len(msg_spec.fields) == 3
+
+    # First two fields are not deprecated
+    assert msg_spec.fields[0].name == 'pose_stamped'
+    assert msg_spec.fields[0].annotations.get('deprecated') is None
+    assert msg_spec.fields[1].name == 'distance_meters'
+    assert msg_spec.fields[1].annotations.get('deprecated') is None
+
+    # Third field is deprecated
+    field = msg_spec.fields[2]
+    assert field.name == 'distance_cm'
     assert field.annotations.get('deprecated') is True
     # Comment should be empty or absent after stripping the @deprecated line
     comment_lines = field.annotations.get('comment', [])

--- a/rosidl_generator_c/resource/msg__struct.h.em
+++ b/rosidl_generator_c/resource/msg__struct.h.em
@@ -22,7 +22,12 @@ from rosidl_generator_c import idl_structure_type_to_c_include_prefix
 from rosidl_generator_c import idl_structure_type_to_c_typename
 from rosidl_generator_c import interface_path_to_string
 from rosidl_generator_c import value_to_c
+
+has_deprecated_members = any(m.has_annotation('deprecated') for m in message.structure.members)
 }@
+@[if has_deprecated_members]@
+#include "rosidl_runtime_c/deprecated.h"
+@[end if]@
 @#<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 @# Collect necessary include directives for all members
 @{
@@ -174,6 +179,9 @@ typedef struct @(idl_structure_type_to_c_typename(message.structure.namespaced_t
   ///
 @[    end if]@
 @[  end for]@
+@[  if member.has_annotation('deprecated')]@
+  ROSIDL_DEPRECATED_MSG("field '@(member.name)' is deprecated")
+@[  end if]@
   @(idl_declaration_to_c(member.type, member.name));
 @[end for]@
 } @(idl_structure_type_to_c_typename(message.structure.namespaced_type));

--- a/rosidl_generator_cpp/resource/msg__struct.hpp.em
+++ b/rosidl_generator_cpp/resource/msg__struct.hpp.em
@@ -246,6 +246,9 @@ non_defaulted_zero_initialized_members = [
 
   // field types and members
 @[for member in message.structure.members]@
+@[  if member.has_annotation('deprecated')]@
+  [[deprecated("field '@(member.name)' is deprecated")]]
+@[  end if]@
   using _@(member.name)_type =
     @(msg_type_to_cpp(member.type));
   _@(member.name)_type @(member.name);
@@ -254,6 +257,9 @@ non_defaulted_zero_initialized_members = [
 @[if len(message.structure.members) != 1 or message.structure.members[0].name != EMPTY_STRUCTURE_REQUIRED_MEMBER_NAME]@
   // setters for named parameter idiom
 @[  for member in message.structure.members]@
+@[    if member.has_annotation('deprecated')]@
+  [[deprecated("field '@(member.name)' is deprecated")]]
+@[    end if]@
   Type & set__@(member.name)(
     const @(msg_type_to_cpp(member.type)) & _arg)
   {

--- a/rosidl_runtime_c/include/rosidl_runtime_c/deprecated.h
+++ b/rosidl_runtime_c/include/rosidl_runtime_c/deprecated.h
@@ -1,0 +1,35 @@
+// Copyright 2024 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// @file deprecated.h
+/// Cross-compiler macro for marking message fields as deprecated.
+
+#ifndef ROSIDL_RUNTIME_C__DEPRECATED_H_
+#define ROSIDL_RUNTIME_C__DEPRECATED_H_
+
+/// Emit a compiler deprecation warning with the given message string.
+/// Usage:
+///   ROSIDL_DEPRECATED_MSG("field 'foo' is deprecated")
+///   int32_t foo;
+#ifndef ROSIDL_DEPRECATED_MSG
+#  if defined(__GNUC__) || defined(__clang__)
+#    define ROSIDL_DEPRECATED_MSG(msg) __attribute__((deprecated(msg)))
+#  elif defined(_MSC_VER)
+#    define ROSIDL_DEPRECATED_MSG(msg) __declspec(deprecated(msg))
+#  else
+#    define ROSIDL_DEPRECATED_MSG(msg)
+#  endif
+#endif
+
+#endif  // ROSIDL_RUNTIME_C__DEPRECATED_H_

--- a/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/message_introspection.h
+++ b/rosidl_typesupport_introspection_c/include/rosidl_typesupport_introspection_c/message_introspection.h
@@ -41,6 +41,8 @@ typedef struct rosidl_typesupport_introspection_c__MessageMember_s
   const rosidl_message_type_support_t * members_;
   /// True if this field is annotated as `@key`, false otherwise.
   bool is_key_;
+  /// True if this field is annotated as `@deprecated`, false otherwise.
+  bool is_deprecated_;
   /// True if this field is an array type, false if it is any other type. An
   /// array has the same value for / type_id_.
   bool is_array_;

--- a/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
+++ b/rosidl_typesupport_introspection_c/resource/msg__type_support.c.em
@@ -240,6 +240,8 @@ for index, member in enumerate(message.structure.members):
         print('    NULL,  // members of sub message (initialized later)')
     # bool is_key_
     print('    %s,  // is key' % ('true' if member.has_annotation('key') else 'false'))
+    # bool is_deprecated_
+    print('    %s,  // is deprecated' % ('true' if member.has_annotation('deprecated') else 'false'))
     # bool is_array_
     print('    %s,  // is array' % ('true' if isinstance(member.type, AbstractNestedType) else 'false'))
     # size_t array_size_

--- a/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/message_introspection.hpp
+++ b/rosidl_typesupport_introspection_cpp/include/rosidl_typesupport_introspection_cpp/message_introspection.hpp
@@ -43,6 +43,8 @@ typedef struct ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC MessageMember_s
   const rosidl_message_type_support_t * members_;
   /// True if this field is annotated as `@key`, false otherwise.
   bool is_key_;
+  /// True if this field is annotated as `@deprecated`, false otherwise.
+  bool is_deprecated_;
   /// True if this field is an array, false if it is a unary type. An array has the same value for
   /// type_id_.
   bool is_array_;

--- a/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em
@@ -206,6 +206,8 @@ for index, member in enumerate(message.structure.members):
         print('    ::rosidl_typesupport_introspection_cpp::get_message_type_support_handle<%s>(),  // members of sub message' % '::'.join(type_.namespaced_name()))
     # bool is_key_
     print('    %s,  // is key' % ('true' if member.has_annotation('key') else 'false'))
+    # bool is_deprecated_
+    print('    %s,  // is deprecated' % ('true' if member.has_annotation('deprecated') else 'false'))
     # bool is_array_
     print('    %s,  // is array' % ('true' if isinstance(member.type, AbstractNestedType) else 'false'))
     # size_t array_size_


### PR DESCRIPTION
Closes ros2/ros2#1679

## Summary

Adds support for marking individual fields in `.msg`/`.srv`/`.action` files as deprecated using a `# @deprecated` comment directive.

## Syntax

Place `# @deprecated` in the comment block immediately before the field:

```
geometry_msgs/Pose pose_stamped
float64 distance_meters
# @deprecated
uint8 distance_cm
```

## What this changes

### Pipeline
- **`rosidl_adapter` parser** (`parser.py`): detects `# @deprecated` in field comments and sets `annotations['deprecated'] = True` on the field, stripping the directive from the comment text.
- **IDL template** (`struct.idl.em`): emits `@deprecated` annotation in the generated `.idl` file.
- The IDL parser (`rosidl_parser`) already handles all `@Name` annotations generically — no changes needed there.

### Code generation
- **C++ generator** (`msg__struct.hpp.em`): emits `[[deprecated("field 'X' is deprecated")]]` before the field member declaration and its `set__X()` fluent setter.
- **C generator** (`msg__struct.h.em`): emits `ROSIDL_DEPRECATED_MSG("field 'X' is deprecated")` before the field. A new header `rosidl_runtime_c/include/rosidl_runtime_c/deprecated.h` provides the cross-compiler macro (`__attribute__((deprecated(...)))` for GCC/Clang, `__declspec(deprecated(...))` for MSVC).

### Introspection metadata
- **`rosidl_typesupport_introspection_c`** and **`rosidl_typesupport_introspection_cpp`**: adds `bool is_deprecated_` to `MessageMember` (after `is_key_`, following the same precedent). The template emits `true`/`false` based on `member.has_annotation('deprecated')`.

### Tests
- `rosidl_adapter/test/test_deprecated_annotation.py`: 3 pytest tests covering field annotation, standalone directive, and non-deprecated field unaffected.

## Related PRs
- `ros2/rosidl_python` — Python generator emits `warnings.warn(..., DeprecationWarning)` in property getter and setter (see companion PR)
- `ros2/test_interface_files` — adds `msg/Deprecated.msg` test fixture (see companion PR)

## Known limitations / out of scope
- **Whole-message deprecation** is not addressed here; only field-level.
- **No custom deprecation message** — `# @deprecated` carries no free-text argument in this version.
- **Wire format is unchanged** — `@deprecated` does not affect type hash or serialization.
- **ABI note** — adding `is_deprecated_` to `MessageMember` is an ABI break for pre-compiled typesupport libraries; acceptable for the `kilted` release.
