### PR TITLE
Add missing std::vector compatible APIs to rosidl::Buffer

### DIFF
--- a/rosidl_buffer/include/rosidl_buffer/buffer.hpp
+++ b/rosidl_buffer/include/rosidl_buffer/buffer.hpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <initializer_list>
+#include <iterator>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -48,10 +49,12 @@ public:
   using difference_type = std::ptrdiff_t;
   using reference = T &;
   using const_reference = const T &;
-  using pointer = T *;
-  using const_pointer = const T *;
-  using iterator = T *;
-  using const_iterator = const T *;
+  using pointer = typename std::vector<T, Allocator>::pointer;
+  using const_pointer = typename std::vector<T, Allocator>::const_pointer;
+  using iterator = typename std::vector<T, Allocator>::iterator;
+  using const_iterator = typename std::vector<T, Allocator>::const_iterator;
+  using reverse_iterator = typename std::vector<T, Allocator>::reverse_iterator;
+  using const_reverse_iterator = typename std::vector<T, Allocator>::const_reverse_iterator;
 
   /// Default constructor creates CPU buffer
   Buffer()
@@ -240,40 +243,67 @@ public:
   iterator begin()
   {
     throw_if_not_cpu_backend();
-    return get_cpu_impl()->get_storage().data();
+    return get_cpu_impl()->get_storage().begin();
   }
 
   const_iterator begin() const
   {
     throw_if_not_cpu_backend();
-    return get_cpu_impl()->get_storage().data();
+    return get_cpu_impl()->get_storage().begin();
   }
 
   const_iterator cbegin() const
   {
     throw_if_not_cpu_backend();
-    return get_cpu_impl()->get_storage().data();
+    return get_cpu_impl()->get_storage().cbegin();
   }
 
   iterator end()
   {
     throw_if_not_cpu_backend();
-    auto & s = get_cpu_impl()->get_storage();
-    return s.data() + s.size();
+    return get_cpu_impl()->get_storage().end();
   }
 
   const_iterator end() const
   {
     throw_if_not_cpu_backend();
-    auto & s = get_cpu_impl()->get_storage();
-    return s.data() + s.size();
+    return get_cpu_impl()->get_storage().end();
   }
 
   const_iterator cend() const
   {
     throw_if_not_cpu_backend();
-    auto & s = get_cpu_impl()->get_storage();
-    return s.data() + s.size();
+    return get_cpu_impl()->get_storage().cend();
+  }
+
+  reverse_iterator rbegin()
+  {
+    return reverse_iterator(end());
+  }
+
+  const_reverse_iterator rbegin() const
+  {
+    return const_reverse_iterator(end());
+  }
+
+  const_reverse_iterator crbegin() const
+  {
+    return const_reverse_iterator(cend());
+  }
+
+  reverse_iterator rend()
+  {
+    return reverse_iterator(begin());
+  }
+
+  const_reverse_iterator rend() const
+  {
+    return const_reverse_iterator(begin());
+  }
+
+  const_reverse_iterator crend() const
+  {
+    return const_reverse_iterator(cbegin());
   }
 
   // ========== Capacity ==========
@@ -283,6 +313,12 @@ public:
 
   /// Works for all backends (delegates to BufferImplBase::size()).
   size_t size() const {return impl_->size();}
+
+  size_t max_size() const
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage().max_size();
+  }
 
   void reserve(size_t new_cap)
   {
@@ -300,6 +336,12 @@ public:
   {
     throw_if_not_cpu_backend();
     get_cpu_impl()->get_storage().shrink_to_fit();
+  }
+
+  allocator_type get_allocator() const
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage().get_allocator();
   }
 
   // ========== Modifiers (CPU only) ==========
@@ -326,47 +368,32 @@ public:
   iterator insert(const_iterator pos, const T & value)
   {
     throw_if_not_cpu_backend();
-    auto & s = get_cpu_impl()->get_storage();
-    auto offset = pos - s.data();
-    auto it = s.insert(s.begin() + offset, value);
-    return s.data() + (it - s.begin());
+    return get_cpu_impl()->get_storage().insert(pos, value);
   }
 
   iterator insert(const_iterator pos, T && value)
   {
     throw_if_not_cpu_backend();
-    auto & s = get_cpu_impl()->get_storage();
-    auto offset = pos - s.data();
-    auto it = s.insert(s.begin() + offset, std::move(value));
-    return s.data() + (it - s.begin());
+    return get_cpu_impl()->get_storage().insert(pos, std::move(value));
   }
 
   iterator insert(const_iterator pos, size_t count, const T & value)
   {
     throw_if_not_cpu_backend();
-    auto & s = get_cpu_impl()->get_storage();
-    auto offset = pos - s.data();
-    auto it = s.insert(s.begin() + offset, count, value);
-    return s.data() + (it - s.begin());
+    return get_cpu_impl()->get_storage().insert(pos, count, value);
   }
 
   template<typename InputIt>
   iterator insert(const_iterator pos, InputIt first, InputIt last)
   {
     throw_if_not_cpu_backend();
-    auto & s = get_cpu_impl()->get_storage();
-    auto offset = pos - s.data();
-    auto it = s.insert(s.begin() + offset, first, last);
-    return s.data() + (it - s.begin());
+    return get_cpu_impl()->get_storage().insert(pos, first, last);
   }
 
   iterator insert(const_iterator pos, std::initializer_list<T> ilist)
   {
     throw_if_not_cpu_backend();
-    auto & s = get_cpu_impl()->get_storage();
-    auto offset = pos - s.data();
-    auto it = s.insert(s.begin() + offset, ilist);
-    return s.data() + (it - s.begin());
+    return get_cpu_impl()->get_storage().insert(pos, ilist);
   }
 
   void clear()
@@ -406,10 +433,29 @@ public:
   }
 
   template<typename ... Args>
-  void emplace_back(Args && ... args)
+  iterator emplace(const_iterator pos, Args && ... args)
   {
     throw_if_not_cpu_backend();
-    get_cpu_impl()->get_storage().emplace_back(std::forward<Args>(args)...);
+    return get_cpu_impl()->get_storage().emplace(pos, std::forward<Args>(args)...);
+  }
+
+  template<typename ... Args>
+  reference emplace_back(Args && ... args)
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage().emplace_back(std::forward<Args>(args)...);
+  }
+
+  iterator erase(const_iterator pos)
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage().erase(pos);
+  }
+
+  iterator erase(const_iterator first, const_iterator last)
+  {
+    throw_if_not_cpu_backend();
+    return get_cpu_impl()->get_storage().erase(first, last);
   }
 
   void swap(Buffer & other) noexcept

--- a/rosidl_buffer/include/rosidl_buffer/buffer.hpp
+++ b/rosidl_buffer/include/rosidl_buffer/buffer.hpp
@@ -412,6 +412,19 @@ public:
     get_cpu_impl()->get_storage().emplace_back(std::forward<Args>(args)...);
   }
 
+  void swap(Buffer & other) noexcept
+  {
+    throw_if_not_cpu_backend();
+    other.throw_if_not_cpu_backend();
+    cpu_impl_->get_storage().swap(other.cpu_impl_->get_storage());
+  }
+
+  void swap(std::vector<T, Allocator> & vec) noexcept
+  {
+    throw_if_not_cpu_backend();
+    cpu_impl_->get_storage().swap(vec);
+  }
+
   // ========== Conversion Operators ==========
 
   /// Implicit conversion to std::vector<T, Allocator>& (CPU only).
@@ -543,6 +556,24 @@ template<typename T, typename Allocator>
 bool operator!=(const Buffer<T, Allocator> & lhs, const std::vector<T, Allocator> & rhs)
 {
   return !(lhs == rhs);
+}
+
+template<typename T, typename Allocator>
+void swap(Buffer<T, Allocator> & lhs, Buffer<T, Allocator> & rhs) noexcept
+{
+  lhs.swap(rhs);
+}
+
+template<typename T, typename Allocator>
+void swap(Buffer<T, Allocator> & lhs, std::vector<T, Allocator> & rhs) noexcept
+{
+  lhs.swap(rhs);
+}
+
+template<typename T, typename Allocator>
+void swap(std::vector<T, Allocator> & lhs, Buffer<T, Allocator> & rhs) noexcept
+{
+  rhs.swap(lhs);
 }
 
 }  // namespace rosidl

--- a/rosidl_buffer/test/test_buffer.cpp
+++ b/rosidl_buffer/test/test_buffer.cpp
@@ -346,6 +346,153 @@ TEST(TestBuffer, shrink_to_fit) {
   EXPECT_LE(buffer.capacity(), 100u);
 }
 
+// Test member swap between two Buffers (CPU)
+TEST(TestBuffer, swap_member_buffer_buffer) {
+  Buffer<uint8_t> a{1, 2, 3};
+  Buffer<uint8_t> b{10, 20};
+
+  const uint8_t * a_data_before = a.data();
+  const uint8_t * b_data_before = b.data();
+
+  a.swap(b);
+
+  EXPECT_EQ(2u, a.size());
+  EXPECT_EQ(10, a[0]);
+  EXPECT_EQ(20, a[1]);
+
+  EXPECT_EQ(3u, b.size());
+  EXPECT_EQ(1, b[0]);
+  EXPECT_EQ(2, b[1]);
+  EXPECT_EQ(3, b[2]);
+
+  // std::vector::swap semantics: underlying storage pointers are swapped,
+  // not the elements copied — so data pointers should swap identities.
+  EXPECT_EQ(b_data_before, a.data());
+  EXPECT_EQ(a_data_before, b.data());
+}
+
+// Test self-swap is a no-op
+TEST(TestBuffer, swap_member_self) {
+  Buffer<uint8_t> a{1, 2, 3};
+  a.swap(a);
+  EXPECT_EQ(3u, a.size());
+  EXPECT_EQ(1, a[0]);
+  EXPECT_EQ(2, a[1]);
+  EXPECT_EQ(3, a[2]);
+}
+
+// Test member swap: Buffer with std::vector
+TEST(TestBuffer, swap_member_buffer_vector) {
+  Buffer<uint8_t> buf{1, 2, 3};
+  std::vector<uint8_t> vec{100, 101};
+
+  buf.swap(vec);
+
+  EXPECT_EQ(2u, buf.size());
+  EXPECT_EQ(100, buf[0]);
+  EXPECT_EQ(101, buf[1]);
+
+  EXPECT_EQ(3u, vec.size());
+  EXPECT_EQ(1, vec[0]);
+  EXPECT_EQ(2, vec[1]);
+  EXPECT_EQ(3, vec[2]);
+}
+
+// Test vector::swap(Buffer) works via implicit conversion operator
+TEST(TestBuffer, swap_vector_member_with_buffer) {
+  Buffer<uint8_t> buf{1, 2, 3};
+  std::vector<uint8_t> vec{100, 101};
+
+  // std::vector::swap takes vector&, Buffer's operator std::vector<T,A>&()
+  // provides the needed implicit conversion.
+  vec.swap(buf);
+
+  EXPECT_EQ(2u, buf.size());
+  EXPECT_EQ(100, buf[0]);
+  EXPECT_EQ(101, buf[1]);
+
+  EXPECT_EQ(3u, vec.size());
+  EXPECT_EQ(1, vec[0]);
+  EXPECT_EQ(2, vec[1]);
+  EXPECT_EQ(3, vec[2]);
+}
+
+// Test non-member swap resolved via ADL (the "using std::swap" idiom)
+TEST(TestBuffer, swap_non_member_adl_buffer_buffer) {
+  Buffer<uint8_t> a{1, 2, 3};
+  Buffer<uint8_t> b{10, 20};
+
+  using std::swap;
+  swap(a, b);   // should resolve to rosidl::swap via ADL
+
+  EXPECT_EQ(2u, a.size());
+  EXPECT_EQ(10, a[0]);
+  EXPECT_EQ(3u, b.size());
+  EXPECT_EQ(1, b[0]);
+}
+
+// Test non-member ADL swap: Buffer <-> std::vector (both directions)
+TEST(TestBuffer, swap_non_member_adl_mixed) {
+  Buffer<uint8_t> buf{1, 2, 3};
+  std::vector<uint8_t> vec{100, 101};
+
+  using std::swap;
+  swap(buf, vec);   // rosidl::swap(Buffer&, std::vector&)
+
+  EXPECT_EQ(2u, buf.size());
+  EXPECT_EQ(100, buf[0]);
+  EXPECT_EQ(3u, vec.size());
+  EXPECT_EQ(1, vec[0]);
+
+  swap(vec, buf);   // rosidl::swap(std::vector&, Buffer&)
+
+  EXPECT_EQ(3u, buf.size());
+  EXPECT_EQ(1, buf[0]);
+  EXPECT_EQ(2u, vec.size());
+  EXPECT_EQ(100, vec[0]);
+}
+
+// Test that std::swap (qualified) still works on Buffers via move fallback.
+// This does not use our specialized swap, but should still be correct
+// because Buffer has a noexcept move ctor and move assignment.
+TEST(TestBuffer, swap_qualified_std_swap) {
+  Buffer<uint8_t> a{1, 2, 3};
+  Buffer<uint8_t> b{10, 20};
+
+  std::swap(a, b);
+
+  EXPECT_EQ(2u, a.size());
+  EXPECT_EQ(10, a[0]);
+  EXPECT_EQ(3u, b.size());
+  EXPECT_EQ(1, b[0]);
+}
+
+// Test std::is_nothrow_swappable_v reports true, matching std::vector.
+TEST(TestBuffer, swap_is_noexcept) {
+  static_assert(
+    std::is_nothrow_swappable_v<Buffer<uint8_t>>,
+    "rosidl::Buffer should be nothrow-swappable to match std::vector");
+  SUCCEED();
+}
+
+// Test swap used by generic STL algorithm (via ADL internally).
+TEST(TestBuffer, swap_used_by_std_algorithm) {
+  std::vector<Buffer<uint8_t>> buffers;
+  buffers.emplace_back(std::initializer_list<uint8_t>{3});
+  buffers.emplace_back(std::initializer_list<uint8_t>{1});
+  buffers.emplace_back(std::initializer_list<uint8_t>{2});
+
+  std::sort(
+    buffers.begin(), buffers.end(),
+    [](const Buffer<uint8_t> & lhs, const Buffer<uint8_t> & rhs) {
+      return lhs[0] < rhs[0];
+    });
+
+  EXPECT_EQ(1, buffers[0][0]);
+  EXPECT_EQ(2, buffers[1][0]);
+  EXPECT_EQ(3, buffers[2][0]);
+}
+
 // Test implicit conversion to std::vector&
 TEST(TestBuffer, implicit_conversion_to_vector) {
   Buffer<uint8_t> buffer;

--- a/rosidl_buffer/test/test_buffer.cpp
+++ b/rosidl_buffer/test/test_buffer.cpp
@@ -194,6 +194,72 @@ TEST(TestBuffer, iterators) {
   EXPECT_EQ(6, const_sum);
 }
 
+// Test reverse iterators
+TEST(TestBuffer, reverse_iterators) {
+  Buffer<uint8_t> buffer{1, 2, 3, 4, 5};
+
+  std::vector<uint8_t> reversed;
+  for (auto it = buffer.rbegin(); it != buffer.rend(); ++it) {
+    reversed.push_back(*it);
+  }
+  ASSERT_EQ(5u, reversed.size());
+  EXPECT_EQ(5, reversed[0]);
+  EXPECT_EQ(4, reversed[1]);
+  EXPECT_EQ(3, reversed[2]);
+  EXPECT_EQ(2, reversed[3]);
+  EXPECT_EQ(1, reversed[4]);
+
+  // rbegin/rend are mutable
+  *buffer.rbegin() = 99;
+  EXPECT_EQ(99, buffer.back());
+}
+
+// Test const reverse iterators via crbegin/crend
+TEST(TestBuffer, const_reverse_iterators) {
+  Buffer<uint8_t> buffer{10, 20, 30};
+  const Buffer<uint8_t> & cbuffer = buffer;
+
+  std::vector<uint8_t> reversed;
+  for (auto it = cbuffer.rbegin(); it != cbuffer.rend(); ++it) {
+    reversed.push_back(*it);
+  }
+  EXPECT_EQ(30, reversed[0]);
+  EXPECT_EQ(20, reversed[1]);
+  EXPECT_EQ(10, reversed[2]);
+
+  // crbegin/crend
+  reversed.clear();
+  for (auto it = buffer.crbegin(); it != buffer.crend(); ++it) {
+    reversed.push_back(*it);
+  }
+  EXPECT_EQ(30, reversed[0]);
+  EXPECT_EQ(20, reversed[1]);
+  EXPECT_EQ(10, reversed[2]);
+
+  // Type check: crbegin returns const_reverse_iterator
+  static_assert(
+    std::is_same_v<
+      decltype(buffer.crbegin()),
+      Buffer<uint8_t>::const_reverse_iterator>,
+    "crbegin must return const_reverse_iterator");
+  static_assert(
+    std::is_same_v<
+      decltype(buffer.crend()),
+      Buffer<uint8_t>::const_reverse_iterator>,
+    "crend must return const_reverse_iterator");
+}
+
+// Test reverse iterators work with std::reverse
+TEST(TestBuffer, reverse_iterators_with_std_reverse) {
+  Buffer<uint8_t> buffer{1, 2, 3, 4, 5};
+  std::reverse(buffer.begin(), buffer.end());
+  EXPECT_EQ(5, buffer[0]);
+  EXPECT_EQ(4, buffer[1]);
+  EXPECT_EQ(3, buffer[2]);
+  EXPECT_EQ(2, buffer[3]);
+  EXPECT_EQ(1, buffer[4]);
+}
+
 // Test resize
 TEST(TestBuffer, resize) {
   Buffer<uint8_t> buffer(5, 10);
@@ -265,6 +331,96 @@ TEST(TestBuffer, emplace_back) {
   EXPECT_EQ(2u, buffer.size());
   EXPECT_EQ(0xFF, buffer[0]);
   EXPECT_EQ(0x00, buffer[1]);
+}
+
+// Test emplace_back returns reference
+TEST(TestBuffer, emplace_back_returns_reference) {
+  Buffer<std::string> buffer;
+  std::string & ref = buffer.emplace_back("hello");
+  EXPECT_EQ("hello", ref);
+  EXPECT_EQ(&ref, &buffer.back());
+
+  ref = "modified";
+  EXPECT_EQ("modified", buffer.back());
+
+  static_assert(
+    std::is_same_v<
+      decltype(buffer.emplace_back("x")),
+      std::string &>,
+    "emplace_back must return reference");
+}
+
+// Test positional emplace at begin/middle/end
+TEST(TestBuffer, emplace_positional) {
+  Buffer<std::string> buffer;
+  buffer.push_back("b");
+  buffer.push_back("d");
+
+  auto it_begin = buffer.emplace(buffer.begin(), "a");
+  EXPECT_EQ("a", *it_begin);
+  EXPECT_EQ(buffer.begin(), it_begin);
+
+  auto it_mid = buffer.emplace(buffer.begin() + 2, "c");
+  EXPECT_EQ("c", *it_mid);
+
+  auto it_end = buffer.emplace(buffer.end(), "e");
+  EXPECT_EQ("e", *it_end);
+
+  ASSERT_EQ(5u, buffer.size());
+  EXPECT_EQ("a", buffer[0]);
+  EXPECT_EQ("b", buffer[1]);
+  EXPECT_EQ("c", buffer[2]);
+  EXPECT_EQ("d", buffer[3]);
+  EXPECT_EQ("e", buffer[4]);
+}
+
+// Test erase single element — beginning, middle, end
+TEST(TestBuffer, erase_single) {
+  Buffer<uint8_t> buffer{1, 2, 3, 4, 5};
+
+  // Erase middle: returns iterator to the element that followed it.
+  auto it = buffer.erase(buffer.begin() + 2);
+  ASSERT_EQ(4u, buffer.size());
+  EXPECT_EQ(4, *it);
+  EXPECT_EQ(1, buffer[0]);
+  EXPECT_EQ(2, buffer[1]);
+  EXPECT_EQ(4, buffer[2]);
+  EXPECT_EQ(5, buffer[3]);
+
+  // Erase beginning
+  it = buffer.erase(buffer.begin());
+  EXPECT_EQ(2, *it);
+  EXPECT_EQ(3u, buffer.size());
+  EXPECT_EQ(2, buffer[0]);
+
+  // Erase last — returned iterator equals end()
+  it = buffer.erase(buffer.end() - 1);
+  EXPECT_EQ(buffer.end(), it);
+  EXPECT_EQ(2u, buffer.size());
+}
+
+// Test erase range
+TEST(TestBuffer, erase_range) {
+  Buffer<uint8_t> buffer{1, 2, 3, 4, 5, 6};
+
+  // Erase middle range [2, 4) -> removes 3, 4
+  auto it = buffer.erase(buffer.begin() + 2, buffer.begin() + 4);
+  ASSERT_EQ(4u, buffer.size());
+  EXPECT_EQ(5, *it);
+  EXPECT_EQ(1, buffer[0]);
+  EXPECT_EQ(2, buffer[1]);
+  EXPECT_EQ(5, buffer[2]);
+  EXPECT_EQ(6, buffer[3]);
+
+  // Empty range is a no-op
+  auto it2 = buffer.erase(buffer.begin() + 1, buffer.begin() + 1);
+  EXPECT_EQ(4u, buffer.size());
+  EXPECT_EQ(2, *it2);
+
+  // Erase all
+  auto it3 = buffer.erase(buffer.begin(), buffer.end());
+  EXPECT_EQ(0u, buffer.size());
+  EXPECT_EQ(buffer.end(), it3);
 }
 
 // Test assign with count and value
@@ -491,6 +647,56 @@ TEST(TestBuffer, swap_used_by_std_algorithm) {
   EXPECT_EQ(1, buffers[0][0]);
   EXPECT_EQ(2, buffers[1][0]);
   EXPECT_EQ(3, buffers[2][0]);
+}
+
+// ========== Group 3: operator<=> and comparisons ==========
+
+// Test equality between Buffers
+TEST(TestBuffer, equality_buffer_buffer) {
+  Buffer<uint8_t> a{1, 2, 3};
+  Buffer<uint8_t> b{1, 2, 3};
+  Buffer<uint8_t> c{1, 2, 4};
+  Buffer<uint8_t> d{1, 2};
+
+  EXPECT_EQ(a, b);
+  EXPECT_NE(a, c);
+  EXPECT_NE(a, d);
+}
+
+// Test equality between Buffer and std::vector (both directions)
+TEST(TestBuffer, equality_buffer_vector) {
+  Buffer<uint8_t> buf{1, 2, 3};
+  std::vector<uint8_t> vec_eq{1, 2, 3};
+  std::vector<uint8_t> vec_neq{1, 2, 4};
+
+  EXPECT_EQ(buf, vec_eq);
+  EXPECT_EQ(vec_eq, buf);
+
+  EXPECT_NE(buf, vec_neq);
+  EXPECT_NE(vec_neq, buf);
+}
+
+// ========== Group 4: max_size, get_allocator ==========
+
+TEST(TestBuffer, max_size) {
+  Buffer<uint8_t> buffer;
+  // max_size is implementation-defined but must be > 0 and >= size().
+  EXPECT_GT(buffer.max_size(), 0u);
+  buffer.resize(16);
+  EXPECT_GE(buffer.max_size(), buffer.size());
+}
+
+TEST(TestBuffer, get_allocator) {
+  Buffer<uint8_t> buffer;
+  auto alloc = buffer.get_allocator();
+  // std::allocator<uint8_t> instances always compare equal.
+  EXPECT_EQ(alloc, std::allocator<uint8_t>{});
+
+  static_assert(
+    std::is_same_v<
+      decltype(buffer.get_allocator()),
+      Buffer<uint8_t>::allocator_type>,
+    "get_allocator must return allocator_type");
 }
 
 // Test implicit conversion to std::vector&
@@ -748,6 +954,11 @@ TEST(TestBufferNonCpu, modifiers_throw) {
   EXPECT_THROW(buffer.push_back(1), std::runtime_error);
   EXPECT_THROW(buffer.pop_back(), std::runtime_error);
   EXPECT_THROW(buffer.emplace_back(1), std::runtime_error);
+
+  using ConstIt = Buffer<uint8_t>::const_iterator;
+  EXPECT_THROW(buffer.erase(ConstIt{}), std::runtime_error);
+  EXPECT_THROW(buffer.erase(ConstIt{}, ConstIt{}), std::runtime_error);
+  EXPECT_THROW(buffer.emplace(ConstIt{}, 1), std::runtime_error);
 }
 
 TEST(TestBufferNonCpu, capacity_throws) {
@@ -757,6 +968,23 @@ TEST(TestBufferNonCpu, capacity_throws) {
   EXPECT_THROW(buffer.reserve(10), std::runtime_error);
   EXPECT_THROW(buffer.capacity(), std::runtime_error);
   EXPECT_THROW(buffer.shrink_to_fit(), std::runtime_error);
+  EXPECT_THROW(buffer.max_size(), std::runtime_error);
+  EXPECT_THROW(buffer.get_allocator(), std::runtime_error);
+}
+
+TEST(TestBufferNonCpu, reverse_iterators_throw) {
+  auto impl = std::make_unique<NonCpuBufferImpl<uint8_t>>(4);
+  Buffer<uint8_t> buffer(std::move(impl));
+
+  EXPECT_THROW(buffer.rbegin(), std::runtime_error);
+  EXPECT_THROW(buffer.rend(), std::runtime_error);
+  EXPECT_THROW(buffer.crbegin(), std::runtime_error);
+  EXPECT_THROW(buffer.crend(), std::runtime_error);
+
+  auto impl2 = std::make_unique<NonCpuBufferImpl<uint8_t>>(4);
+  const Buffer<uint8_t> cbuffer(std::move(impl2));
+  EXPECT_THROW(cbuffer.rbegin(), std::runtime_error);
+  EXPECT_THROW(cbuffer.rend(), std::runtime_error);
 }
 
 TEST(TestBufferNonCpu, implicit_conversion_throws) {
@@ -781,6 +1009,62 @@ TEST(TestBufferNonCpu, to_vector_works) {
 
   std::vector<uint8_t> vec = buffer.to_vector();
   EXPECT_EQ(3u, vec.size());
+}
+
+// ========== Non-CPU swap death tests ==========
+//
+// Every swap entry point is declared noexcept to match std::vector::swap's
+// noexcept contract and preserve std::is_nothrow_swappable_v<Buffer>.
+// Calling swap on a non-CPU backend is therefore a precondition violation:
+// throw_if_not_cpu_backend() throws a std::runtime_error which escapes the
+// noexcept function and invokes std::terminate().
+
+TEST(TestBufferNonCpuDeathTest, member_swap_buffer_terminates) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  auto impl_a = std::make_unique<NonCpuBufferImpl<uint8_t>>(4);
+  Buffer<uint8_t> a(std::move(impl_a));
+  Buffer<uint8_t> b{1, 2, 3};
+  EXPECT_DEATH({a.swap(b);}, "CPU backend");
+}
+
+TEST(TestBufferNonCpuDeathTest, member_swap_buffer_other_side_terminates) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  Buffer<uint8_t> a{1, 2, 3};
+  auto impl_b = std::make_unique<NonCpuBufferImpl<uint8_t>>(4);
+  Buffer<uint8_t> b(std::move(impl_b));
+  EXPECT_DEATH({a.swap(b);}, "CPU backend");
+}
+
+TEST(TestBufferNonCpuDeathTest, member_swap_vector_terminates) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  auto impl = std::make_unique<NonCpuBufferImpl<uint8_t>>(4);
+  Buffer<uint8_t> buf(std::move(impl));
+  std::vector<uint8_t> vec{1, 2, 3};
+  EXPECT_DEATH({buf.swap(vec);}, "CPU backend");
+}
+
+TEST(TestBufferNonCpuDeathTest, free_swap_buffer_buffer_terminates) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  auto impl_a = std::make_unique<NonCpuBufferImpl<uint8_t>>(4);
+  Buffer<uint8_t> a(std::move(impl_a));
+  Buffer<uint8_t> b{1, 2, 3};
+  EXPECT_DEATH({using std::swap; swap(a, b);}, "CPU backend");
+}
+
+TEST(TestBufferNonCpuDeathTest, free_swap_buffer_vector_terminates) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  auto impl = std::make_unique<NonCpuBufferImpl<uint8_t>>(4);
+  Buffer<uint8_t> buf(std::move(impl));
+  std::vector<uint8_t> vec{1, 2, 3};
+  EXPECT_DEATH({using std::swap; swap(buf, vec);}, "CPU backend");
+}
+
+TEST(TestBufferNonCpuDeathTest, free_swap_vector_buffer_terminates) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  auto impl = std::make_unique<NonCpuBufferImpl<uint8_t>>(4);
+  Buffer<uint8_t> buf(std::move(impl));
+  std::vector<uint8_t> vec{1, 2, 3};
+  EXPECT_DEATH({using std::swap; swap(vec, buf);}, "CPU backend");
 }
 
 int main(int argc, char ** argv)

--- a/rosidl_buffer/test/test_buffer.cpp
+++ b/rosidl_buffer/test/test_buffer.cpp
@@ -1024,7 +1024,7 @@ TEST(TestBufferNonCpuDeathTest, member_swap_buffer_terminates) {
   auto impl_a = std::make_unique<NonCpuBufferImpl<uint8_t>>(4);
   Buffer<uint8_t> a(std::move(impl_a));
   Buffer<uint8_t> b{1, 2, 3};
-  EXPECT_DEATH({a.swap(b);}, "CPU backend");
+  EXPECT_DEATH({a.swap(b);}, ".*");
 }
 
 TEST(TestBufferNonCpuDeathTest, member_swap_buffer_other_side_terminates) {
@@ -1032,7 +1032,7 @@ TEST(TestBufferNonCpuDeathTest, member_swap_buffer_other_side_terminates) {
   Buffer<uint8_t> a{1, 2, 3};
   auto impl_b = std::make_unique<NonCpuBufferImpl<uint8_t>>(4);
   Buffer<uint8_t> b(std::move(impl_b));
-  EXPECT_DEATH({a.swap(b);}, "CPU backend");
+  EXPECT_DEATH({a.swap(b);}, ".*");
 }
 
 TEST(TestBufferNonCpuDeathTest, member_swap_vector_terminates) {
@@ -1040,7 +1040,7 @@ TEST(TestBufferNonCpuDeathTest, member_swap_vector_terminates) {
   auto impl = std::make_unique<NonCpuBufferImpl<uint8_t>>(4);
   Buffer<uint8_t> buf(std::move(impl));
   std::vector<uint8_t> vec{1, 2, 3};
-  EXPECT_DEATH({buf.swap(vec);}, "CPU backend");
+  EXPECT_DEATH({buf.swap(vec);}, ".*");
 }
 
 TEST(TestBufferNonCpuDeathTest, free_swap_buffer_buffer_terminates) {
@@ -1048,7 +1048,7 @@ TEST(TestBufferNonCpuDeathTest, free_swap_buffer_buffer_terminates) {
   auto impl_a = std::make_unique<NonCpuBufferImpl<uint8_t>>(4);
   Buffer<uint8_t> a(std::move(impl_a));
   Buffer<uint8_t> b{1, 2, 3};
-  EXPECT_DEATH({using std::swap; swap(a, b);}, "CPU backend");
+  EXPECT_DEATH({using std::swap; swap(a, b);}, ".*");
 }
 
 TEST(TestBufferNonCpuDeathTest, free_swap_buffer_vector_terminates) {
@@ -1056,7 +1056,7 @@ TEST(TestBufferNonCpuDeathTest, free_swap_buffer_vector_terminates) {
   auto impl = std::make_unique<NonCpuBufferImpl<uint8_t>>(4);
   Buffer<uint8_t> buf(std::move(impl));
   std::vector<uint8_t> vec{1, 2, 3};
-  EXPECT_DEATH({using std::swap; swap(buf, vec);}, "CPU backend");
+  EXPECT_DEATH({using std::swap; swap(buf, vec);}, ".*");
 }
 
 TEST(TestBufferNonCpuDeathTest, free_swap_vector_buffer_terminates) {
@@ -1064,7 +1064,7 @@ TEST(TestBufferNonCpuDeathTest, free_swap_vector_buffer_terminates) {
   auto impl = std::make_unique<NonCpuBufferImpl<uint8_t>>(4);
   Buffer<uint8_t> buf(std::move(impl));
   std::vector<uint8_t> vec{1, 2, 3};
-  EXPECT_DEATH({using std::swap; swap(vec, buf);}, "CPU backend");
+  EXPECT_DEATH({using std::swap; swap(vec, buf);}, ".*");
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
## Description

Adds the missing `swap()` and other APIs to `rosidl::Buffer` so that it remains a true drop-in replacement for `std::vector` in CPU-backed message fields.

Specifically the following functions are added for `rosidl::Buffer` (`src/ros2/rosidl/rosidl_buffer/include/rosidl_buffer/buffer.hpp`):

- swap APIs
  - Member `swap(Buffer &)`
  - Member `swap(std::vector<T, Allocator> &)`
  - Non-member `rosidl::swap(Buffer&, Buffer&)`
  - Non-member `rosidl::swap(Buffer&, std::vector&)`
  - Non-member `rosidl::swap(std::vector&, Buffer&)`
- other missing std::vector APIs
  - iterator erase(const_iterator pos) and iterator erase(const_iterator first, const_iterator last)
  - template<typename... Args> iterator emplace(const_iterator pos, Args &&... args)
  - emplace_back(...) now returns reference (C++17 signature; previously returned void)
  - Reverse iterators: rbegin(), rend(), crbegin(), crend() (in addition to the new reverse-iterator type aliases)
  - size_type max_size() const
  - allocator_type get_allocator() const

### Is this user-facing behavior change?

Yes. This pull request tries to fill the gap in `rosidl::Buffer` to make it a drop-in replacement for `std::vector`.

### Additional Information

This is to fix the issue discovered from https://github.com/ros-perception/perception_pcl/pull/529.