### PR TITLE
Make codegen of rosidl_generator_c deterministic for jazzy

### DIFF
--- a/rosidl_generator_c/resource/full__description.c.em
+++ b/rosidl_generator_c/resource/full__description.c.em
@@ -1,5 +1,6 @@
 @# Included from rosidl_generator_c/resource/idl__description.c.em
 @{
+from collections import OrderedDict
 from rosidl_generator_c import escape_string
 from rosidl_generator_c import idl_structure_type_to_c_include_prefix
 from rosidl_generator_c import type_hash_to_c_definition
@@ -31,7 +32,7 @@ def utf8_encode(value_string):
   return escape_string(repr(value_string.encode('utf-8'))[2:-1])
 
 implicit_type_names = set(td['type_description']['type_name'] for td, _ in implicit_type_descriptions)
-includes = set()
+includes = OrderedDict()
 toplevel_msg, _ = toplevel_type_description
 
 for referenced_td in toplevel_msg['referenced_type_descriptions']:
@@ -40,7 +41,7 @@ for referenced_td in toplevel_msg['referenced_type_descriptions']:
     names = referenced_td['type_name'].split('/')
     _type = NamespacedType(names[:-1], names[-1])
     include_prefix = idl_structure_type_to_c_include_prefix(_type, 'detail')
-    includes.add(include_prefix + '__functions.h')
+    includes[include_prefix + '__functions.h'] = None
 
 full_type_descriptions = [toplevel_type_description] + implicit_type_descriptions
 full_type_names = [t['type_description']['type_name'] for t, _ in full_type_descriptions]

--- a/rosidl_generator_c/resource/idl__type_support.c.em
+++ b/rosidl_generator_c/resource/idl__type_support.c.em
@@ -16,16 +16,19 @@ include_parts = [package_name] + list(interface_path.parents[0].parts) + [
     'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
 include_base = '/'.join(include_parts)
 
-include_directives = {
+top_level_includes = [
   'rosidl_typesupport_interface/macros.h',
   include_base + '__type_support.h',
   include_base + '__struct.h',
-  include_base + '__functions.h'}
+  include_base + '__functions.h']
+
+include_directives = set(top_level_includes)
+
 }@
 
 #include <string.h>
 
-@[for header_file in include_directives]@
+@[for header_file in top_level_includes]@
 #include "@(header_file)"
 @[end for]@
 


### PR DESCRIPTION
Applying the patch merged in #846 to `rolling` branch also to `jazzy` to
keep the implementations as close as possible.