### PR TITLE
Add language bindings for buffer-backed sequences

### DIFF
--- a/rosidl_buffer/include/rosidl_buffer/c_helpers.h
+++ b/rosidl_buffer/include/rosidl_buffer/c_helpers.h
@@ -15,11 +15,52 @@
 #ifndef ROSIDL_BUFFER__C_HELPERS_H_
 #define ROSIDL_BUFFER__C_HELPERS_H_
 
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include "rosidl_buffer/visibility_control.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+typedef enum rosidl_buffer_ret_e
+{
+  ROSIDL_BUFFER_RET_OK = 0,
+  ROSIDL_BUFFER_RET_INVALID_ARGUMENT = 1,
+  ROSIDL_BUFFER_RET_NOT_CPU = 2,
+  ROSIDL_BUFFER_RET_BAD_ALLOC = 3,
+  ROSIDL_BUFFER_RET_ERROR = 4
+} rosidl_buffer_ret_t;
+
+ROSIDL_BUFFER_PUBLIC
+rosidl_buffer_ret_t rosidl_buffer_uint8_create_cpu(
+  const uint8_t * data, size_t size, void ** buffer_ptr);
+
+ROSIDL_BUFFER_PUBLIC
+rosidl_buffer_ret_t rosidl_buffer_uint8_clone(
+  const void * source_ptr, void ** buffer_ptr);
+
+ROSIDL_BUFFER_PUBLIC
+rosidl_buffer_ret_t rosidl_buffer_uint8_size(
+  const void * buffer_ptr, size_t * size);
+
+ROSIDL_BUFFER_PUBLIC
+rosidl_buffer_ret_t rosidl_buffer_uint8_backend_name(
+  const void * buffer_ptr, char * output, size_t output_capacity, size_t * required_size);
+
+ROSIDL_BUFFER_PUBLIC
+rosidl_buffer_ret_t rosidl_buffer_uint8_copy_to(
+  const void * buffer_ptr, uint8_t * output, size_t output_size);
+
+ROSIDL_BUFFER_PUBLIC
+rosidl_buffer_ret_t rosidl_buffer_uint8_are_equal(
+  const void * lhs_ptr, const void * rhs_ptr, bool * are_equal);
+
+ROSIDL_BUFFER_PUBLIC
+rosidl_buffer_ret_t rosidl_buffer_uint8_equals_data(
+  const void * buffer_ptr, const uint8_t * data, size_t size, bool * are_equal);
 
 /// Throw std::runtime_error if the buffer is not CPU-backed.
 /**

--- a/rosidl_buffer/src/c_helpers.cpp
+++ b/rosidl_buffer/src/c_helpers.cpp
@@ -14,11 +14,155 @@
 
 #include "rosidl_buffer/c_helpers.h"
 
+#include <algorithm>
 #include <cstdint>
+#include <cstring>
+#include <new>
+#include <string>
+#include <vector>
 
 #include "rosidl_buffer/buffer.hpp"
 
 extern "C" {
+
+rosidl_buffer_ret_t rosidl_buffer_uint8_create_cpu(
+  const uint8_t * data, size_t size, void ** buffer_ptr)
+{
+  if (!buffer_ptr || (size != 0 && !data)) {
+    return ROSIDL_BUFFER_RET_INVALID_ARGUMENT;
+  }
+  *buffer_ptr = nullptr;
+  try {
+    auto * buffer = new rosidl::Buffer<uint8_t>(size);
+    if (size != 0) {
+      std::copy_n(data, size, buffer->data());
+    }
+    *buffer_ptr = buffer;
+    return ROSIDL_BUFFER_RET_OK;
+  } catch (const std::bad_alloc &) {
+    return ROSIDL_BUFFER_RET_BAD_ALLOC;
+  } catch (...) {
+    return ROSIDL_BUFFER_RET_ERROR;
+  }
+}
+
+rosidl_buffer_ret_t rosidl_buffer_uint8_clone(
+  const void * source_ptr, void ** buffer_ptr)
+{
+  if (!source_ptr || !buffer_ptr) {
+    return ROSIDL_BUFFER_RET_INVALID_ARGUMENT;
+  }
+  *buffer_ptr = nullptr;
+  try {
+    const auto * source = static_cast<const rosidl::Buffer<uint8_t> *>(source_ptr);
+    *buffer_ptr = new rosidl::Buffer<uint8_t>(*source);
+    return ROSIDL_BUFFER_RET_OK;
+  } catch (const std::bad_alloc &) {
+    return ROSIDL_BUFFER_RET_BAD_ALLOC;
+  } catch (...) {
+    return ROSIDL_BUFFER_RET_ERROR;
+  }
+}
+
+rosidl_buffer_ret_t rosidl_buffer_uint8_size(
+  const void * buffer_ptr, size_t * size)
+{
+  if (!buffer_ptr || !size) {
+    return ROSIDL_BUFFER_RET_INVALID_ARGUMENT;
+  }
+  try {
+    *size = static_cast<const rosidl::Buffer<uint8_t> *>(buffer_ptr)->size();
+    return ROSIDL_BUFFER_RET_OK;
+  } catch (...) {
+    return ROSIDL_BUFFER_RET_ERROR;
+  }
+}
+
+rosidl_buffer_ret_t rosidl_buffer_uint8_backend_name(
+  const void * buffer_ptr, char * output, size_t output_capacity, size_t * required_size)
+{
+  if (!buffer_ptr || !required_size || (!output && output_capacity != 0)) {
+    return ROSIDL_BUFFER_RET_INVALID_ARGUMENT;
+  }
+  try {
+    const std::string backend =
+      static_cast<const rosidl::Buffer<uint8_t> *>(buffer_ptr)->get_backend_type();
+    *required_size = backend.size() + 1;
+    if (!output) {
+      return ROSIDL_BUFFER_RET_OK;
+    }
+    if (output_capacity < *required_size) {
+      return ROSIDL_BUFFER_RET_INVALID_ARGUMENT;
+    }
+    std::memcpy(output, backend.c_str(), *required_size);
+    return ROSIDL_BUFFER_RET_OK;
+  } catch (...) {
+    return ROSIDL_BUFFER_RET_ERROR;
+  }
+}
+
+rosidl_buffer_ret_t rosidl_buffer_uint8_copy_to(
+  const void * buffer_ptr, uint8_t * output, size_t output_size)
+{
+  if (!buffer_ptr || (!output && output_size != 0)) {
+    return ROSIDL_BUFFER_RET_INVALID_ARGUMENT;
+  }
+  try {
+    const auto * buffer = static_cast<const rosidl::Buffer<uint8_t> *>(buffer_ptr);
+    if (output_size < buffer->size()) {
+      return ROSIDL_BUFFER_RET_INVALID_ARGUMENT;
+    }
+    const std::vector<uint8_t> data = buffer->to_vector();
+    if (!data.empty()) {
+      std::copy(data.begin(), data.end(), output);
+    }
+    return ROSIDL_BUFFER_RET_OK;
+  } catch (const std::bad_alloc &) {
+    return ROSIDL_BUFFER_RET_BAD_ALLOC;
+  } catch (...) {
+    return ROSIDL_BUFFER_RET_ERROR;
+  }
+}
+
+rosidl_buffer_ret_t rosidl_buffer_uint8_are_equal(
+  const void * lhs_ptr, const void * rhs_ptr, bool * are_equal)
+{
+  if (!lhs_ptr || !rhs_ptr || !are_equal) {
+    return ROSIDL_BUFFER_RET_INVALID_ARGUMENT;
+  }
+  try {
+    const auto * lhs = static_cast<const rosidl::Buffer<uint8_t> *>(lhs_ptr);
+    const auto * rhs = static_cast<const rosidl::Buffer<uint8_t> *>(rhs_ptr);
+    *are_equal = lhs->to_vector() == rhs->to_vector();
+    return ROSIDL_BUFFER_RET_OK;
+  } catch (const std::bad_alloc &) {
+    return ROSIDL_BUFFER_RET_BAD_ALLOC;
+  } catch (...) {
+    return ROSIDL_BUFFER_RET_ERROR;
+  }
+}
+
+rosidl_buffer_ret_t rosidl_buffer_uint8_equals_data(
+  const void * buffer_ptr, const uint8_t * data, size_t size, bool * are_equal)
+{
+  if (!buffer_ptr || (!data && size != 0) || !are_equal) {
+    return ROSIDL_BUFFER_RET_INVALID_ARGUMENT;
+  }
+  try {
+    const auto * buffer = static_cast<const rosidl::Buffer<uint8_t> *>(buffer_ptr);
+    if (buffer->size() != size) {
+      *are_equal = false;
+      return ROSIDL_BUFFER_RET_OK;
+    }
+    const std::vector<uint8_t> buffer_data = buffer->to_vector();
+    *are_equal = std::equal(buffer_data.begin(), buffer_data.end(), data);
+    return ROSIDL_BUFFER_RET_OK;
+  } catch (const std::bad_alloc &) {
+    return ROSIDL_BUFFER_RET_BAD_ALLOC;
+  } catch (...) {
+    return ROSIDL_BUFFER_RET_ERROR;
+  }
+}
 
 void rosidl_buffer_uint8_throw_if_not_cpu(const void * buffer_ptr)
 {

--- a/rosidl_buffer/test/test_c_helpers.cpp
+++ b/rosidl_buffer/test/test_c_helpers.cpp
@@ -15,6 +15,7 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <stdexcept>
 
@@ -59,6 +60,59 @@ TEST(TestCHelpers, destroy_non_cpu_buffer) {
   auto * buf = new Buffer<uint8_t>(std::make_unique<NonCpuBufferImpl<uint8_t>>(10));
   EXPECT_EQ(buf->get_backend_type(), "non_cpu_test");
   rosidl_buffer_uint8_destroy(buf);
+}
+
+TEST(TestCHelpers, create_clone_and_query_cpu_buffer) {
+  const uint8_t source[] = {1, 2, 3, 4};
+  void * buffer = nullptr;
+  ASSERT_EQ(
+    ROSIDL_BUFFER_RET_OK,
+    rosidl_buffer_uint8_create_cpu(source, sizeof(source), &buffer));
+  ASSERT_NE(buffer, nullptr);
+
+  size_t size = 0;
+  EXPECT_EQ(ROSIDL_BUFFER_RET_OK, rosidl_buffer_uint8_size(buffer, &size));
+  EXPECT_EQ(sizeof(source), size);
+
+  size_t required_size = 0;
+  EXPECT_EQ(
+    ROSIDL_BUFFER_RET_OK,
+    rosidl_buffer_uint8_backend_name(buffer, nullptr, 0, &required_size));
+  std::string backend(required_size, '\0');
+  EXPECT_EQ(
+    ROSIDL_BUFFER_RET_OK,
+    rosidl_buffer_uint8_backend_name(
+      buffer, backend.data(), backend.size(), &required_size));
+  EXPECT_STREQ("cpu", backend.c_str());
+
+  uint8_t copied[sizeof(source)] = {};
+  EXPECT_EQ(
+    ROSIDL_BUFFER_RET_OK,
+    rosidl_buffer_uint8_copy_to(buffer, copied, sizeof(copied)));
+  EXPECT_EQ(0, std::memcmp(source, copied, sizeof(source)));
+
+  void * clone = nullptr;
+  ASSERT_EQ(ROSIDL_BUFFER_RET_OK, rosidl_buffer_uint8_clone(buffer, &clone));
+  bool are_equal = false;
+  EXPECT_EQ(
+    ROSIDL_BUFFER_RET_OK,
+    rosidl_buffer_uint8_are_equal(buffer, clone, &are_equal));
+  EXPECT_TRUE(are_equal);
+
+  rosidl_buffer_uint8_destroy(clone);
+  rosidl_buffer_uint8_destroy(buffer);
+}
+
+TEST(TestCHelpers, rejects_invalid_arguments) {
+  EXPECT_EQ(
+    ROSIDL_BUFFER_RET_INVALID_ARGUMENT,
+    rosidl_buffer_uint8_create_cpu(nullptr, 1, nullptr));
+  EXPECT_EQ(
+    ROSIDL_BUFFER_RET_INVALID_ARGUMENT,
+    rosidl_buffer_uint8_clone(nullptr, nullptr));
+  EXPECT_EQ(
+    ROSIDL_BUFFER_RET_INVALID_ARGUMENT,
+    rosidl_buffer_uint8_size(nullptr, nullptr));
 }
 
 int main(int argc, char ** argv)

--- a/rosidl_runtime_c/include/rosidl_runtime_c/primitives_sequence.h
+++ b/rosidl_runtime_c/include/rosidl_runtime_c/primitives_sequence.h
@@ -25,26 +25,34 @@
     TYPE_NAME * data; /*!< The pointer to an array of STRUCT_NAME */ \
     size_t size; /*!< The number of valid items in data */ \
     size_t capacity; /*!< The number of allocated items in data */ \
+  } rosidl_runtime_c__ ## STRUCT_NAME ## __Sequence;
+
+#define ROSIDL_RUNTIME_C__BUFFER_PRIMITIVE_SEQUENCE(STRUCT_NAME, TYPE_NAME) \
+  typedef struct rosidl_runtime_c__ ## STRUCT_NAME ## __Sequence \
+  { \
+    TYPE_NAME * data; /*!< The pointer to an array of STRUCT_NAME */ \
+    size_t size; /*!< The number of valid items in data */ \
+    size_t capacity; /*!< The number of allocated items in data */ \
     bool is_rosidl_buffer; /*!< When true, data points to an rosidl::Buffer<T>* */ \
     bool owns_rosidl_buffer; /*!< When true, Sequence__fini will destroy the Buffer */ \
   } rosidl_runtime_c__ ## STRUCT_NAME ## __Sequence;
 
 // sequence types for all basic types
-ROSIDL_RUNTIME_C__PRIMITIVE_SEQUENCE(float, float)
-ROSIDL_RUNTIME_C__PRIMITIVE_SEQUENCE(double, double)
-ROSIDL_RUNTIME_C__PRIMITIVE_SEQUENCE(long_double, long double)
-ROSIDL_RUNTIME_C__PRIMITIVE_SEQUENCE(char, signed char)
-ROSIDL_RUNTIME_C__PRIMITIVE_SEQUENCE(wchar, uint16_t)
-ROSIDL_RUNTIME_C__PRIMITIVE_SEQUENCE(boolean, bool)
-ROSIDL_RUNTIME_C__PRIMITIVE_SEQUENCE(octet, uint8_t)
-ROSIDL_RUNTIME_C__PRIMITIVE_SEQUENCE(uint8, uint8_t)
-ROSIDL_RUNTIME_C__PRIMITIVE_SEQUENCE(int8, int8_t)
-ROSIDL_RUNTIME_C__PRIMITIVE_SEQUENCE(uint16, uint16_t)
-ROSIDL_RUNTIME_C__PRIMITIVE_SEQUENCE(int16, int16_t)
-ROSIDL_RUNTIME_C__PRIMITIVE_SEQUENCE(uint32, uint32_t)
-ROSIDL_RUNTIME_C__PRIMITIVE_SEQUENCE(int32, int32_t)
-ROSIDL_RUNTIME_C__PRIMITIVE_SEQUENCE(uint64, uint64_t)
-ROSIDL_RUNTIME_C__PRIMITIVE_SEQUENCE(int64, int64_t)
+ROSIDL_RUNTIME_C__BUFFER_PRIMITIVE_SEQUENCE(float, float)
+ROSIDL_RUNTIME_C__BUFFER_PRIMITIVE_SEQUENCE(double, double)
+ROSIDL_RUNTIME_C__BUFFER_PRIMITIVE_SEQUENCE(long_double, long double)
+ROSIDL_RUNTIME_C__BUFFER_PRIMITIVE_SEQUENCE(char, signed char)
+ROSIDL_RUNTIME_C__BUFFER_PRIMITIVE_SEQUENCE(wchar, uint16_t)
+ROSIDL_RUNTIME_C__BUFFER_PRIMITIVE_SEQUENCE(boolean, bool)
+ROSIDL_RUNTIME_C__BUFFER_PRIMITIVE_SEQUENCE(octet, uint8_t)
+ROSIDL_RUNTIME_C__BUFFER_PRIMITIVE_SEQUENCE(uint8, uint8_t)
+ROSIDL_RUNTIME_C__BUFFER_PRIMITIVE_SEQUENCE(int8, int8_t)
+ROSIDL_RUNTIME_C__BUFFER_PRIMITIVE_SEQUENCE(uint16, uint16_t)
+ROSIDL_RUNTIME_C__BUFFER_PRIMITIVE_SEQUENCE(int16, int16_t)
+ROSIDL_RUNTIME_C__BUFFER_PRIMITIVE_SEQUENCE(uint32, uint32_t)
+ROSIDL_RUNTIME_C__BUFFER_PRIMITIVE_SEQUENCE(int32, int32_t)
+ROSIDL_RUNTIME_C__BUFFER_PRIMITIVE_SEQUENCE(uint64, uint64_t)
+ROSIDL_RUNTIME_C__BUFFER_PRIMITIVE_SEQUENCE(int64, int64_t)
 
 // emulate legacy API
 typedef rosidl_runtime_c__boolean__Sequence

--- a/rosidl_runtime_c/src/primitives_sequence_functions.c
+++ b/rosidl_runtime_c/src/primitives_sequence_functions.c
@@ -22,7 +22,8 @@
 #include "rosidl_buffer/c_helpers.h"
 #include "rosidl_runtime_c/primitives_sequence_functions.h"
 
-#define ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(STRUCT_NAME, TYPE_NAME) \
+#define ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS( \
+    STRUCT_NAME, TYPE_NAME, SUPPORTS_BUFFER) \
   bool rosidl_runtime_c__ ## STRUCT_NAME ## __Sequence__init( \
     rosidl_runtime_c__ ## STRUCT_NAME ## __Sequence * sequence, size_t size) \
   { \
@@ -90,6 +91,23 @@
     if (lhs->size != rhs->size) { \
       return false; \
     } \
+    if (lhs->is_rosidl_buffer || rhs->is_rosidl_buffer) { \
+      if (!(SUPPORTS_BUFFER)) { \
+        return false; \
+      } \
+      bool are_equal = false; \
+      rosidl_buffer_ret_t ret; \
+      if (lhs->is_rosidl_buffer && rhs->is_rosidl_buffer) { \
+        ret = rosidl_buffer_uint8_are_equal(lhs->data, rhs->data, &are_equal); \
+      } else if (lhs->is_rosidl_buffer) { \
+        ret = rosidl_buffer_uint8_equals_data( \
+          lhs->data, (const uint8_t *)rhs->data, rhs->size, &are_equal); \
+      } else { \
+        ret = rosidl_buffer_uint8_equals_data( \
+          rhs->data, (const uint8_t *)lhs->data, lhs->size, &are_equal); \
+      } \
+      return ROSIDL_BUFFER_RET_OK == ret && are_equal; \
+    } \
     for (size_t i = 0; i < lhs->size; ++i) { \
       if (lhs->data[i] != rhs->data[i]) { \
         return false; \
@@ -104,6 +122,28 @@
   { \
     if (!input || !output) { \
       return false; \
+    } \
+    if (input == output) { \
+      return true; \
+    } \
+    if (input->is_rosidl_buffer) { \
+      if (!(SUPPORTS_BUFFER)) { \
+        return false; \
+      } \
+      void * clone = NULL; \
+      if (ROSIDL_BUFFER_RET_OK != rosidl_buffer_uint8_clone(input->data, &clone)) { \
+        return false; \
+      } \
+      rosidl_runtime_c__ ## STRUCT_NAME ## __Sequence__fini(output); \
+      output->data = (TYPE_NAME *)clone; \
+      output->size = input->size; \
+      output->capacity = input->capacity; \
+      output->is_rosidl_buffer = true; \
+      output->owns_rosidl_buffer = true; \
+      return true; \
+    } \
+    if (output->is_rosidl_buffer) { \
+      rosidl_runtime_c__ ## STRUCT_NAME ## __Sequence__fini(output); \
     } \
     if (output->capacity < input->size) { \
       if (input->size > SIZE_MAX / sizeof(TYPE_NAME)) { \
@@ -120,28 +160,28 @@
     } \
     memcpy(output->data, input->data, sizeof(TYPE_NAME) * input->size); \
     output->size = input->size; \
-    output->is_rosidl_buffer = input->is_rosidl_buffer; \
-    output->owns_rosidl_buffer = input->owns_rosidl_buffer; \
+    output->is_rosidl_buffer = false; \
+    output->owns_rosidl_buffer = false; \
     return true; \
   }
 
 
 // array functions for all basic types
-ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(float, float)
-ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(double, double)
-ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(long_double, long double)
-ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(char, signed char)
-ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(wchar, uint16_t)
-ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(boolean, bool)
-ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(octet, uint8_t)
-ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(uint8, uint8_t)
-ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(int8, int8_t)
-ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(uint16, uint16_t)
-ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(int16, int16_t)
-ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(uint32, uint32_t)
-ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(int32, int32_t)
-ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(uint64, uint64_t)
-ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(int64, int64_t)
+ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(float, float, false)
+ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(double, double, false)
+ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(long_double, long double, false)
+ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(char, signed char, false)
+ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(wchar, uint16_t, false)
+ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(boolean, bool, false)
+ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(octet, uint8_t, false)
+ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(uint8, uint8_t, true)
+ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(int8, int8_t, false)
+ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(uint16, uint16_t, false)
+ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(int16, int16_t, false)
+ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(uint32, uint32_t, false)
+ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(int32, int32_t, false)
+ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(uint64, uint64_t, false)
+ROSIDL_GENERATOR_C__DEFINE_PRIMITIVE_SEQUENCE_FUNCTIONS(int64, int64_t, false)
 
 // emulate legacy API
 bool rosidl_runtime_c__bool__Sequence__init(

--- a/rosidl_runtime_c/test/test_primitives_sequence_functions.cpp
+++ b/rosidl_runtime_c/test/test_primitives_sequence_functions.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "gtest/gtest.h"
+#include "rosidl_buffer/buffer.hpp"
 #include "rosidl_runtime_c/primitives_sequence.h"
 #include "rosidl_runtime_c/primitives_sequence_functions.h"
 
@@ -142,3 +143,33 @@ TEST_PRIMITIVE_SEQUENCE_FUNCTIONS(bool, bool)
 TEST_PRIMITIVE_SEQUENCE_FUNCTIONS(byte, uint8_t)
 TEST_PRIMITIVE_SEQUENCE_FUNCTIONS(float32, float)
 TEST_PRIMITIVE_SEQUENCE_FUNCTIONS(float64, double)
+
+TEST(primitives_sequence_functions, uint8_buffer_copy_and_equality)
+{
+  rosidl_runtime_c__uint8__Sequence input;
+  ASSERT_TRUE(rosidl_runtime_c__uint8__Sequence__init(&input, 0));
+  input.data = reinterpret_cast<uint8_t *>(new rosidl::Buffer<uint8_t>({1, 2, 3}));
+  input.size = 3;
+  input.capacity = 3;
+  input.is_rosidl_buffer = true;
+  input.owns_rosidl_buffer = true;
+
+  rosidl_runtime_c__uint8__Sequence output;
+  ASSERT_TRUE(rosidl_runtime_c__uint8__Sequence__init(&output, 1));
+  ASSERT_TRUE(rosidl_runtime_c__uint8__Sequence__copy(&input, &output));
+  EXPECT_TRUE(output.is_rosidl_buffer);
+  EXPECT_TRUE(output.owns_rosidl_buffer);
+  EXPECT_NE(input.data, output.data);
+  EXPECT_TRUE(rosidl_runtime_c__uint8__Sequence__are_equal(&input, &output));
+
+  rosidl_runtime_c__uint8__Sequence cpu;
+  ASSERT_TRUE(rosidl_runtime_c__uint8__Sequence__init(&cpu, 3));
+  cpu.data[0] = 1;
+  cpu.data[1] = 2;
+  cpu.data[2] = 3;
+  EXPECT_TRUE(rosidl_runtime_c__uint8__Sequence__are_equal(&input, &cpu));
+
+  rosidl_runtime_c__uint8__Sequence__fini(&cpu);
+  rosidl_runtime_c__uint8__Sequence__fini(&output);
+  rosidl_runtime_c__uint8__Sequence__fini(&input);
+}


### PR DESCRIPTION
## Summary
- expose exception-safe C helpers for creating, cloning, querying, comparing, and destroying `rosidl::Buffer<uint8_t>`
- make primitive sequence copy and equality operations preserve native Buffer ownership
- keep string and wide-string sequences on their existing three-field ABI

## Dependency
Foundation PR for the Rust native Buffer stack; no other draft in the stack is required to review this change.

## Test plan
- [x] Build `rosidl_buffer` and `rosidl_runtime_c`
- [x] Run their C/C++ unit tests
- [x] Validate Buffer-backed sequence clone, equality, and cleanup