### PR TITLE
rosidl_buffer_backend_registry: add missing ament_cmake_gtest dep

### DIFF
--- a/rosidl_buffer_backend_registry/package.xml
+++ b/rosidl_buffer_backend_registry/package.xml
@@ -18,6 +18,7 @@
   <depend>rosidl_runtime_cpp</depend>
   <depend>pluginlib</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>rosidl_buffer</test_depend>


### PR DESCRIPTION
## Description

https://github.com/ros2/rosidl/blob/fb48dcf959dff3292999483634a1da5acecb1a26/rosidl_buffer_backend_registry/CMakeLists.txt#L66

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information

N/A