### PR TITLE
Bump rosidl_buffer min CMake version

### DIFF
--- a/rosidl_buffer/CMakeLists.txt
+++ b/rosidl_buffer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(rosidl_buffer)
 
 # Default to C++17

--- a/rosidl_buffer_backend/CMakeLists.txt
+++ b/rosidl_buffer_backend/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(rosidl_buffer_backend)
 
 # Default to C++17

--- a/rosidl_buffer_backend_registry/CMakeLists.txt
+++ b/rosidl_buffer_backend_registry/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(rosidl_buffer_backend_registry)
 
 # Default to C++17

--- a/rosidl_buffer_py/CMakeLists.txt
+++ b/rosidl_buffer_py/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(rosidl_buffer_py)
 
 # Default to C++17


### PR DESCRIPTION
## Description
Fixes warnings like this one:

```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
```


### Is this user-facing behavior change?

no

### Did you use Generative AI?

no

### Additional Information
