### PR TITLE
rosidl_parser: add in-process memoization for parse_idl_file and parse_idl_string

### DIFF
--- a/rosidl_parser/rosidl_parser/parser.py
+++ b/rosidl_parser/rosidl_parser/parser.py
@@ -83,16 +83,24 @@ with open(grammar_file, mode='r', encoding='utf-8') as h:
     grammar = h.read()
 
 _parser: Optional[Lark] = None
+_idl_cache: Dict[str, IdlFile] = {}
 
 
 def parse_idl_file(locator: IdlLocator, png_file: Optional[str] = None) -> IdlFile:
+    abs_path = str(locator.get_absolute_path())
+    if png_file is None and abs_path in _idl_cache:
+        return _idl_cache[abs_path]
+
     string = locator.get_absolute_path().read_text(encoding='utf-8')
     try:
         content = parse_idl_string(string, png_file=png_file)
     except Exception as e:
         print(str(e), str(locator.get_absolute_path()), file=sys.stderr)
         raise
-    return IdlFile(locator, content)
+    result = IdlFile(locator, content)
+    if png_file is None:
+        _idl_cache[abs_path] = result
+    return result
 
 
 def parse_idl_string(idl_string: str, png_file: Optional[str] = None) -> IdlContent:

--- a/rosidl_parser/rosidl_parser/parser.py
+++ b/rosidl_parser/rosidl_parser/parser.py
@@ -24,6 +24,7 @@ from typing import Literal
 from typing import Match
 from typing import Optional
 from typing import Pattern
+from typing import Tuple
 from typing import TYPE_CHECKING
 from typing import Union
 
@@ -83,27 +84,45 @@ with open(grammar_file, mode='r', encoding='utf-8') as h:
     grammar = h.read()
 
 _parser: Optional[Lark] = None
-_idl_cache: Dict[str, IdlFile] = {}
+_idl_file_cache: Dict[Tuple[str, int], IdlFile] = {}
+_idl_string_cache: Dict[str, IdlContent] = {}
+
+
+def clear_ast_cache() -> None:
+    """Clear the in-process AST cache."""
+    _idl_file_cache.clear()
+    _idl_string_cache.clear()
 
 
 def parse_idl_file(locator: IdlLocator, png_file: Optional[str] = None) -> IdlFile:
-    abs_path = str(locator.get_absolute_path())
-    if png_file is None and abs_path in _idl_cache:
-        return _idl_cache[abs_path]
+    abs_path = locator.get_absolute_path()
+    if png_file is None:
+        try:
+            mtime_ns = abs_path.stat().st_mtime_ns
+            cache_key = (str(abs_path), mtime_ns)
+            if cache_key in _idl_file_cache:
+                return _idl_file_cache[cache_key]
+        except OSError:
+            cache_key = None
+    else:
+        cache_key = None
 
-    string = locator.get_absolute_path().read_text(encoding='utf-8')
+    string = abs_path.read_text(encoding='utf-8')
     try:
         content = parse_idl_string(string, png_file=png_file)
     except Exception as e:
-        print(str(e), str(locator.get_absolute_path()), file=sys.stderr)
+        print(str(e), str(abs_path), file=sys.stderr)
         raise
-    result = IdlFile(locator, content)
-    if png_file is None:
-        _idl_cache[abs_path] = result
-    return result
+    idl_file = IdlFile(locator, content)
+    if cache_key is not None:
+        _idl_file_cache[cache_key] = idl_file
+    return idl_file
 
 
 def parse_idl_string(idl_string: str, png_file: Optional[str] = None) -> IdlContent:
+    if png_file is None and idl_string in _idl_string_cache:
+        return _idl_string_cache[idl_string]
+
     tree = get_ast_from_idl_string(idl_string)
     content = extract_content_from_ast(tree)
 
@@ -113,6 +132,8 @@ def parse_idl_string(idl_string: str, png_file: Optional[str] = None) -> IdlCont
             pydot__tree_to_png(tree, png_file)
         except ImportError:
             pass
+    elif png_file is None:
+        _idl_string_cache[idl_string] = content
 
     return content
 

--- a/rosidl_parser/test/test_parser.py
+++ b/rosidl_parser/test/test_parser.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pathlib
+import time
 
 import pytest
 from rosidl_parser.definition import Action
@@ -31,9 +32,11 @@ from rosidl_parser.definition import SERVICE_EVENT_MESSAGE_SUFFIX
 from rosidl_parser.definition import UnboundedSequence
 from rosidl_parser.definition import UnboundedString
 from rosidl_parser.definition import UnboundedWString
+from rosidl_parser.parser import clear_ast_cache
 from rosidl_parser.parser import get_ast_from_idl_string
 from rosidl_parser.parser import get_string_literals_value
 from rosidl_parser.parser import parse_idl_file
+from rosidl_parser.parser import parse_idl_string
 
 MESSAGE_IDL_LOCATOR = IdlLocator(
     pathlib.Path(__file__).parent, pathlib.Path('msg') / 'MyMessage.idl')
@@ -489,3 +492,59 @@ def test_action_parser(action_idl_file: IdlFile) -> None:
         action.feedback.structure.namespaced_type.namespaces
     assert structure.members[1].type.name == \
         action.feedback.structure.namespaced_type.name
+
+
+def test_parse_idl_file_memoization(tmp_path: pathlib.Path) -> None:
+    clear_ast_cache()
+    # Create temporary IDL file
+    test_idl = tmp_path / 'TestMsg.idl'
+    test_idl.write_text("""
+module test_pkg {
+  module msg {
+    struct TestMsg {
+      int32 data;
+    };
+  };
+};
+""", encoding='utf-8')
+    locator = IdlLocator(tmp_path, pathlib.Path('TestMsg.idl'))
+
+    # First parse
+    ast1 = parse_idl_file(locator)
+    # Second parse - should return cached instance
+    ast2 = parse_idl_file(locator)
+    assert ast1 is ast2
+
+    # Clear cache - should return new instance
+    clear_ast_cache()
+    ast3 = parse_idl_file(locator)
+    assert ast3 is not ast1
+    assert ast3.content.elements[0].structure.namespaced_type.name == 'TestMsg'
+
+    # Modify file mtime/content - should invalidate cache
+    time.sleep(0.01)
+    test_idl.write_text("""
+module test_pkg {
+  module msg {
+    struct TestMsg {
+      int64 modified_data;
+    };
+  };
+};
+""", encoding='utf-8')
+    ast4 = parse_idl_file(locator)
+    assert ast4 is not ast3
+    struct = ast4.content.elements[0].structure
+    assert struct.members[0].name == 'modified_data'
+
+
+def test_parse_idl_string_memoization() -> None:
+    clear_ast_cache()
+    idl_str = 'module test { module msg { struct Foo { int32 x; }; }; };'
+    ast1 = parse_idl_string(idl_str)
+    ast2 = parse_idl_string(idl_str)
+    assert ast1 is ast2
+
+    clear_ast_cache()
+    ast3 = parse_idl_string(idl_str)
+    assert ast3 is not ast1

--- a/rosidl_parser/test/test_parser.py
+++ b/rosidl_parser/test/test_parser.py
@@ -519,7 +519,9 @@ module test_pkg {
     clear_ast_cache()
     ast3 = parse_idl_file(locator)
     assert ast3 is not ast1
-    assert ast3.content.elements[0].structure.namespaced_type.name == 'TestMsg'
+    elem3 = ast3.content.elements[0]
+    assert isinstance(elem3, Message)
+    assert elem3.structure.namespaced_type.name == 'TestMsg'
 
     # Modify file mtime/content - should invalidate cache
     time.sleep(0.01)
@@ -534,7 +536,9 @@ module test_pkg {
 """, encoding='utf-8')
     ast4 = parse_idl_file(locator)
     assert ast4 is not ast3
-    struct = ast4.content.elements[0].structure
+    elem4 = ast4.content.elements[0]
+    assert isinstance(elem4, Message)
+    struct = elem4.structure
     assert struct.members[0].name == 'modified_data'
 
 


### PR DESCRIPTION
## Description

This PR breaks out and refactors the `parse_idl_file()` caching concept originally proposed in #934 by @otamachan into an in-memory memoization approach.

During interface code generation and multi-generator builds, `rosidl_parser.parse_idl_file()` and `rosidl_parser.parse_idl_string()` are repeatedly invoked across generator passes, dependency resolution, and validation checks. Repeatedly parsing the same IDL definitions within a single process introduces unnecessary latency.

This PR adds in-process AST memoization to `rosidl_parser`:
- **File-level caching:** `parse_idl_file(locator)` caches the resulting `IdlFile` in `_idl_file_cache` keyed by `(str(abs_path), mtime_ns)`. Subsequent requests for an unchanged file within the process return the cached AST immediately without re-reading or re-parsing from disk.
- **String-level caching:** `parse_idl_string(idl_string)` caches parsed `IdlContent` in `_idl_string_cache` keyed by the IDL string.
- **Automatic invalidation & reset:** Entries are invalidated if the file's modification time changes. `clear_ast_cache()` is exposed for explicit cache resets.
- **Safety:** If `png_file` debugging output is requested, caching is bypassed.

Related to https://github.com/ros2/rosidl/issues/931  
Related to https://github.com/ros2/rosidl/pull/934

### Is this user-facing behavior change?

No, this is an internal performance optimization.

### Did you use Generative AI?

Yes, Gemini.

### Additional Information

#### Testing
- **Unit Tests:** Added `test_parse_idl_file_memoization` and `test_parse_idl_string_memoization` in `rosidl_parser/test/test_parser.py` covering cache hits, cache invalidation upon file modification, and cache reset via `clear_ast_cache()`.
- **Local Verification:**
  - Ran pytest suite for `rosidl_parser`: 12/12 unit tests pass.
  - Rebuilt downstream interface packages (`test_msgs`, `builtin_interfaces`, `service_msgs`) to verify end-to-end generator compatibility.
