### PR TITLE
Skip redundant find_package(Python3) in generator extensions

### DIFF
--- a/rosidl_adapter/cmake/rosidl_adapt_interfaces.cmake
+++ b/rosidl_adapter/cmake/rosidl_adapt_interfaces.cmake
@@ -37,7 +37,9 @@ function(rosidl_adapt_interfaces idl_var arguments_file)
       "arguments: ${ARG_UNPARSED_ARGUMENTS}")
   endif()
 
-  find_package(Python3 REQUIRED COMPONENTS Interpreter)
+  if(NOT TARGET Python3::Interpreter)
+    find_package(Python3 REQUIRED COMPONENTS Interpreter)
+  endif()
 
   set(idl_output "${CMAKE_CURRENT_BINARY_DIR}/rosidl_adapter/${ARG_TARGET}.idls")
   set(cmd

--- a/rosidl_generator_c/cmake/rosidl_generator_c_generate_interfaces.cmake
+++ b/rosidl_generator_c/cmake/rosidl_generator_c_generate_interfaces.cmake
@@ -92,23 +92,25 @@ rosidl_write_generator_arguments(
   ROS_INTERFACE_FILES "${_target_sources}"
 )
 
-# By default, without the settings below, find_package(Python3) will attempt
-# to find the newest python version it can, and additionally will find the
-# most specific version.  For instance, on a system that has
-# /usr/bin/python3.10, /usr/bin/python3.11, and /usr/bin/python3, it will find
-# /usr/bin/python3.11, even if /usr/bin/python3 points to /usr/bin/python3.10.
-# The behavior we want is to prefer the "system" installed version unless the
-# user specifically tells us othewise through the Python3_EXECUTABLE hint.
-# Setting CMP0094 to NEW means that the search will stop after the first
-# python version is found.  Setting Python3_FIND_UNVERSIONED_NAMES means that
-# the search will prefer /usr/bin/python3 over /usr/bin/python3.11.  And that
-# latter functionality is only available in CMake 3.20 or later, so we need
-# at least that version.
-cmake_minimum_required(VERSION 3.20)
-cmake_policy(SET CMP0094 NEW)
-set(Python3_FIND_UNVERSIONED_NAMES FIRST)
+if(NOT TARGET Python3::Interpreter)
+  # By default, without the settings below, find_package(Python3) will attempt
+  # to find the newest python version it can, and additionally will find the
+  # most specific version.  For instance, on a system that has
+  # /usr/bin/python3.10, /usr/bin/python3.11, and /usr/bin/python3, it will find
+  # /usr/bin/python3.11, even if /usr/bin/python3 points to /usr/bin/python3.10.
+  # The behavior we want is to prefer the "system" installed version unless the
+  # user specifically tells us othewise through the Python3_EXECUTABLE hint.
+  # Setting CMP0094 to NEW means that the search will stop after the first
+  # python version is found.  Setting Python3_FIND_UNVERSIONED_NAMES means that
+  # the search will prefer /usr/bin/python3 over /usr/bin/python3.11.  And that
+  # latter functionality is only available in CMake 3.20 or later, so we need
+  # at least that version.
+  cmake_minimum_required(VERSION 3.20)
+  cmake_policy(SET CMP0094 NEW)
+  set(Python3_FIND_UNVERSIONED_NAMES FIRST)
 
-find_package(Python3 REQUIRED COMPONENTS Interpreter)
+  find_package(Python3 REQUIRED COMPONENTS Interpreter)
+endif()
 
 set(disable_description_codegen_arg)
 if(ROSIDL_GENERATOR_C_DISABLE_TYPE_DESCRIPTION_CODEGEN)

--- a/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_interfaces.cmake
+++ b/rosidl_generator_cpp/cmake/rosidl_generator_cpp_generate_interfaces.cmake
@@ -94,23 +94,25 @@ rosidl_write_generator_arguments(
   TYPE_DESCRIPTION_TUPLES "${${rosidl_generate_interfaces_TARGET}__DESCRIPTION_TUPLES}"
 )
 
-# By default, without the settings below, find_package(Python3) will attempt
-# to find the newest python version it can, and additionally will find the
-# most specific version.  For instance, on a system that has
-# /usr/bin/python3.10, /usr/bin/python3.11, and /usr/bin/python3, it will find
-# /usr/bin/python3.11, even if /usr/bin/python3 points to /usr/bin/python3.10.
-# The behavior we want is to prefer the "system" installed version unless the
-# user specifically tells us othewise through the Python3_EXECUTABLE hint.
-# Setting CMP0094 to NEW means that the search will stop after the first
-# python version is found.  Setting Python3_FIND_UNVERSIONED_NAMES means that
-# the search will prefer /usr/bin/python3 over /usr/bin/python3.11.  And that
-# latter functionality is only available in CMake 3.20 or later, so we need
-# at least that version.
-cmake_minimum_required(VERSION 3.20)
-cmake_policy(SET CMP0094 NEW)
-set(Python3_FIND_UNVERSIONED_NAMES FIRST)
+if(NOT TARGET Python3::Interpreter)
+  # By default, without the settings below, find_package(Python3) will attempt
+  # to find the newest python version it can, and additionally will find the
+  # most specific version.  For instance, on a system that has
+  # /usr/bin/python3.10, /usr/bin/python3.11, and /usr/bin/python3, it will find
+  # /usr/bin/python3.11, even if /usr/bin/python3 points to /usr/bin/python3.10.
+  # The behavior we want is to prefer the "system" installed version unless the
+  # user specifically tells us othewise through the Python3_EXECUTABLE hint.
+  # Setting CMP0094 to NEW means that the search will stop after the first
+  # python version is found.  Setting Python3_FIND_UNVERSIONED_NAMES means that
+  # the search will prefer /usr/bin/python3 over /usr/bin/python3.11.  And that
+  # latter functionality is only available in CMake 3.20 or later, so we need
+  # at least that version.
+  cmake_minimum_required(VERSION 3.20)
+  cmake_policy(SET CMP0094 NEW)
+  set(Python3_FIND_UNVERSIONED_NAMES FIRST)
 
-find_package(Python3 REQUIRED COMPONENTS Interpreter)
+  find_package(Python3 REQUIRED COMPONENTS Interpreter)
+endif()
 
 add_custom_command(
   OUTPUT ${_generated_headers}

--- a/rosidl_generator_type_description/cmake/rosidl_generator_type_description_generate_interfaces.cmake
+++ b/rosidl_generator_type_description/cmake/rosidl_generator_type_description_generate_interfaces.cmake
@@ -12,23 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# By default, without the settings below, find_package(Python3) will attempt
-# to find the newest python version it can, and additionally will find the
-# most specific version.  For instance, on a system that has
-# /usr/bin/python3.10, /usr/bin/python3.11, and /usr/bin/python3, it will find
-# /usr/bin/python3.11, even if /usr/bin/python3 points to /usr/bin/python3.10.
-# The behavior we want is to prefer the "system" installed version unless the
-# user specifically tells us othewise through the Python3_EXECUTABLE hint.
-# Setting CMP0094 to NEW means that the search will stop after the first
-# python version is found.  Setting Python3_FIND_UNVERSIONED_NAMES means that
-# the search will prefer /usr/bin/python3 over /usr/bin/python3.11.  And that
-# latter functionality is only available in CMake 3.20 or later, so we need
-# at least that version.
-cmake_minimum_required(VERSION 3.20)
-cmake_policy(SET CMP0094 NEW)
-set(Python3_FIND_UNVERSIONED_NAMES FIRST)
+if(NOT TARGET Python3::Interpreter)
+  # By default, without the settings below, find_package(Python3) will attempt
+  # to find the newest python version it can, and additionally will find the
+  # most specific version.  For instance, on a system that has
+  # /usr/bin/python3.10, /usr/bin/python3.11, and /usr/bin/python3, it will find
+  # /usr/bin/python3.11, even if /usr/bin/python3 points to /usr/bin/python3.10.
+  # The behavior we want is to prefer the "system" installed version unless the
+  # user specifically tells us othewise through the Python3_EXECUTABLE hint.
+  # Setting CMP0094 to NEW means that the search will stop after the first
+  # python version is found.  Setting Python3_FIND_UNVERSIONED_NAMES means that
+  # the search will prefer /usr/bin/python3 over /usr/bin/python3.11.  And that
+  # latter functionality is only available in CMake 3.20 or later, so we need
+  # at least that version.
+  cmake_minimum_required(VERSION 3.20)
+  cmake_policy(SET CMP0094 NEW)
+  set(Python3_FIND_UNVERSIONED_NAMES FIRST)
 
-find_package(Python3 REQUIRED COMPONENTS Interpreter)
+  find_package(Python3 REQUIRED COMPONENTS Interpreter)
+endif()
 
 set(_output_path "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_type_description/${PROJECT_NAME}")
 set(_generated_files "")

--- a/rosidl_typesupport_introspection_c/cmake/rosidl_typesupport_introspection_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_introspection_c/cmake/rosidl_typesupport_introspection_c_generate_interfaces.cmake
@@ -77,23 +77,25 @@ rosidl_write_generator_arguments(
   TARGET_DEPENDENCIES ${target_dependencies}
 )
 
-# By default, without the settings below, find_package(Python3) will attempt
-# to find the newest python version it can, and additionally will find the
-# most specific version.  For instance, on a system that has
-# /usr/bin/python3.10, /usr/bin/python3.11, and /usr/bin/python3, it will find
-# /usr/bin/python3.11, even if /usr/bin/python3 points to /usr/bin/python3.10.
-# The behavior we want is to prefer the "system" installed version unless the
-# user specifically tells us othewise through the Python3_EXECUTABLE hint.
-# Setting CMP0094 to NEW means that the search will stop after the first
-# python version is found.  Setting Python3_FIND_UNVERSIONED_NAMES means that
-# the search will prefer /usr/bin/python3 over /usr/bin/python3.11.  And that
-# latter functionality is only available in CMake 3.20 or later, so we need
-# at least that version.
-cmake_minimum_required(VERSION 3.20)
-cmake_policy(SET CMP0094 NEW)
-set(Python3_FIND_UNVERSIONED_NAMES FIRST)
+if(NOT TARGET Python3::Interpreter)
+  # By default, without the settings below, find_package(Python3) will attempt
+  # to find the newest python version it can, and additionally will find the
+  # most specific version.  For instance, on a system that has
+  # /usr/bin/python3.10, /usr/bin/python3.11, and /usr/bin/python3, it will find
+  # /usr/bin/python3.11, even if /usr/bin/python3 points to /usr/bin/python3.10.
+  # The behavior we want is to prefer the "system" installed version unless the
+  # user specifically tells us othewise through the Python3_EXECUTABLE hint.
+  # Setting CMP0094 to NEW means that the search will stop after the first
+  # python version is found.  Setting Python3_FIND_UNVERSIONED_NAMES means that
+  # the search will prefer /usr/bin/python3 over /usr/bin/python3.11.  And that
+  # latter functionality is only available in CMake 3.20 or later, so we need
+  # at least that version.
+  cmake_minimum_required(VERSION 3.20)
+  cmake_policy(SET CMP0094 NEW)
+  set(Python3_FIND_UNVERSIONED_NAMES FIRST)
 
-find_package(Python3 REQUIRED COMPONENTS Interpreter)
+  find_package(Python3 REQUIRED COMPONENTS Interpreter)
+endif()
 
 if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.27)
   set(_dep_explicit_only DEPENDS_EXPLICIT_ONLY)

--- a/rosidl_typesupport_introspection_cpp/cmake/rosidl_typesupport_introspection_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_introspection_cpp/cmake/rosidl_typesupport_introspection_cpp_generate_interfaces.cmake
@@ -77,23 +77,25 @@ rosidl_write_generator_arguments(
   TARGET_DEPENDENCIES ${target_dependencies}
 )
 
-# By default, without the settings below, find_package(Python3) will attempt
-# to find the newest python version it can, and additionally will find the
-# most specific version.  For instance, on a system that has
-# /usr/bin/python3.10, /usr/bin/python3.11, and /usr/bin/python3, it will find
-# /usr/bin/python3.11, even if /usr/bin/python3 points to /usr/bin/python3.10.
-# The behavior we want is to prefer the "system" installed version unless the
-# user specifically tells us othewise through the Python3_EXECUTABLE hint.
-# Setting CMP0094 to NEW means that the search will stop after the first
-# python version is found.  Setting Python3_FIND_UNVERSIONED_NAMES means that
-# the search will prefer /usr/bin/python3 over /usr/bin/python3.11.  And that
-# latter functionality is only available in CMake 3.20 or later, so we need
-# at least that version.
-cmake_minimum_required(VERSION 3.20)
-cmake_policy(SET CMP0094 NEW)
-set(Python3_FIND_UNVERSIONED_NAMES FIRST)
+if(NOT TARGET Python3::Interpreter)
+  # By default, without the settings below, find_package(Python3) will attempt
+  # to find the newest python version it can, and additionally will find the
+  # most specific version.  For instance, on a system that has
+  # /usr/bin/python3.10, /usr/bin/python3.11, and /usr/bin/python3, it will find
+  # /usr/bin/python3.11, even if /usr/bin/python3 points to /usr/bin/python3.10.
+  # The behavior we want is to prefer the "system" installed version unless the
+  # user specifically tells us othewise through the Python3_EXECUTABLE hint.
+  # Setting CMP0094 to NEW means that the search will stop after the first
+  # python version is found.  Setting Python3_FIND_UNVERSIONED_NAMES means that
+  # the search will prefer /usr/bin/python3 over /usr/bin/python3.11.  And that
+  # latter functionality is only available in CMake 3.20 or later, so we need
+  # at least that version.
+  cmake_minimum_required(VERSION 3.20)
+  cmake_policy(SET CMP0094 NEW)
+  set(Python3_FIND_UNVERSIONED_NAMES FIRST)
 
-find_package(Python3 REQUIRED COMPONENTS Interpreter)
+  find_package(Python3 REQUIRED COMPONENTS Interpreter)
+endif()
 
 if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.27)
   set(_dep_explicit_only DEPENDS_EXPLICIT_ONLY)


### PR DESCRIPTION
## Problem

Every rosidl generator extension calls `find_package(Python3 REQUIRED COMPONENTS Interpreter)` unconditionally at the top of its `*_generate_interfaces.cmake`.

For a default rolling workspace that is **13 searches per interface package**: `ament_cmake_core`, `rosidl_adapter`, `rosidl_generator_type_description`, `_c`, `_cpp`, `_py`, `typesupport_c`, `typesupport_cpp`, `typesupport_introspection_c`/`_cpp`, `typesupport_fastrtps_c`/`_cpp`, plus any third-party generator.

CMake does not memoize this. Each repeat re-enters `FindPython/Support.cmake` and re-interrogates the interpreter to confirm the cached value is still good — version, `-V`, `sys.copyright`, sysconfig paths, `EXT_SUFFIX`, `SOSABI`, and, on `WIN32` only, `ABIFLAGS`. That is roughly seven interpreter launches per call.

On Linux those launches are ~1–3ms and disappear into the noise. On Windows `CreateProcess` for `python.exe` costs ~60ms on a fast desktop and considerably more on a CI runner, so the repeats come to dominate configure time.

## Fix

Guard each call on the imported target, exactly as [`ament_cmake_core/cmake/core/python.cmake`](https://github.com/ros2/ament_cmake/blob/rolling/ament_cmake_core/cmake/core/python.cmake) already does:

```cmake
if(NOT TARGET Python3::Interpreter)
  cmake_minimum_required(VERSION 3.20)
  cmake_policy(SET CMP0094 NEW)
  set(Python3_FIND_UNVERSIONED_NAMES FIRST)

  find_package(Python3 REQUIRED COMPONENTS Interpreter)
endif()
```

Imported targets are directory-scoped, not function-scoped, so the target created by the first search is visible to every later extension and to functions called from that directory — including `rosidl_adapt_interfaces()`.