### PR TITLE
Remove tests in rosidl_buffer for unconventional cases

### DIFF
--- a/rosidl_buffer/test/test_buffer.cpp
+++ b/rosidl_buffer/test/test_buffer.cpp
@@ -954,14 +954,6 @@ TEST(TestBufferNonCpu, modifiers_throw) {
   EXPECT_THROW(buffer.push_back(1), std::runtime_error);
   EXPECT_THROW(buffer.pop_back(), std::runtime_error);
   EXPECT_THROW(buffer.emplace_back(1), std::runtime_error);
-
-  using ConstIt = Buffer<uint8_t>::const_iterator;
-  std::vector<uint8_t> aux = {0, 1};
-  ConstIt it0 = aux.cbegin();
-  ConstIt it1 = aux.cbegin() + 1;
-  EXPECT_THROW(buffer.erase(it0), std::runtime_error);
-  EXPECT_THROW(buffer.erase(it0, it1), std::runtime_error);
-  EXPECT_THROW(buffer.emplace(it0, 1), std::runtime_error);
 }
 
 TEST(TestBufferNonCpu, capacity_throws) {


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Raised in #968, the tests that emit `-Warray-bounds` warnings from `__builtin_memmove` are exercising an unrealistic use case: passing iterators from a separate CPU-backed `std::vector` to modifier APIs on a non-CPU `Buffer`. Although the tests pass because the non-CPU path throws before those iterators are used, the compiler can still inline and analyze the unreachable `std::vector::erase()` path and warn about the invalid iterator usage.

These tests should be considered out of scope because the key non-CPU behavior is already covered by `TestBufferNonCpu.iterators_throw`, which verifies that `begin()`, `end()`, `cbegin()`, and `cend()` throw for non-CPU buffers. CPU iterator behavior for positional `emplace` and `erase` remains covered by the existing `TestBuffer.emplace_positional`, `TestBuffer.erase_single`, and `TestBuffer.erase_range` tests.

Therefore, this PR removes those tests due to their unrealistic iterator usage.


Fixes #968 

### Is this user-facing behavior change?

No.

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

No.
