### PR TITLE
Solving issue #799. BoundedVector::data() is unusable. 

### DIFF
--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/bounded_vector.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/bounded_vector.hpp
@@ -418,7 +418,7 @@ public:
    * For a non-empty %BoundedVector, data() == &front().
    */
   template<
-    typename T=Tp,
+    typename T = Tp,
     typename std::enable_if<
       !std::is_same<T, bool>::value
     >::type * = nullptr
@@ -430,7 +430,7 @@ public:
   }
 
   template<
-    typename T=Tp,
+    typename T = Tp,
     typename std::enable_if<
       !std::is_same<T, bool>::value
     >::type * = nullptr

--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/bounded_vector.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/bounded_vector.hpp
@@ -418,9 +418,8 @@ public:
    * For a non-empty %BoundedVector, data() == &front().
    */
   template<
-    typename T,
+    typename T=Tp,
     typename std::enable_if<
-      !std::is_same<T, Tp>::value &&
       !std::is_same<T, bool>::value
     >::type * = nullptr
   >
@@ -431,9 +430,8 @@ public:
   }
 
   template<
-    typename T,
+    typename T=Tp,
     typename std::enable_if<
-      !std::is_same<T, Tp>::value &&
       !std::is_same<T, bool>::value
     >::type * = nullptr
   >

--- a/rosidl_runtime_cpp/test/test_bounded_vector.cpp
+++ b/rosidl_runtime_cpp/test/test_bounded_vector.cpp
@@ -123,3 +123,20 @@ TEST(rosidl_generator_cpp, bounded_vector_forward_iterators) {
   ASSERT_THROW(v.insert(v.begin() + 1, l.begin(), l.end()), std::length_error);
   ASSERT_EQ(v, vv);
 }
+
+TEST(rosidl_generator_cpp, bounded_vector_data) {
+  rosidl_runtime_cpp::BoundedVector<int, 4> v{1, 2, 3};
+  ASSERT_EQ(v.data(), &v.front());
+  ASSERT_EQ(v.data()[0], 1);
+  ASSERT_EQ(v.data()[1], 2);
+  ASSERT_EQ(v.data()[2], 3);
+
+  // Const version
+  const auto & const_v = v;
+  ASSERT_EQ(const_v.data(), &const_v.front());
+  ASSERT_EQ(const_v.data()[0], 1);
+
+  // Check that BoundedVector<bool, N> compiles without issue
+  rosidl_runtime_cpp::BoundedVector<bool, 4> bool_v{true, false};
+  ASSERT_EQ(bool_v.size(), 2u);
+}


### PR DESCRIPTION
 I believe that pointer returned by data should be of type Tp with which the class is templated with and therefore ! next to std::is_same<T, Tp>::value is typo and can be replaced with T=Tp for the BoundedVector::data() to work.
