### PR TITLE
Avoid warnings from use of default constructed iterators

### DIFF
--- a/rosidl_buffer/test/test_buffer.cpp
+++ b/rosidl_buffer/test/test_buffer.cpp
@@ -956,7 +956,7 @@ TEST(TestBufferNonCpu, modifiers_throw) {
   EXPECT_THROW(buffer.emplace_back(1), std::runtime_error);
 
   using ConstIt = Buffer<uint8_t>::const_iterator;
-  std::vector<uint8_t> aux = { 0, 1 };
+  std::vector<uint8_t> aux = {0, 1};
   ConstIt it0 = aux.cbegin();
   ConstIt it1 = aux.cbegin() + 1;
   EXPECT_THROW(buffer.erase(it0), std::runtime_error);

--- a/rosidl_buffer/test/test_buffer.cpp
+++ b/rosidl_buffer/test/test_buffer.cpp
@@ -956,9 +956,12 @@ TEST(TestBufferNonCpu, modifiers_throw) {
   EXPECT_THROW(buffer.emplace_back(1), std::runtime_error);
 
   using ConstIt = Buffer<uint8_t>::const_iterator;
-  EXPECT_THROW(buffer.erase(ConstIt{}), std::runtime_error);
-  EXPECT_THROW(buffer.erase(ConstIt{}, ConstIt{}), std::runtime_error);
-  EXPECT_THROW(buffer.emplace(ConstIt{}, 1), std::runtime_error);
+  std::vector<uint8_t> aux = { 0, 1 };
+  ConstIt it0 = aux.cbegin();
+  ConstIt it1 = aux.cbegin() + 1;
+  EXPECT_THROW(buffer.erase(it0), std::runtime_error);
+  EXPECT_THROW(buffer.erase(it0, it1), std::runtime_error);
+  EXPECT_THROW(buffer.emplace(it0, 1), std::runtime_error);
 }
 
 TEST(TestBufferNonCpu, capacity_throws) {


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

This fixes a pair of warnings when building `test_buffer.cpp`.
Instead of using default-constructed iterators, we get a pair of valid iterators from a vector.
They will never be used due to the restriction imposed on non-CPU buffers, so the behavior of the test remains the same.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->



### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No.

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
