### PR TITLE
Clarify return of get_descriptor_type_support() in rosidl_buffer_backend

### DIFF
--- a/rosidl_buffer_backend/include/rosidl_buffer_backend/buffer_backend.hpp
+++ b/rosidl_buffer_backend/include/rosidl_buffer_backend/buffer_backend.hpp
@@ -52,8 +52,12 @@ public:
     return "";
   }
 
-  /// Get the descriptor message type support handle for this backend.
-  /// This must return a rosidl_typesupport_fastrtps_cpp handle.
+  /// Get the message type support handle for this backend's descriptor type.
+  /// Implementations should return the generic aggregate handle, typically via
+  /// `rosidl_typesupport_cpp::get_message_type_support_handle<YourDescriptor>()`.
+  /// The consuming RMW resolves this aggregate to the concrete per-typesupport
+  /// library handle it needs at runtime (e.g. rosidl_typesupport_fastrtps_cpp),
+  /// so the plugin itself stays RMW-agnostic.
   virtual const rosidl_message_type_support_t * get_descriptor_type_support() const = 0;
 
   /// Create an empty descriptor message instance for this backend.


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

This pull request updates description for the function `get_descriptor_type_support()` in the `BufferBackend` class to clarify that the returned type support handle from the function should be generic to keep the backend plugin RMW-agnostic. This will match description in a documentation introducing `BufferBackend` to be added to ROS2 documentation.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

### Is this user-facing behavior change?

No, this change only touches comments for a funciton.

### Did you use Generative AI?

No.

