### PR TITLE
Suppress GCC false positives in buffer resize test

### DIFF
--- a/rosidl_buffer/test/test_buffer.cpp
+++ b/rosidl_buffer/test/test_buffer.cpp
@@ -274,6 +274,13 @@ TEST(TestBuffer, resize) {
 }
 
 // Test resize with value
+// GCC 15 emits false-positive warnings from std::vector::resize with C++20 at -O3.
+// See https://github.com/ros2/rosidl/issues/979.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
 TEST(TestBuffer, resize_with_value) {
   Buffer<uint8_t> buffer(2, 5);
   buffer.resize(5, 99);
@@ -284,6 +291,9 @@ TEST(TestBuffer, resize_with_value) {
   EXPECT_EQ(99, buffer[2]);
   EXPECT_EQ(99, buffer[4]);
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 // Test push_back
 TEST(TestBuffer, push_back) {


### PR DESCRIPTION
## Description

Suppress GCC 15 false-positive -Wstringop-overflow and -Warray-bounds warnings around the resize_with_value buffer test.

The warnings began when `rosidl_buffer` switched from C++17 to C++20 and originate from the optimized C++20 std::vector::resize implementation at -O3, rather than an actual buffer overflow. The diagnostic suppression is scoped to the affected test and GNU compilers only.

Fixes #979

### Is this user-facing behavior change?
No.

### Did you use Generative AI?
Yes. OpenAI GPT-5.6 was used to draft the fix in this PR.
