### PR TITLE
Create an aggregate target for rosidl generated interfaces targets

### DIFF
--- a/rosidl_cmake/cmake/rosidl_cmake_aggregate_target-extras.cmake.in
+++ b/rosidl_cmake/cmake/rosidl_cmake_aggregate_target-extras.cmake.in
@@ -1,0 +1,10 @@
+# generated from rosidl_cmake/cmake/rosidl_cmake_aggregate_target-extras.cmake.in
+
+# Create a convenience aggregate target @PROJECT_NAME@::@PROJECT_NAME@
+# that links all generated interface targets, so downstream packages can use
+# a single modern CMake target name instead of ${@PROJECT_NAME@_TARGETS}.
+if(@PROJECT_NAME@_TARGETS AND NOT TARGET @PROJECT_NAME@::@PROJECT_NAME@)
+  add_library(@PROJECT_NAME@::@PROJECT_NAME@ INTERFACE IMPORTED)
+  set_target_properties(@PROJECT_NAME@::@PROJECT_NAME@ PROPERTIES
+    INTERFACE_LINK_LIBRARIES "${@PROJECT_NAME@_TARGETS}")
+endif()

--- a/rosidl_cmake/cmake/rosidl_cmake_aggregate_target_package_hook.cmake
+++ b/rosidl_cmake/cmake/rosidl_cmake_aggregate_target_package_hook.cmake
@@ -1,0 +1,26 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Generate and register a post-extra file that creates the aggregate
+# interface target ${PROJECT_NAME}::${PROJECT_NAME} for downstream packages.
+# This uses CONFIG_EXTRAS_POST so it runs after ament_cmake_export_targets
+# has populated ${PROJECT_NAME}_TARGETS.
+set(_generated_extra_file
+  "${CMAKE_CURRENT_BINARY_DIR}/rosidl_cmake/rosidl_cmake_aggregate_target-extras.cmake")
+configure_file(
+  "${rosidl_cmake_DIR}/rosidl_cmake_aggregate_target-extras.cmake.in"
+  "${_generated_extra_file}"
+  @ONLY
+)
+list(APPEND ${PROJECT_NAME}_CONFIG_EXTRAS_POST "${_generated_extra_file}")

--- a/rosidl_cmake/rosidl_cmake-extras.cmake
+++ b/rosidl_cmake/rosidl_cmake-extras.cmake
@@ -24,6 +24,19 @@ macro(_rosidl_cmake_register_package_hook)
       "rosidl_cmake_package_hook.cmake")
 
     find_package(ament_cmake_export_dependencies QUIET REQUIRED)
+
+    _rosidl_cmake_aggregate_target_register_package_hook()
+  endif()
+endmacro()
+
+# register ament_package() hook for the aggregate interface target once
+macro(_rosidl_cmake_aggregate_target_register_package_hook)
+  if(NOT DEFINED _ROSIDL_CMAKE_AGGREGATE_TARGET_PACKAGE_HOOK_REGISTERED)
+    set(_ROSIDL_CMAKE_AGGREGATE_TARGET_PACKAGE_HOOK_REGISTERED TRUE)
+
+    find_package(ament_cmake_core QUIET REQUIRED)
+    ament_register_extension("ament_package" "rosidl_cmake"
+      "rosidl_cmake_aggregate_target_package_hook.cmake")
   endif()
 endmacro()
 


### PR DESCRIPTION
## Description

Fixes #746

Adds a new aggregate target via CMake `INTERFACE` target type to bundle together the `${package_TARGETS}` that are currently needed to use rosidl interfaces.

```
target_link_libraries(my_lib ${sensor_msgs_TARGETS}
```

can now use the following to get the same result.

```
target_link_libraries(my_lib sensor_msgs::sensor_msgs
```


### Is this user-facing behavior change?

This is a new feature that users can opt in to using.

### Did you use Generative AI?

This was assisted by Claude Code using Sonnet 4.6 model, all lines manually reviewed.

### Additional Information

N/A