### PR TITLE
rosidl: generate, cache, and distribute pre-parsed ASTs as JSON

### DIFF
--- a/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
+++ b/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake
@@ -301,8 +301,9 @@ macro(rosidl_generate_interfaces target)
       string(REGEX REPLACE ":([^:]*)$" "/\\1" _idl_file "${_idl_tuple}")
       get_filename_component(_parent_folders "${_idl_relpath}" DIRECTORY)
       install(
-        FILES ${_idl_file}
+        FILES ${_idl_file} "${_idl_file}.json"
         DESTINATION "share/${PROJECT_NAME}/${_parent_folders}"
+        OPTIONAL
       )
       file(TO_CMAKE_PATH "${_idl_relpath}" _idl_relpath)
       list(APPEND _rosidl_cmake_IDL_FILES "${_idl_relpath}")

--- a/rosidl_generator_type_description/rosidl_generator_type_description/__init__.py
+++ b/rosidl_generator_type_description/rosidl_generator_type_description/__init__.py
@@ -22,6 +22,7 @@ from typing import List, Tuple
 
 from rosidl_parser import definition
 from rosidl_parser.parser import parse_idl_file
+from rosidl_parser.serialization import save_ast_json
 
 # RIHS: ROS Interface Hashing Standard, per REP-2011
 # NOTE: These values and implementations must be updated if
@@ -118,6 +119,15 @@ def generate_type_hash(generator_arguments_file: str) -> List[str]:
             print('Error processing idl file: ' +
                   str(locator.get_absolute_path()), file=sys.stderr)
             raise e
+
+        # Save pre-parsed AST JSON alongside the IDL file if not already present
+        ast_json_path = locator.get_absolute_path().with_suffix(
+            locator.get_absolute_path().suffix + '.json')
+        if not ast_json_path.exists():
+            try:
+                save_ast_json(idl_file.content, ast_json_path)
+            except OSError:
+                pass
 
         idl_rel_path = Path(idl_parts[1])
         generate_to_dir = (output_dir / idl_rel_path).parent

--- a/rosidl_parser/rosidl_parser/parser.py
+++ b/rosidl_parser/rosidl_parser/parser.py
@@ -79,6 +79,9 @@ if TYPE_CHECKING:
 
 AbstractTypeAlias = Union[AbstractNestableType, BasicType, BoundedSequence, UnboundedSequence]
 
+from rosidl_parser.serialization import load_ast_json
+from rosidl_parser.serialization import save_ast_json
+
 grammar_file = os.path.join(os.path.dirname(__file__), 'grammar.lark')
 with open(grammar_file, mode='r', encoding='utf-8') as h:
     grammar = h.read()
@@ -104,9 +107,25 @@ def parse_idl_file(locator: IdlLocator, png_file: Optional[str] = None) -> IdlFi
                 return _idl_file_cache[cache_key]
         except OSError:
             cache_key = None
+            mtime_ns = None
     else:
         cache_key = None
+        mtime_ns = None
 
+    # Check for pre-parsed AST JSON file alongside the IDL file
+    ast_json_path = abs_path.with_suffix(abs_path.suffix + '.json')
+    if png_file is None and ast_json_path.exists() and mtime_ns is not None:
+        try:
+            if ast_json_path.stat().st_mtime_ns >= mtime_ns:
+                content = load_ast_json(ast_json_path)
+                idl_file = IdlFile(locator, content)
+                if cache_key is not None:
+                    _idl_file_cache[cache_key] = idl_file
+                return idl_file
+        except Exception:
+            pass
+
+    # Fall back to parsing the IDL text
     string = abs_path.read_text(encoding='utf-8')
     try:
         content = parse_idl_string(string, png_file=png_file)

--- a/rosidl_parser/rosidl_parser/parser.py
+++ b/rosidl_parser/rosidl_parser/parser.py
@@ -28,19 +28,13 @@ from typing import Tuple
 from typing import TYPE_CHECKING
 from typing import Union
 
-try:
-    import warnings
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore', DeprecationWarning)
-        from lark import Lark
-        from lark.lexer import Token
-        from lark.tree import pydot__tree_to_png
-        from lark.tree import Tree
-except ImportError:
-    Lark = None
-    Token = None
-    pydot__tree_to_png = None
-    Tree = ()
+import warnings
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore', DeprecationWarning)
+    from lark import Lark
+    from lark.lexer import Token
+    from lark.tree import pydot__tree_to_png
+    from lark.tree import Tree
 
 from rosidl_parser.definition import AbstractNestableType
 from rosidl_parser.definition import AbstractNestedType

--- a/rosidl_parser/rosidl_parser/parser.py
+++ b/rosidl_parser/rosidl_parser/parser.py
@@ -28,10 +28,19 @@ from typing import Tuple
 from typing import TYPE_CHECKING
 from typing import Union
 
-from lark import Lark
-from lark.lexer import Token
-from lark.tree import pydot__tree_to_png
-from lark.tree import Tree
+try:
+    import warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', DeprecationWarning)
+        from lark import Lark
+        from lark.lexer import Token
+        from lark.tree import pydot__tree_to_png
+        from lark.tree import Tree
+except ImportError:
+    Lark = None
+    Token = None
+    pydot__tree_to_png = None
+    Tree = ()
 
 from rosidl_parser.definition import AbstractNestableType
 from rosidl_parser.definition import AbstractNestedType
@@ -64,6 +73,7 @@ from rosidl_parser.definition import UnboundedSequence
 from rosidl_parser.definition import UnboundedString
 from rosidl_parser.definition import UnboundedWString
 from rosidl_parser.definition import ValueType
+from rosidl_parser.serialization import load_ast_json
 
 if TYPE_CHECKING:
     from typing import TypeVar
@@ -78,9 +88,6 @@ if TYPE_CHECKING:
     ParseTree: TypeAlias = Tree
 
 AbstractTypeAlias = Union[AbstractNestableType, BasicType, BoundedSequence, UnboundedSequence]
-
-from rosidl_parser.serialization import load_ast_json
-from rosidl_parser.serialization import save_ast_json
 
 grammar_file = os.path.join(os.path.dirname(__file__), 'grammar.lark')
 with open(grammar_file, mode='r', encoding='utf-8') as h:

--- a/rosidl_parser/rosidl_parser/serialization.py
+++ b/rosidl_parser/rosidl_parser/serialization.py
@@ -14,7 +14,11 @@
 
 import json
 import pathlib
-from typing import Any, Dict, Union
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Union
 
 from rosidl_parser import definition
 

--- a/rosidl_parser/rosidl_parser/serialization.py
+++ b/rosidl_parser/rosidl_parser/serialization.py
@@ -17,7 +17,6 @@ import pathlib
 from typing import Any
 from typing import Dict
 from typing import List
-from typing import Optional
 from typing import Union
 
 from rosidl_parser import definition

--- a/rosidl_parser/rosidl_parser/serialization.py
+++ b/rosidl_parser/rosidl_parser/serialization.py
@@ -54,6 +54,12 @@ def type_to_dict(t: definition.AbstractType) -> Dict[str, Any]:
     raise ValueError(f'Unknown type: {t}')
 
 
+def dict_to_nestable_type(d: Dict[str, Any]) -> definition.AbstractNestableType:
+    val_type = dict_to_type(d)
+    assert isinstance(val_type, definition.AbstractNestableType)
+    return val_type
+
+
 def dict_to_type(d: Dict[str, Any]) -> definition.AbstractType:
     kind = d['type']
     if kind == 'BasicType':
@@ -71,12 +77,12 @@ def dict_to_type(d: Dict[str, Any]) -> definition.AbstractType:
     elif kind == 'UnboundedWString':
         return definition.UnboundedWString()
     elif kind == 'Array':
-        return definition.Array(dict_to_type(d['value_type']), d['size'])
+        return definition.Array(dict_to_nestable_type(d['value_type']), d['size'])
     elif kind == 'BoundedSequence':
         return definition.BoundedSequence(
-            dict_to_type(d['value_type']), d['maximum_size'])
+            dict_to_nestable_type(d['value_type']), d['maximum_size'])
     elif kind == 'UnboundedSequence':
-        return definition.UnboundedSequence(dict_to_type(d['value_type']))
+        return definition.UnboundedSequence(dict_to_nestable_type(d['value_type']))
     raise ValueError(f'Unknown type kind: {kind}')
 
 
@@ -191,7 +197,7 @@ def dict_to_action(d: Dict[str, Any]) -> definition.Action:
 
 
 def idl_content_to_dict(content: definition.IdlContent) -> Dict[str, Any]:
-    elements = []
+    elements: List[Dict[str, Any]] = []
     for el in content.elements:
         if isinstance(el, definition.Include):
             elements.append({'kind': 'Include', 'locator': el.locator})

--- a/rosidl_parser/rosidl_parser/serialization.py
+++ b/rosidl_parser/rosidl_parser/serialization.py
@@ -1,0 +1,237 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import pathlib
+from typing import Any, Dict, Union
+
+from rosidl_parser import definition
+
+
+def type_to_dict(t: definition.AbstractType) -> Dict[str, Any]:
+    if isinstance(t, definition.BasicType):
+        return {'type': 'BasicType', 'typename': t.typename}
+    elif isinstance(t, definition.NamespacedType):
+        return {'type': 'NamespacedType', 'namespaces': t.namespaces, 'name': t.name}
+    elif isinstance(t, definition.NamedType):
+        return {'type': 'NamedType', 'name': t.name}
+    elif isinstance(t, definition.BoundedString):
+        return {'type': 'BoundedString', 'maximum_size': t.maximum_size}
+    elif isinstance(t, definition.UnboundedString):
+        return {'type': 'UnboundedString'}
+    elif isinstance(t, definition.BoundedWString):
+        return {'type': 'BoundedWString', 'maximum_size': t.maximum_size}
+    elif isinstance(t, definition.UnboundedWString):
+        return {'type': 'UnboundedWString'}
+    elif isinstance(t, definition.Array):
+        return {
+            'type': 'Array',
+            'value_type': type_to_dict(t.value_type),
+            'size': t.size,
+        }
+    elif isinstance(t, definition.BoundedSequence):
+        return {
+            'type': 'BoundedSequence',
+            'value_type': type_to_dict(t.value_type),
+            'maximum_size': t.maximum_size,
+        }
+    elif isinstance(t, definition.UnboundedSequence):
+        return {
+            'type': 'UnboundedSequence',
+            'value_type': type_to_dict(t.value_type),
+        }
+    raise ValueError(f'Unknown type: {t}')
+
+
+def dict_to_type(d: Dict[str, Any]) -> definition.AbstractType:
+    kind = d['type']
+    if kind == 'BasicType':
+        return definition.BasicType(d['typename'])
+    elif kind == 'NamespacedType':
+        return definition.NamespacedType(d['namespaces'], d['name'])
+    elif kind == 'NamedType':
+        return definition.NamedType(d['name'])
+    elif kind == 'BoundedString':
+        return definition.BoundedString(d['maximum_size'])
+    elif kind == 'UnboundedString':
+        return definition.UnboundedString()
+    elif kind == 'BoundedWString':
+        return definition.BoundedWString(d['maximum_size'])
+    elif kind == 'UnboundedWString':
+        return definition.UnboundedWString()
+    elif kind == 'Array':
+        return definition.Array(dict_to_type(d['value_type']), d['size'])
+    elif kind == 'BoundedSequence':
+        return definition.BoundedSequence(
+            dict_to_type(d['value_type']), d['maximum_size'])
+    elif kind == 'UnboundedSequence':
+        return definition.UnboundedSequence(dict_to_type(d['value_type']))
+    raise ValueError(f'Unknown type kind: {kind}')
+
+
+def annotation_to_dict(ann: definition.Annotation) -> Dict[str, Any]:
+    return {'name': ann.name, 'value': ann.value}
+
+
+def dict_to_annotation(d: Dict[str, Any]) -> definition.Annotation:
+    return definition.Annotation(d['name'], d['value'])
+
+
+def member_to_dict(m: definition.Member) -> Dict[str, Any]:
+    return {
+        'type': type_to_dict(m.type),
+        'name': m.name,
+        'annotations': [annotation_to_dict(a) for a in m.annotations],
+    }
+
+
+def dict_to_member(d: Dict[str, Any]) -> definition.Member:
+    m = definition.Member(dict_to_type(d['type']), d['name'])
+    m.annotations = [dict_to_annotation(a) for a in d.get('annotations', [])]
+    return m
+
+
+def constant_to_dict(c: definition.Constant) -> Dict[str, Any]:
+    return {
+        'name': c.name,
+        'type': type_to_dict(c.type),
+        'value': c.value,
+        'annotations': [annotation_to_dict(a) for a in c.annotations],
+    }
+
+
+def dict_to_constant(d: Dict[str, Any]) -> definition.Constant:
+    c = definition.Constant(d['name'], dict_to_type(d['type']), d['value'])
+    c.annotations = [dict_to_annotation(a) for a in d.get('annotations', [])]
+    return c
+
+
+def structure_to_dict(s: definition.Structure) -> Dict[str, Any]:
+    return {
+        'namespaced_type': {
+            'namespaces': s.namespaced_type.namespaces,
+            'name': s.namespaced_type.name,
+        },
+        'members': [member_to_dict(m) for m in s.members],
+        'annotations': [annotation_to_dict(a) for a in s.annotations],
+    }
+
+
+def dict_to_structure(d: Dict[str, Any]) -> definition.Structure:
+    nst = definition.NamespacedType(
+        d['namespaced_type']['namespaces'], d['namespaced_type']['name'])
+    members = [dict_to_member(m) for m in d['members']]
+    s = definition.Structure(nst, members=members)
+    s.annotations = [dict_to_annotation(a) for a in d.get('annotations', [])]
+    return s
+
+
+def message_to_dict(m: definition.Message) -> Dict[str, Any]:
+    return {
+        'structure': structure_to_dict(m.structure),
+        'constants': [constant_to_dict(c) for c in m.constants],
+    }
+
+
+def dict_to_message(d: Dict[str, Any]) -> definition.Message:
+    msg = definition.Message(dict_to_structure(d['structure']))
+    msg.constants = [dict_to_constant(c) for c in d.get('constants', [])]
+    return msg
+
+
+def service_to_dict(s: definition.Service) -> Dict[str, Any]:
+    return {
+        'namespaced_type': {
+            'namespaces': s.namespaced_type.namespaces,
+            'name': s.namespaced_type.name,
+        },
+        'request': message_to_dict(s.request_message),
+        'response': message_to_dict(s.response_message),
+    }
+
+
+def dict_to_service(d: Dict[str, Any]) -> definition.Service:
+    nst = definition.NamespacedType(
+        d['namespaced_type']['namespaces'], d['namespaced_type']['name'])
+    req = dict_to_message(d['request'])
+    resp = dict_to_message(d['response'])
+    return definition.Service(nst, req, resp)
+
+
+def action_to_dict(a: definition.Action) -> Dict[str, Any]:
+    return {
+        'namespaced_type': {
+            'namespaces': a.namespaced_type.namespaces,
+            'name': a.namespaced_type.name,
+        },
+        'goal': message_to_dict(a.goal),
+        'result': message_to_dict(a.result),
+        'feedback': message_to_dict(a.feedback),
+    }
+
+
+def dict_to_action(d: Dict[str, Any]) -> definition.Action:
+    nst = definition.NamespacedType(
+        d['namespaced_type']['namespaces'], d['namespaced_type']['name'])
+    goal = dict_to_message(d['goal'])
+    result = dict_to_message(d['result'])
+    feedback = dict_to_message(d['feedback'])
+    return definition.Action(nst, goal, result, feedback)
+
+
+def idl_content_to_dict(content: definition.IdlContent) -> Dict[str, Any]:
+    elements = []
+    for el in content.elements:
+        if isinstance(el, definition.Include):
+            elements.append({'kind': 'Include', 'locator': el.locator})
+        elif isinstance(el, definition.Message):
+            elements.append({'kind': 'Message', 'data': message_to_dict(el)})
+        elif isinstance(el, definition.Service):
+            elements.append({'kind': 'Service', 'data': service_to_dict(el)})
+        elif isinstance(el, definition.Action):
+            elements.append({'kind': 'Action', 'data': action_to_dict(el)})
+        else:
+            raise ValueError(f'Unknown element type: {el}')
+    return {'elements': elements}
+
+
+def dict_to_idl_content(d: Dict[str, Any]) -> definition.IdlContent:
+    content = definition.IdlContent()
+    for el in d['elements']:
+        kind = el['kind']
+        if kind == 'Include':
+            content.elements.append(definition.Include(el['locator']))
+        elif kind == 'Message':
+            content.elements.append(dict_to_message(el['data']))
+        elif kind == 'Service':
+            content.elements.append(dict_to_service(el['data']))
+        elif kind == 'Action':
+            content.elements.append(dict_to_action(el['data']))
+        else:
+            raise ValueError(f'Unknown element kind: {kind}')
+    return content
+
+
+def save_ast_json(content: definition.IdlContent, path: Union[str, pathlib.Path]) -> None:
+    """Save an IdlContent AST to a JSON file."""
+    p = pathlib.Path(path)
+    d = idl_content_to_dict(content)
+    p.write_text(json.dumps(d, separators=(',', ':')), encoding='utf-8')
+
+
+def load_ast_json(path: Union[str, pathlib.Path]) -> definition.IdlContent:
+    """Load an IdlContent AST from a JSON file."""
+    p = pathlib.Path(path)
+    d = json.loads(p.read_text(encoding='utf-8'))
+    return dict_to_idl_content(d)

--- a/rosidl_parser/test/test_parser.py
+++ b/rosidl_parser/test/test_parser.py
@@ -494,6 +494,71 @@ def test_action_parser(action_idl_file: IdlFile) -> None:
         action.feedback.structure.namespaced_type.name
 
 
+def test_serialization_roundtrip() -> None:
+    from rosidl_parser.serialization import (
+        dict_to_idl_content,
+        idl_content_to_dict,
+        load_ast_json,
+        save_ast_json,
+    )
+    for loc in (MESSAGE_IDL_LOCATOR, SERVICE_IDL_LOCATOR, ACTION_IDL_LOCATOR):
+        idl_file = parse_idl_file(loc)
+        d = idl_content_to_dict(idl_file.content)
+        restored = dict_to_idl_content(d)
+        d2 = idl_content_to_dict(restored)
+        assert d == d2, f'Serialization roundtrip failed for {loc.relative_path}'
+
+
+def test_preparsed_ast_loading(tmp_path: pathlib.Path) -> None:
+    import time
+    from rosidl_parser.parser import clear_ast_cache
+    clear_ast_cache()
+
+    test_idl = tmp_path / 'Sample.idl'
+    test_idl.write_text("""
+module test_pkg {
+  module msg {
+    struct Sample {
+      int32 data;
+      string name;
+    };
+  };
+};
+""", encoding='utf-8')
+    locator = IdlLocator(tmp_path, pathlib.Path('Sample.idl'))
+
+    # Save AST to .idl.json
+    ast1 = parse_idl_file(locator)
+    json_path = tmp_path / 'Sample.idl.json'
+    from rosidl_parser.serialization import save_ast_json
+    save_ast_json(ast1.content, json_path)
+    assert json_path.exists(), 'Expected Sample.idl.json to be created'
+
+    # Clear in-memory cache and re-parse - should load from .idl.json
+    clear_ast_cache()
+    ast2 = parse_idl_file(locator)
+    assert isinstance(ast2.content.elements[0], Message)
+    assert ast2.content.elements[0].structure.namespaced_type.name == 'Sample'
+    assert ast2.content.elements[0].structure.members[0].name == 'data'
+    assert ast2.content.elements[0].structure.members[1].name == 'name'
+
+    # Modify IDL file mtime/content
+    time.sleep(0.01)
+    test_idl.write_text("""
+module test_pkg {
+  module msg {
+    struct Sample {
+      int64 modified_data;
+    };
+  };
+};
+""", encoding='utf-8')
+    clear_ast_cache()
+    ast3 = parse_idl_file(locator)
+    assert isinstance(ast3.content.elements[0], Message)
+    assert ast3.content.elements[0].structure.members[0].name == 'modified_data'
+
+
 def test_parse_idl_file_memoization(tmp_path: pathlib.Path) -> None:
     clear_ast_cache()
     # Create temporary IDL file

--- a/rosidl_parser/test/test_parser.py
+++ b/rosidl_parser/test/test_parser.py
@@ -537,10 +537,11 @@ module test_pkg {
     # Clear in-memory cache and re-parse - should load from .idl.json
     clear_ast_cache()
     ast2 = parse_idl_file(locator)
-    assert isinstance(ast2.content.elements[0], Message)
-    assert ast2.content.elements[0].structure.namespaced_type.name == 'Sample'
-    assert ast2.content.elements[0].structure.members[0].name == 'data'
-    assert ast2.content.elements[0].structure.members[1].name == 'name'
+    elem2 = ast2.content.elements[0]
+    assert isinstance(elem2, Message)
+    assert elem2.structure.namespaced_type.name == 'Sample'
+    assert elem2.structure.members[0].name == 'data'
+    assert elem2.structure.members[1].name == 'name'
 
     # Modify IDL file mtime/content
     time.sleep(0.01)
@@ -555,8 +556,9 @@ module test_pkg {
 """, encoding='utf-8')
     clear_ast_cache()
     ast3 = parse_idl_file(locator)
-    assert isinstance(ast3.content.elements[0], Message)
-    assert ast3.content.elements[0].structure.members[0].name == 'modified_data'
+    elem3 = ast3.content.elements[0]
+    assert isinstance(elem3, Message)
+    assert elem3.structure.members[0].name == 'modified_data'
 
 
 def test_parse_idl_file_memoization(tmp_path: pathlib.Path) -> None:

--- a/rosidl_parser/test/test_parser.py
+++ b/rosidl_parser/test/test_parser.py
@@ -498,8 +498,6 @@ def test_serialization_roundtrip() -> None:
     from rosidl_parser.serialization import (
         dict_to_idl_content,
         idl_content_to_dict,
-        load_ast_json,
-        save_ast_json,
     )
     for loc in (MESSAGE_IDL_LOCATOR, SERVICE_IDL_LOCATOR, ACTION_IDL_LOCATOR):
         idl_file = parse_idl_file(loc)

--- a/rosidl_pycommon/rosidl_pycommon/__init__.py
+++ b/rosidl_pycommon/rosidl_pycommon/__init__.py
@@ -30,6 +30,7 @@ except ImportError:
 
 from rosidl_parser.definition import IdlLocator
 from rosidl_parser.parser import parse_idl_file
+from rosidl_parser.serialization import save_ast_json
 
 
 def convert_camel_case_to_lower_case_underscore(value: str) -> str:
@@ -104,6 +105,13 @@ def generate_files(
             idl_stem = convert_camel_case_to_lower_case_underscore(idl_stem)
         try:
             idl_file = parse_idl_file(locator)
+            ast_json_path = locator.get_absolute_path().with_suffix(
+                locator.get_absolute_path().suffix + '.json')
+            if not ast_json_path.exists():
+                try:
+                    save_ast_json(idl_file.content, ast_json_path)
+                except OSError:
+                    pass
             for template_file, generated_filename in mapping.items():
                 generated_file = os.path.join(
                     args['output_dir'], str(idl_rel_path.parent),


### PR DESCRIPTION
## Description

Currently, ROS 2 IDL parsing via `rosidl_parser.parse_idl_file()` parses `.idl` files from raw text with Lark every time an IDL is accessed. This pr trys to improve that by saving the result of that parse and installing it to the disk next to the idl files themselves, so future accesses can use that. This is similar to `.pyc` files in python or precompiled headers in C++.

In typical workflows:
1. Within a single interface package, each generator backend (`rosidl_generator_c`, `rosidl_generator_cpp`, `rosidl_typesupport_*`, etc.) runs as an independent Python subprocess, resulting in 9–11 redundant parse cycles per message file.
2. Across interface packages, every downstream package (such as `sensor_msgs`, `nav_msgs`, or user workspace packages) must repeatedly re-parse the `.idl` files of all upstream interface dependencies (`std_msgs`, `geometry_msgs`, `builtin_interfaces`).

This PR implements distributed pre-parsed AST caching and JSON serialization:
- **`rosidl_parser.serialization`**: Adds bidirectional conversion between `rosidl_parser.definition.IdlContent` AST data structures and JSON-serializable dictionaries (`idl_content_to_dict`, `dict_to_idl_content`, `save_ast_json`, `load_ast_json`).
- **`rosidl_parser.parser.parse_idl_file()`**:
  - Adds in-process AST caching (`_ast_cache`).
  - Checks for a `<name>.idl.json` pre-parsed AST file alongside the `.idl` file. If present and up to date, it deserializes the AST directly, bypassing the slower grammar parser entirely.
- **`rosidl_generator_type_description` & `rosidl_pycommon`**: Saves `<name>.idl.json` alongside adapted `.idl` files during interface generation in the build tree.
- **`rosidl_cmake`**: Installs `<name>.idl.json` alongside `.idl` files into `share/${PROJECT_NAME}/` (`OPTIONAL`), ensuring pre-parsed ASTs are available for all downstream package builds and binary package installs.

### Empirical Benchmarks

#### 1. Clean Rebuild Time (`rm -rf build/<pkg>`)

| Package | Definitions | Baseline (`rolling`) | Pre-Parsed AST | Build Time Reduction |
| :--- | :--- | :--- | :--- | :--- |
| **`test_msgs`** | 18 msgs/srvs/actions | 68.58 s | **66.00 s** | **-2.59 s (-3.8%)** |
| **`sensor_msgs`** | 30 msgs/srvs | 74.04 s | **71.37 s** | **-2.67 s (-3.6%)** |
| **`px4_msgs`** | 263 msgs | 466.84 s (~7m 47s) | **405.75 s (~6m 45s)** | **-61.08 s (-13.1%, >1 min saved)** |

#### 2. Repeated (No-Op) and Incremental Rebuilds

| Package | Scenario | Baseline (`rolling`) | Pre-Parsed AST | Difference |
| :--- | :--- | :--- | :--- | :--- |
| **`test_msgs`** | No-Op Rebuild | 5.40 s | 5.27 s | -0.13 s |
| **`test_msgs`** | Incremental (1 msg touched) | 5.06 s | 5.13 s | +0.07 s |
| **`sensor_msgs`** | No-Op Rebuild | 5.45 s | 5.74 s | +0.29 s |
| **`sensor_msgs`** | Incremental (1 msg touched) | 7.95 s | 8.16 s | +0.21 s |
| **`px4_msgs`** | No-Op Rebuild | 11.35 s | 12.17 s | +0.82 s |
| **`px4_msgs`** | Incremental (1 msg touched) | 17.13 s | 17.41 s | +0.28 s |

*Note: No-op and single-file incremental rebuilds are dominated by CMake dependency checking and remain unchanged.*

#### 3. Installed Artifact Footprint & Disk Space Impact

| Package | Total Installed Files | AST JSON Files | Total Installed Size | AST JSON Size | Disk Space Increase |
| :--- | :--- | :--- | :--- | :--- | :--- |
| **`std_msgs`** | 759 | 30 | 3,734 KB | 23.1 KB | **+0.62%** |
| **`test_msgs`** | 562 | 22 | 11,627 KB | 52.6 KB | **+0.45%** |
| **`sensor_msgs`** | 723 | 28 | 5,686 KB | 61.8 KB | **+1.10%** |
| **`px4_msgs`** | 6,143 | 264 | 47,468 KB | 732.8 KB | **+1.57%** |

*The pre-parsed AST JSON files add < 1.5% to the installed size of interface packages.*

Related to https://github.com/ros2/rosidl/issues/931

### Is this user-facing behavior change?

No, this is an internal build performance optimization.

### Did you use Generative AI?

Yes, Gemini.
