### PR TITLE
rosidl_buffer: let a buffer say where its memory is

### DIFF
--- a/rosidl_buffer/include/rosidl_buffer/buffer_impl_base.hpp
+++ b/rosidl_buffer/include/rosidl_buffer/buffer_impl_base.hpp
@@ -15,9 +15,18 @@
 #ifndef ROSIDL_BUFFER__BUFFER_IMPL_BASE_HPP_
 #define ROSIDL_BUFFER__BUFFER_IMPL_BASE_HPP_
 
+// Revision of this header's BufferImplBase vtable layout. Bump whenever a
+// virtual is added, removed or reordered. A build that mixes this header with a
+// differently-revisioned copy of it is an ODR violation with a wrong vtable --
+// silent at runtime -- so consumers that pin a particular copy compare this
+// against a value delivered independently of the include path.
+#define ROSIDL_BUFFER_SOURCE_REV 4
+
 #include <cstddef>
 #include <memory>
 #include <string>
+
+#include "rosidl_buffer/buffer_memory.hpp"
 
 namespace rosidl
 {
@@ -51,6 +60,57 @@ public:
   /// Create a deep copy of this buffer.
   /// @return New BufferImplBase instance with copied data
   virtual std::unique_ptr<BufferImplBase<T>> clone() const = 0;
+
+  /// Where this buffer's elements live, so a consumer can address them in
+  /// place instead of copying them to the host.
+  ///
+  /// The default answer is "I am not saying" (`Kind::unknown`), which every
+  /// caller must handle by falling back to `to_cpu()`. That default is what
+  /// makes this safe to add: an implementation written before this existed
+  /// keeps compiling and keeps working.
+  ///
+  /// **The contents are ready when this returns.** An implementation that
+  /// writes asynchronously synchronizes before returning, so a caller can use
+  /// the handle immediately without knowing anything about the backend's
+  /// streams or fences. That costs a synchronization the caller may not have
+  /// needed; making it avoidable needs a way to hand back a wait token, which
+  /// is deliberately left to a later revision rather than guessed at now.
+  ///
+  /// The returned handle is valid for at least as long as this object. An
+  /// implementation that is a *view* of memory owned elsewhere can promise more
+  /// by returning a non-null `BufferMemory::keepalive`, which holds that memory
+  /// valid independently of this buffer.
+  virtual BufferMemory memory() const {return BufferMemory{};}
+
+  /// `memory()`, but without the synchronization.
+  ///
+  /// `memory()` guarantees the contents are ready by *waiting*, which is simple
+  /// and always correct and costs the caller a stall it may not need. This is
+  /// the version for a caller that has its own queue and would rather order
+  /// against it: instead of waiting, the implementation makes `queue` wait for
+  /// whatever writes are outstanding, and returns immediately.
+  ///
+  /// `queue` is interpreted according to the returned `BufferMemory::kind` --
+  /// a `cudaStream_t` for `Kind::cuda_device`. Passing null means "no queue of
+  /// mine", which is just `memory()`.
+  ///
+  /// The direction matters and is deliberately the same as DLPack's: the
+  /// consumer states where it will work, and the producer arranges the
+  /// ordering. Handing back a fence for the consumer to interpret would mean
+  /// standardizing a fence type across every accelerator, which is a far larger
+  /// design and is what NvSciSync exists to be.
+  ///
+  /// A caller must hold the returned `BufferMemory` for as long as it is still
+  /// reading -- an implementation may use `keepalive` to track outstanding
+  /// reads, not merely to keep the allocation alive.
+  ///
+  /// The default ignores `queue` and defers to `memory()`. That is always
+  /// correct: waiting more than you needed to is a cost, never a bug.
+  virtual BufferMemory memory_on(void * queue) const
+  {
+    (void)queue;
+    return memory();
+  }
 };
 
 }  // namespace rosidl

--- a/rosidl_buffer/include/rosidl_buffer/buffer_memory.hpp
+++ b/rosidl_buffer/include/rosidl_buffer/buffer_memory.hpp
@@ -1,0 +1,117 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_BUFFER__BUFFER_MEMORY_HPP_
+#define ROSIDL_BUFFER__BUFFER_MEMORY_HPP_
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+namespace rosidl
+{
+
+/// Where a buffer's elements physically live, and how to address them.
+///
+/// `BufferImplBase` describes a buffer in terms of what you can *do* to it --
+/// `size()`, `to_cpu()`, `clone()` -- and deliberately says nothing about where
+/// the bytes are. That is the right default: it keeps the interface portable,
+/// and a consumer that only wants values should use the accessors.
+///
+/// It is not enough for a consumer that wants to keep work on an accelerator.
+/// Handed a CUDA-backed buffer, such a consumer has only `to_cpu()`, which is
+/// the one thing it is trying to avoid. Its alternatives today are to know the
+/// concrete implementation type and `dynamic_cast` to it -- which couples it to
+/// one backend, and fails silently across a shared-library boundary -- or to
+/// copy. This type is the third option: ask the buffer where its memory is, in
+/// terms every backend can express and any consumer can interpret.
+///
+/// Deliberately close in shape to DLPack's `DLTensor`/`DLDevice`, which solves
+/// the same problem for the ML frameworks: an address, tagged with what kind of
+/// thing it is and which device it belongs to. Reusing that shape is worth more
+/// than any originality here.
+///
+/// \sa BufferImplBase::memory()
+struct BufferMemory
+{
+  /// What `handle` is. A raw address alone is not interpretable: a CUDA device
+  /// pointer, a host pointer, a DMA-BUF file descriptor and an NvSciBufObj are
+  /// all pointer-shaped and none can be substituted for another.
+  enum class Kind : uint32_t
+  {
+    /// No native handle on offer. The default for any implementation that has
+    /// not overridden `memory()`, and the answer every consumer must handle:
+    /// fall back to `to_cpu()`, which always works.
+    unknown = 0,
+
+    /// `handle` is a host pointer, directly dereferenceable in this process.
+    host = 1,
+
+    /// `handle` is a device pointer valid in the CUDA address space of
+    /// `device_id`. Process-local.
+    cuda_device = 2,
+
+    /// `handle` is a DMA-BUF file descriptor, cast from `int`. Crosses process
+    /// boundaries; the receiver imports it.
+    dmabuf = 3,
+
+    /// `handle` is an `NvSciBufObj`. Crosses process and partition boundaries.
+    nvscibuf = 4,
+  };
+
+  Kind kind = Kind::unknown;
+
+  /// Interpreted according to `kind`. Null whenever `kind` is `unknown`.
+  void * handle = nullptr;
+
+  /// Which device `handle` belongs to, in whatever numbering `kind` implies --
+  /// a CUDA device ordinal for `cuda_device`. -1 when not applicable, which is
+  /// the only correct answer for `host` and `unknown`.
+  ///
+  /// Not optional for the accelerator kinds: a CUDA pointer is meaningless
+  /// without knowing whose address space it is in, and assuming "the current
+  /// device" is a bug that only shows up on a second GPU.
+  int64_t device_id = -1;
+
+  /// Bytes reachable from `handle`. May exceed the buffer's logical size when
+  /// the implementation is a view of a larger allocation.
+  size_t size_bytes = 0;
+
+  /// Holds `handle` valid for as long as this is held.
+  ///
+  /// Null means "valid only while the buffer you got this from lives", which is
+  /// the honest answer for an implementation that owns its allocation outright
+  /// -- there is nothing to hand out, and the buffer already is the lifetime.
+  ///
+  /// Non-null matters when the implementation is a *view*: memory owned by
+  /// something else, on loan for a while. A zero-copy transport is the case
+  /// this exists for -- its buffers point into a slot that is recycled once the
+  /// message is dropped, so a consumer that wants to outlive the callback, or
+  /// merely to finish a kernel it launched, has no safe way to say so today.
+  /// Holding this says it.
+  ///
+  /// It is carried here rather than fetched by a second call on purpose: an
+  /// address and the reason it stays valid are one fact, and code that can ask
+  /// for them separately will eventually ask for only the first. This is
+  /// DLPack's `manager_ctx`/`deleter` pair in a C++ idiom.
+  std::shared_ptr<void> keepalive;
+
+  /// True when `handle` is usable. Sugar for the `kind != unknown` check every
+  /// caller has to write.
+  bool valid() const {return kind != Kind::unknown && handle != nullptr;}
+};
+
+}  // namespace rosidl
+
+#endif  // ROSIDL_BUFFER__BUFFER_MEMORY_HPP_

--- a/rosidl_buffer/include/rosidl_buffer/cpu_buffer_impl.hpp
+++ b/rosidl_buffer/include/rosidl_buffer/cpu_buffer_impl.hpp
@@ -56,6 +56,18 @@ public:
     return copy;
   }
 
+  /// Host storage, always addressable. An empty vector's `data()` may be null,
+  /// which `valid()` reports as unusable -- correct, since there is nothing to
+  /// address.
+  BufferMemory memory() const override
+  {
+    BufferMemory out;
+    out.kind = BufferMemory::Kind::host;
+    out.handle = const_cast<T *>(storage_.data());
+    out.size_bytes = storage_.size() * sizeof(T);
+    return out;
+  }
+
 private:
   std::vector<T, Allocator> storage_;
 };


### PR DESCRIPTION
`BufferImplBase` describes a buffer by what you can do to it -- `size()`, `to_cpu()`, `clone()` -- and says nothing about where the bytes are. For a consumer that only wants values that is exactly right. For one trying to keep work on an accelerator it is a dead end: handed a CUDA-backed buffer, its only option is `to_cpu()`, which is the one thing it is trying to avoid.

Today the ways around that are to know the concrete implementation type and `dynamic_cast` to it, or to copy. The cast couples the consumer to one backend, and because these implementations are header-only class templates with no key function, it can fail across a shared-library boundary on an object that genuinely is the right type -- silently, degrading to a copy that still produces correct output. That is a bad failure to build on.

Add `BufferMemory` and three ways to ask for it, layered so each is useful alone:

* `BufferMemory` + `memory()` -- what and where. An address tagged with what kind of handle it is (host / CUDA device / DMA-BUF / NvSciBuf) and which device it belongs to. Shape follows DLPack's DLTensor/DLDevice, which solves the same problem for the ML frameworks; reusing it is worth more than originality here. Defaults to `Kind::unknown`, so an implementation written before this keeps compiling and every caller has a defined fallback. Contents are ready when it returns: an implementation that writes asynchronously synchronizes first, which is what keeps this layer small.

* `BufferMemory::keepalive` -- how long. Null means "valid while the buffer lives", which is the honest answer for an implementation that owns its allocation. It matters for a *view* of memory owned elsewhere: a zero-copy transport whose buffers point into a slot recycled when the message drops. Carried in the struct rather than fetched by a second call on purpose -- an address and the reason it stays valid are one fact, and code that can ask for them separately will eventually ask for only the first.

* `memory_on(queue)` -- when. Instead of waiting, order the caller's queue behind the outstanding writes and return. Same direction as DLPack's stream protocol: the consumer states where it will work and the producer arranges the ordering, which avoids standardizing a fence type across every accelerator. Defaults to `memory()`, and that default is always correct -- waiting more than you needed is a cost, never a bug.

The device id is not decoration. A CUDA pointer is meaningless without knowing whose address space it is in, and answering "whichever device is current" is a bug that only appears on a second GPU.

`CpuBufferImpl` implements the first, and is the reference for what a trivial backend owes.

Note for anyone bisecting: the added virtuals change BufferImplBase's vtable layout. A class deriving from it that does *not* override them will compile against either revision of this header while disagreeing about the vtable, so mixing revisions in one build is an ODR violation with no diagnostic. ROSIDL_BUFFER_SOURCE_REV exists so a build that pins a particular copy can detect that.

Motivating case: an RMW carrying GPU payloads through shared memory. It needs to reach a foreign backend's device memory to publish it, and its subscribers need to read the delivered frame in place. Both are possible today only by naming a specific backend in the transport -- which is what this removes.

## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
