### PR TITLE
Add include guards to generated IDL

### DIFF
--- a/rosidl_adapter/rosidl_adapter/resource/action.idl.em
+++ b/rosidl_adapter/rosidl_adapter/resource/action.idl.em
@@ -6,10 +6,13 @@
 import re
 from rosidl_adapter.msg import get_include_file
 
-include_guard = re.sub(r'[^0-9A-Za-z]+', '_', f'{pkg_name}_{relative_input_file}')
-include_guard = include_guard.strip('_').upper()
-if not include_guard or not include_guard[0].isalpha():
-    include_guard = f'ROSIDL_{include_guard}'
+include_guard_parts = [
+    re.sub(r'[^0-9A-Za-z]+', '_', part).strip('_').upper()
+    for part in (pkg_name, *relative_input_file.parts)
+]
+assert all(include_guard_parts)
+include_guard = '__'.join(include_guard_parts)
+assert include_guard[0].isalpha()
 include_files = set()
 fields = action.goal.fields + action.result.fields + action.feedback.fields
 for field in fields:
@@ -20,12 +23,10 @@ for field in fields:
 #ifndef @(include_guard)
 #define @(include_guard)
 
-@[if include_files]@
 @[for include_file in sorted(include_files)]@
 #include "@(include_file)"
 @[end for]@
 
-@[end if]@
 module @(pkg_name) {
   module action {
 @{

--- a/rosidl_adapter/rosidl_adapter/resource/action.idl.em
+++ b/rosidl_adapter/rosidl_adapter/resource/action.idl.em
@@ -3,7 +3,13 @@
 // generated code does not contain a copyright notice
 
 @{
+import re
 from rosidl_adapter.msg import get_include_file
+
+include_guard = re.sub(r'[^0-9A-Za-z]+', '_', f'{pkg_name}_{relative_input_file}')
+include_guard = include_guard.strip('_').upper()
+if not include_guard or not include_guard[0].isalpha():
+    include_guard = f'ROSIDL_{include_guard}'
 include_files = set()
 fields = action.goal.fields + action.result.fields + action.feedback.fields
 for field in fields:
@@ -11,10 +17,15 @@ for field in fields:
     if include_file is not None:
         include_files.add(include_file)
 }@
+#ifndef @(include_guard)
+#define @(include_guard)
+
+@[if include_files]@
 @[for include_file in sorted(include_files)]@
 #include "@(include_file)"
 @[end for]@
 
+@[end if]@
 module @(pkg_name) {
   module action {
 @{
@@ -37,3 +48,5 @@ TEMPLATE(
 }@
   };
 };
+
+#endif  // @(include_guard)

--- a/rosidl_adapter/rosidl_adapter/resource/msg.idl.em
+++ b/rosidl_adapter/rosidl_adapter/resource/msg.idl.em
@@ -3,17 +3,28 @@
 // generated code does not contain a copyright notice
 
 @{
+import re
 from rosidl_adapter.msg import get_include_file
+
+include_guard = re.sub(r'[^0-9A-Za-z]+', '_', f'{pkg_name}_{relative_input_file}')
+include_guard = include_guard.strip('_').upper()
+if not include_guard or not include_guard[0].isalpha():
+    include_guard = f'ROSIDL_{include_guard}'
 include_files = set()
 for field in msg.fields:
     include_file = get_include_file(field.type)
     if include_file is not None:
         include_files.add(include_file)
 }@
+#ifndef @(include_guard)
+#define @(include_guard)
+
+@[if include_files]@
 @[for include_file in sorted(include_files)]@
 #include "@(include_file)"
 @[end for]@
 
+@[end if]@
 module @(pkg_name) {
   module msg {
 @{
@@ -24,3 +35,5 @@ TEMPLATE(
 }@
   };
 };
+
+#endif  // @(include_guard)

--- a/rosidl_adapter/rosidl_adapter/resource/msg.idl.em
+++ b/rosidl_adapter/rosidl_adapter/resource/msg.idl.em
@@ -6,10 +6,13 @@
 import re
 from rosidl_adapter.msg import get_include_file
 
-include_guard = re.sub(r'[^0-9A-Za-z]+', '_', f'{pkg_name}_{relative_input_file}')
-include_guard = include_guard.strip('_').upper()
-if not include_guard or not include_guard[0].isalpha():
-    include_guard = f'ROSIDL_{include_guard}'
+include_guard_parts = [
+    re.sub(r'[^0-9A-Za-z]+', '_', part).strip('_').upper()
+    for part in (pkg_name, *relative_input_file.parts)
+]
+assert all(include_guard_parts)
+include_guard = '__'.join(include_guard_parts)
+assert include_guard[0].isalpha()
 include_files = set()
 for field in msg.fields:
     include_file = get_include_file(field.type)
@@ -19,12 +22,10 @@ for field in msg.fields:
 #ifndef @(include_guard)
 #define @(include_guard)
 
-@[if include_files]@
 @[for include_file in sorted(include_files)]@
 #include "@(include_file)"
 @[end for]@
 
-@[end if]@
 module @(pkg_name) {
   module msg {
 @{

--- a/rosidl_adapter/rosidl_adapter/resource/srv.idl.em
+++ b/rosidl_adapter/rosidl_adapter/resource/srv.idl.em
@@ -6,10 +6,13 @@
 import re
 from rosidl_adapter.msg import get_include_file
 
-include_guard = re.sub(r'[^0-9A-Za-z]+', '_', f'{pkg_name}_{relative_input_file}')
-include_guard = include_guard.strip('_').upper()
-if not include_guard or not include_guard[0].isalpha():
-    include_guard = f'ROSIDL_{include_guard}'
+include_guard_parts = [
+    re.sub(r'[^0-9A-Za-z]+', '_', part).strip('_').upper()
+    for part in (pkg_name, *relative_input_file.parts)
+]
+assert all(include_guard_parts)
+include_guard = '__'.join(include_guard_parts)
+assert include_guard[0].isalpha()
 include_files = set()
 for field in srv.request.fields + srv.response.fields:
     include_file = get_include_file(field.type)
@@ -19,12 +22,10 @@ for field in srv.request.fields + srv.response.fields:
 #ifndef @(include_guard)
 #define @(include_guard)
 
-@[if include_files]@
 @[for include_file in sorted(include_files)]@
 #include "@(include_file)"
 @[end for]@
 
-@[end if]@
 module @(pkg_name) {
   module srv {
 @{

--- a/rosidl_adapter/rosidl_adapter/resource/srv.idl.em
+++ b/rosidl_adapter/rosidl_adapter/resource/srv.idl.em
@@ -3,17 +3,28 @@
 // generated code does not contain a copyright notice
 
 @{
+import re
 from rosidl_adapter.msg import get_include_file
+
+include_guard = re.sub(r'[^0-9A-Za-z]+', '_', f'{pkg_name}_{relative_input_file}')
+include_guard = include_guard.strip('_').upper()
+if not include_guard or not include_guard[0].isalpha():
+    include_guard = f'ROSIDL_{include_guard}'
 include_files = set()
 for field in srv.request.fields + srv.response.fields:
     include_file = get_include_file(field.type)
     if include_file is not None:
         include_files.add(include_file)
 }@
+#ifndef @(include_guard)
+#define @(include_guard)
+
+@[if include_files]@
 @[for include_file in sorted(include_files)]@
 #include "@(include_file)"
 @[end for]@
 
+@[end if]@
 module @(pkg_name) {
   module srv {
 @{
@@ -30,3 +41,5 @@ TEMPLATE(
 }@
   };
 };
+
+#endif  // @(include_guard)

--- a/rosidl_adapter/test/data/action/Test.expected.idl
+++ b/rosidl_adapter/test/data/action/Test.expected.idl
@@ -2,8 +2,8 @@
 // with input from test_msgs/action/Test.action
 // generated code does not contain a copyright notice
 
-#ifndef TEST_MSGS_ACTION_TEST_ACTION
-#define TEST_MSGS_ACTION_TEST_ACTION
+#ifndef TEST_MSGS__ACTION__TEST_ACTION
+#define TEST_MSGS__ACTION__TEST_ACTION
 
 module test_msgs {
   module action {
@@ -67,4 +67,4 @@ module test_msgs {
   };
 };
 
-#endif  // TEST_MSGS_ACTION_TEST_ACTION
+#endif  // TEST_MSGS__ACTION__TEST_ACTION

--- a/rosidl_adapter/test/data/action/Test.expected.idl
+++ b/rosidl_adapter/test/data/action/Test.expected.idl
@@ -2,6 +2,8 @@
 // with input from test_msgs/action/Test.action
 // generated code does not contain a copyright notice
 
+#ifndef TEST_MSGS_ACTION_TEST_ACTION
+#define TEST_MSGS_ACTION_TEST_ACTION
 
 module test_msgs {
   module action {
@@ -64,3 +66,5 @@ module test_msgs {
     };
   };
 };
+
+#endif  // TEST_MSGS_ACTION_TEST_ACTION

--- a/rosidl_adapter/test/data/msg/Test.expected.idl
+++ b/rosidl_adapter/test/data/msg/Test.expected.idl
@@ -2,6 +2,8 @@
 // with input from test_msgs/msg/Test.msg
 // generated code does not contain a copyright notice
 
+#ifndef TEST_MSGS_MSG_TEST_MSG
+#define TEST_MSGS_MSG_TEST_MSG
 
 module test_msgs {
   module msg {
@@ -63,3 +65,5 @@ module test_msgs {
     };
   };
 };
+
+#endif  // TEST_MSGS_MSG_TEST_MSG

--- a/rosidl_adapter/test/data/msg/Test.expected.idl
+++ b/rosidl_adapter/test/data/msg/Test.expected.idl
@@ -2,8 +2,8 @@
 // with input from test_msgs/msg/Test.msg
 // generated code does not contain a copyright notice
 
-#ifndef TEST_MSGS_MSG_TEST_MSG
-#define TEST_MSGS_MSG_TEST_MSG
+#ifndef TEST_MSGS__MSG__TEST_MSG
+#define TEST_MSGS__MSG__TEST_MSG
 
 module test_msgs {
   module msg {
@@ -66,4 +66,4 @@ module test_msgs {
   };
 };
 
-#endif  // TEST_MSGS_MSG_TEST_MSG
+#endif  // TEST_MSGS__MSG__TEST_MSG

--- a/rosidl_adapter/test/data/srv/Test.expected.idl
+++ b/rosidl_adapter/test/data/srv/Test.expected.idl
@@ -2,8 +2,8 @@
 // with input from test_msgs/srv/Test.srv
 // generated code does not contain a copyright notice
 
-#ifndef TEST_MSGS_SRV_TEST_SRV
-#define TEST_MSGS_SRV_TEST_SRV
+#ifndef TEST_MSGS__SRV__TEST_SRV
+#define TEST_MSGS__SRV__TEST_SRV
 
 module test_msgs {
   module srv {
@@ -59,4 +59,4 @@ module test_msgs {
   };
 };
 
-#endif  // TEST_MSGS_SRV_TEST_SRV
+#endif  // TEST_MSGS__SRV__TEST_SRV

--- a/rosidl_adapter/test/data/srv/Test.expected.idl
+++ b/rosidl_adapter/test/data/srv/Test.expected.idl
@@ -2,6 +2,8 @@
 // with input from test_msgs/srv/Test.srv
 // generated code does not contain a copyright notice
 
+#ifndef TEST_MSGS_SRV_TEST_SRV
+#define TEST_MSGS_SRV_TEST_SRV
 
 module test_msgs {
   module srv {
@@ -56,3 +58,5 @@ module test_msgs {
     };
   };
 };
+
+#endif  // TEST_MSGS_SRV_TEST_SRV

--- a/rosidl_parser/rosidl_parser/grammar.lark
+++ b/rosidl_parser/rosidl_parser/grammar.lark
@@ -3,7 +3,8 @@
 // 7.2.3 Identifiers
 // 7.2.6 Literals
 // 7.3 Preprocessing
-//   only #include and simple include guard directives are supported
+//   only #include and simple include guard directives
+//   (#ifndef / #define / #endif) are supported
 // 7.4.1 Building Block Core Data Types
 // 7.4.15.4.2 Applying Annotations
 //   Only supported on modules, structs, members, enums and enum identifiers

--- a/rosidl_parser/rosidl_parser/grammar.lark
+++ b/rosidl_parser/rosidl_parser/grammar.lark
@@ -3,7 +3,7 @@
 // 7.2.3 Identifiers
 // 7.2.6 Literals
 // 7.3 Preprocessing
-//   only #include is supported
+//   only #include and simple include guard directives are supported
 // 7.4.1 Building Block Core Data Types
 // 7.4.15.4.2 Applying Annotations
 //   Only supported on modules, structs, members, enums and enum identifiers
@@ -91,7 +91,15 @@ fixed_pt_literal: DECIMAL "d"i
 
 
 // 7.3 Preprocessing
+PREPROCESSOR_IDENTIFIER: (LETTER | "_") (LETTER | DIGIT | "_")*
+preprocessor_directive: include_directive
+  | ifndef_directive
+  | define_directive
+  | endif_directive
 include_directive: "#include" ("<" h_char_sequence ">" | "\"" q_char_sequence "\"")
+ifndef_directive: "#ifndef" PREPROCESSOR_IDENTIFIER
+define_directive: "#define" PREPROCESSOR_IDENTIFIER
+endif_directive: "#endif"
 // Preprocessor spec - 5.8 Header names
 h_char_sequence: /[^>]+/
 q_char_sequence: /[^"]+/
@@ -106,7 +114,7 @@ specification: definition+
 definition: module_dcl ";"
   | const_dcl ";"
   | type_dcl ";"
-  | include_directive
+  | preprocessor_directive
 
 // (3), 7.4.15.2
 module_dcl: annotation_appl* "module" IDENTIFIER "{" definition+ "}"

--- a/rosidl_parser/test/test_parser.py
+++ b/rosidl_parser/test/test_parser.py
@@ -95,8 +95,8 @@ def test_message_parser_includes(message_idl_file: IdlFile) -> None:
 
 def test_message_parser_include_guard() -> None:
     content = parse_idl_string("""
-#ifndef _ROSIDL_PARSER_MSG_GUARDED_IDL
-#define _ROSIDL_PARSER_MSG_GUARDED_IDL
+#ifndef ROSIDL_PARSER__MSG__GUARDED_IDL
+#define ROSIDL_PARSER__MSG__GUARDED_IDL
 
 #include "OtherMessage.idl"
 
@@ -108,7 +108,7 @@ module rosidl_parser {
   };
 };
 
-#endif  // _ROSIDL_PARSER_MSG_GUARDED_IDL
+#endif  // ROSIDL_PARSER__MSG__GUARDED_IDL
 """)
 
     includes = content.get_elements_of_type(Include)

--- a/rosidl_parser/test/test_parser.py
+++ b/rosidl_parser/test/test_parser.py
@@ -34,6 +34,7 @@ from rosidl_parser.definition import UnboundedWString
 from rosidl_parser.parser import get_ast_from_idl_string
 from rosidl_parser.parser import get_string_literals_value
 from rosidl_parser.parser import parse_idl_file
+from rosidl_parser.parser import parse_idl_string
 
 MESSAGE_IDL_LOCATOR = IdlLocator(
     pathlib.Path(__file__).parent, pathlib.Path('msg') / 'MyMessage.idl')
@@ -90,6 +91,35 @@ def test_message_parser_includes(message_idl_file: IdlFile) -> None:
     assert len(includes) == 2
     assert includes[0].locator == 'OtherMessage.idl'
     assert includes[1].locator == 'pkgname/msg/OtherMessage.idl'
+
+
+def test_message_parser_include_guard() -> None:
+    content = parse_idl_string("""
+#ifndef _ROSIDL_PARSER_MSG_GUARDED_IDL
+#define _ROSIDL_PARSER_MSG_GUARDED_IDL
+
+#include "OtherMessage.idl"
+
+module rosidl_parser {
+  module msg {
+    struct Guarded {
+      int32 value;
+    };
+  };
+};
+
+#endif  // _ROSIDL_PARSER_MSG_GUARDED_IDL
+""")
+
+    includes = content.get_elements_of_type(Include)
+    assert len(includes) == 1
+    assert includes[0].locator == 'OtherMessage.idl'
+
+    messages = content.get_elements_of_type(Message)
+    assert len(messages) == 1
+    assert messages[0].structure.namespaced_type.namespaces == [
+        'rosidl_parser', 'msg']
+    assert messages[0].structure.namespaced_type.name == 'Guarded'
 
 
 def test_message_parser_structure(message_idl_file: IdlFile) -> None:


### PR DESCRIPTION
## Description

Fixes #911.

This adds include guards to IDL generated by `rosidl_adapter` for `.msg`, `.srv`, and `.action` inputs. The guard name is derived from the package name and relative input file path, with non-alphanumeric characters normalized to underscores.

This also teaches `rosidl_parser` to accept the preprocessor lines emitted by the generated guarded IDL (`#ifndef`, `#define`, and `#endif`) and updates the generated IDL test fixtures.

### Is this user-facing behavior change?

Yes. Generated IDL now includes include guards, so downstream consumers that include generated IDL more than once can avoid duplicate definition issues. The generated message, service, and action interfaces otherwise keep the same IDL content.

### Did you use Generative AI?

Yes. I used OpenAI Codex (GPT-5) to help draft and update this pull request and its tests.

### Additional Information

The previous `Before / After` section was intended to show the concrete generated IDL output change for `test_msgs/msg/Test.msg`: before this PR, the generated IDL started directly with the `module test_msgs` declaration; after this PR, the same generated IDL is wrapped by the new `#ifndef` / `#define` / `#endif` include guard. The parser regression test confirms that guarded IDL still parses.

Tests run locally:

```bash
PYTHONPATH=rosidl_parser python3 -m pytest rosidl_parser/test/test_parser.py -q
```

Output:

```text
...........                                                              [100%]
11 passed in 0.68s
```

```bash
PYTHONPATH=rosidl_adapter:rosidl_parser python3 -m pytest rosidl_adapter/test/test_parse_message_string.py rosidl_adapter/test/test_parse_service_string.py rosidl_adapter/test/test_parse_action_string.py -q
```

Output:

```text
.......                                                                  [100%]
7 passed in 0.02s
```

```bash
git diff --check
```

Output:

```text
<no output>
```
