### PR TITLE
Avoid wstring_convert for ASCII UTF-16 YAML output

### DIFF
--- a/rosidl_runtime_cpp/include/rosidl_runtime_cpp/traits.hpp
+++ b/rosidl_runtime_cpp/include/rosidl_runtime_cpp/traits.hpp
@@ -15,7 +15,6 @@
 #ifndef ROSIDL_RUNTIME_CPP__TRAITS_HPP_
 #define ROSIDL_RUNTIME_CPP__TRAITS_HPP_
 
-#include <codecvt>
 #include <cstdint>
 #include <iomanip>
 #include <iosfwd>
@@ -129,14 +128,12 @@ inline void value_to_yaml(const std::string & value, std::ostream & out)
 inline void value_to_yaml(const std::u16string & value, std::ostream & out)
 {
   out << "\"";
-  std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> convert;
   auto flags = out.flags();
   size_t index = 0;
   while (index < value.size()) {
     uint_least16_t character = static_cast<uint_least16_t>(value[index]);
     if (!(character & 0xff80)) {  // ASCII
-      std::string character_as_string = convert.to_bytes(character);
-      out << std::hex << character_as_string.c_str();
+      out << static_cast<char>(character);
     } else if (!(character & 0xff00)) {  // only 1 byte set
       out << "\\x" << std::hex << std::setw(2) << std::setfill('0') << \
         character;


### PR DESCRIPTION
This PR is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack `patch/ros-rolling-rosidl-runtime-cpp.osx.patch`, authored by Daisuke Nishimatsu.

Best-guess rationale: std::wstring_convert and codecvt are deprecated in C++17 and can be problematic on newer standard libraries; ASCII char16_t values can be emitted directly without using the converter.
