### PR TITLE
Add cstdint include to c_helpers.cpp

### DIFF
--- a/rosidl_buffer/src/c_helpers.cpp
+++ b/rosidl_buffer/src/c_helpers.cpp
@@ -14,6 +14,7 @@
 
 #include "rosidl_buffer/c_helpers.h"
 #include "rosidl_buffer/buffer.hpp"
+#include <cstdint>
 
 extern "C" {
 

--- a/rosidl_buffer/src/c_helpers.cpp
+++ b/rosidl_buffer/src/c_helpers.cpp
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 #include "rosidl_buffer/c_helpers.h"
-#include "rosidl_buffer/buffer.hpp"
+
 #include <cstdint>
+
+#include "rosidl_buffer/buffer.hpp"
 
 extern "C" {
 


### PR DESCRIPTION


## Description

fix:
error: ‘uint8_t’ was not declared in this scope

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
