### PR TITLE
Fix pybind11 rosdep key

### DIFF
--- a/rosidl_buffer_py/package.xml
+++ b/rosidl_buffer_py/package.xml
@@ -19,7 +19,7 @@
 
   <depend>rosidl_buffer</depend>
 
-  <build_depend>pybind11</build_depend>
+  <build_depend>pybind11-dev</build_depend>
   <build_depend>python3-dev</build_depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
A new package was added with #942 but our source builds now fail with
`2026-04-07T05:40:33.9687563Z rosidl_buffer_py: Cannot locate rosdep definition for [pybind11]`
IMHO the rosdep key is wrong, see rosdistro
https://github.com/ros/rosdistro/blob/dd245d73626c4aa8d6536bee12b75ca0eedc743f/rosdep/base.yaml#L8845-L8857