### PR TITLE
Add integer overflow guards to rosidl sequence init and copy functions

### DIFF
--- a/rosidl_generator_c/resource/msg__functions.c.em
+++ b/rosidl_generator_c/resource/msg__functions.c.em
@@ -357,6 +357,9 @@ bool
   @(message_typename) * data = NULL;
 
   if (size) {
+    if (size > SIZE_MAX / sizeof(@(message_typename))) {
+      return false;
+    }
     data = (@(message_typename) *)allocator.zero_allocate(size, sizeof(@(message_typename)), allocator.state);
     if (!data) {
       return false;
@@ -462,6 +465,9 @@ bool
     return false;
   }
   if (output->capacity < input->size) {
+    if (input->size > SIZE_MAX / sizeof(@(message_typename))) {
+      return false;
+    }
     const size_t allocation_size =
       input->size * sizeof(@(message_typename));
     rcutils_allocator_t allocator = rcutils_get_default_allocator();

--- a/rosidl_runtime_c/src/primitives_sequence_functions.c
+++ b/rosidl_runtime_c/src/primitives_sequence_functions.c
@@ -30,6 +30,9 @@
     } \
     TYPE_NAME * data = NULL; \
     if (size) { \
+      if (size > SIZE_MAX / sizeof(TYPE_NAME)) { \
+        return false; \
+      } \
       rcutils_allocator_t allocator = rcutils_get_default_allocator(); \
       data = allocator.allocate(sizeof(TYPE_NAME) * size, allocator.state); \
       if (!data) { \
@@ -89,6 +92,9 @@
       return false; \
     } \
     if (output->capacity < input->size) { \
+      if (input->size > SIZE_MAX / sizeof(TYPE_NAME)) { \
+        return false; \
+      } \
       rcutils_allocator_t allocator = rcutils_get_default_allocator(); \
       TYPE_NAME * data = (TYPE_NAME *)allocator.reallocate( \
         output->data, sizeof(TYPE_NAME) * input->size, allocator.state); \

--- a/rosidl_runtime_c/src/string_functions.c
+++ b/rosidl_runtime_c/src/string_functions.c
@@ -175,6 +175,9 @@ rosidl_runtime_c__String__Sequence__init(
   if (!sequence) {
     return false;
   }
+  if (size > SIZE_MAX / sizeof(rosidl_runtime_c__String)) {
+    return false;
+  }
   rosidl_runtime_c__String * data = NULL;
   if (size) {
     rcutils_allocator_t allocator = rcutils_get_default_allocator();
@@ -254,6 +257,9 @@ rosidl_runtime_c__String__Sequence__copy(
   rosidl_runtime_c__String__Sequence * output)
 {
   if (!input || !output) {
+    return false;
+  }
+  if (input->size > SIZE_MAX / sizeof(rosidl_runtime_c__String)) {
     return false;
   }
   if (output->capacity < input->size) {

--- a/rosidl_runtime_c/src/u16string_functions.c
+++ b/rosidl_runtime_c/src/u16string_functions.c
@@ -198,6 +198,9 @@ rosidl_runtime_c__U16String__Sequence__init(
   }
   rosidl_runtime_c__U16String * data = NULL;
   if (size) {
+    if (size > SIZE_MAX / sizeof(rosidl_runtime_c__U16String)) {
+      return false;
+    }
     rcutils_allocator_t allocator = rcutils_get_default_allocator();
     data = (rosidl_runtime_c__U16String *)allocator.allocate(
       size * sizeof(rosidl_runtime_c__U16String), allocator.state);
@@ -275,6 +278,9 @@ rosidl_runtime_c__U16String__Sequence__copy(
   rosidl_runtime_c__U16String__Sequence * output)
 {
   if (!input || !output) {
+    return false;
+  }
+  if (input->size > SIZE_MAX / sizeof(rosidl_runtime_c__U16String)) {
     return false;
   }
   if (output->capacity < input->size) {

--- a/rosidl_runtime_c/test/test_primitives_sequence_functions.cpp
+++ b/rosidl_runtime_c/test/test_primitives_sequence_functions.cpp
@@ -98,6 +98,27 @@
     EXPECT_TRUE(rosidl_runtime_c__ ## STRUCT_NAME ## __Sequence__are_equal(&input, &output)); \
     rosidl_runtime_c__ ## STRUCT_NAME ## __Sequence__fini(&output); \
     rosidl_runtime_c__ ## STRUCT_NAME ## __Sequence__fini(&input); \
+  } \
+ \
+  TEST(primitives_sequence_functions, test_ ## STRUCT_NAME ## _overflow) \
+  { \
+    rosidl_runtime_c__ ## STRUCT_NAME ## __Sequence sequence; \
+    size_t overflow_size = (SIZE_MAX / sizeof(TYPE_NAME)) + 1u; \
+    if (overflow_size > 0u) { \
+      EXPECT_FALSE( \
+        rosidl_runtime_c__ ## STRUCT_NAME ## __Sequence__init(&sequence, overflow_size)); \
+    } \
+    rosidl_runtime_c__ ## STRUCT_NAME ## __Sequence input, output; \
+    EXPECT_TRUE(rosidl_runtime_c__ ## STRUCT_NAME ## __Sequence__init(&input, 1u)); \
+    EXPECT_TRUE(rosidl_runtime_c__ ## STRUCT_NAME ## __Sequence__init(&output, 0u)); \
+    if (overflow_size > 0u) { \
+      input.size = overflow_size; \
+      EXPECT_FALSE( \
+        rosidl_runtime_c__ ## STRUCT_NAME ## __Sequence__copy(&input, &output)); \
+    } \
+    input.size = 1u; \
+    rosidl_runtime_c__ ## STRUCT_NAME ## __Sequence__fini(&output); \
+    rosidl_runtime_c__ ## STRUCT_NAME ## __Sequence__fini(&input); \
   }
 
 TEST_PRIMITIVE_SEQUENCE_FUNCTIONS(float, float)


### PR DESCRIPTION
Check that target size multiplied by item size does not overflow SIZE_MAX. This prevents undersized heap allocations when sequence length inputs are malicious or overflow.